### PR TITLE
Hessian inverse calculations

### DIFF
--- a/tests/fenics/test_block_system.py
+++ b/tests/fenics/test_block_system.py
@@ -1,0 +1,473 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from .test_base import setup_test  # noqa: F401
+
+import mpi4py.MPI as MPI  # noqa: N817
+import numpy as np
+import pytest
+import ufl
+
+pytestmark = pytest.mark.skipif(
+    MPI.COMM_WORLD.size not in [1, 4],
+    reason="tests must be run in serial, or with 4 processes")
+
+from tlm_adjoint.fenics.block_system import (  # noqa: E402
+    BlockMatrix, ConstantNullspace, DirichletBCNullspace, System as _System,
+    UnityNullspace)
+
+from fenics import (  # noqa: E402
+    Constant, DirichletBC, Expression, Function, FunctionSpace, KrylovSolver,
+    TestFunction, TrialFunction, UnitSquareMesh, VectorFunctionSpace, action,
+    adjoint, assemble, ds, dx, grad, inner, solve)
+
+
+class System(_System):
+    def solve(self, *args, **kwargs):
+        return super().solve(
+            *args, correct_initial_guess=False, correct_solution=False,
+            **kwargs)
+
+
+@pytest.mark.fenics
+@pytest.mark.parametrize("pc", ["none", "block_cg_jacobi"])
+def test_block_diagonal(setup_test, pc):  # noqa: F811
+    mesh = UnitSquareMesh(10, 10)
+    space_0 = FunctionSpace(mesh, "Lagrange", 1)
+    space_1 = FunctionSpace(mesh, "Lagrange", 2)
+
+    test_0, trial_0 = TestFunction(space_0), TrialFunction(space_0)
+    test_1, trial_1 = TestFunction(space_1), TrialFunction(space_1)
+
+    block_00 = inner(trial_0, test_0) * dx
+    block_01 = None
+    block_10 = None
+    block_11 = inner(trial_1, test_1) * dx
+
+    system = System(
+        (space_0, space_1), (space_0, space_1),
+        {(0, 0): block_00, (0, 1): block_01,
+         (1, 0): block_10, (1, 1): block_11})
+
+    u_0_ref = Function(space_0)
+    u_0_ref.interpolate(Expression("x[0] * exp(x[1])",
+                                   element=space_0.ufl_element()))
+    u_1_ref = Function(space_1)
+    u_1_ref.interpolate(Expression("sin(pi * x[0]) * sin(2.0 * pi * x[1])",
+                                   element=space_1.ufl_element()))
+
+    b_0 = Function(space_0)
+    assemble(inner(u_0_ref, test_0) * dx, tensor=b_0.vector())
+    b_1 = Function(space_1)
+    assemble(inner(u_1_ref, test_1) * dx, tensor=b_1.vector())
+
+    u_0 = Function(space_0)
+    u_1 = Function(space_1)
+
+    if pc == "none":
+        pc_fn = None
+    else:
+        assert pc == "block_cg_jacobi"
+
+        def pc_fn(u, b):
+            u_0, u_1 = u
+            b_0, b_1 = b
+            solver_0 = KrylovSolver(
+                assemble(block_00),
+                "cg", "jacobi")
+            solver_0.parameters.update({"maximum_iterations": 1,
+                                        "absolute_tolerance": 0.0,
+                                        "relative_tolerance": 0.0})
+            solver_1 = KrylovSolver(
+                assemble(block_11),
+                "cg", "jacobi")
+            solver_1.parameters.update({"maximum_iterations": 1,
+                                        "absolute_tolerance": 0.0,
+                                        "relative_tolerance": 0.0})
+            try:
+                solver_0.solve(u_0.vector(), b_0.copy(deepcopy=True).vector())
+            except RuntimeError:
+                pass
+            try:
+                solver_1.solve(u_1.vector(), b_1.copy(deepcopy=True).vector())
+            except RuntimeError:
+                pass
+
+    ksp_solver = system.solve(
+        (u_0, u_1), (b_0, b_1),
+        solver_parameters={"linear_solver": "cg",
+                           "relative_tolerance": 1.0e-14,
+                           "absolute_tolerance": 1.0e-14},
+        pc_fn=pc_fn)
+
+    u_0_error_norm = np.sqrt(abs(assemble(inner(u_0 - u_0_ref,
+                                                u_0 - u_0_ref) * dx)))
+    assert u_0_error_norm < 1.0e-12
+
+    u_1_error_norm = np.sqrt(abs(assemble(inner(u_1 - u_1_ref,
+                                                u_1 - u_1_ref) * dx)))
+    assert u_1_error_norm < 1.0e-12
+
+    if pc == "none":
+        assert ksp_solver.getIterationNumber() <= 70
+    else:
+        assert pc == "block_cg_jacobi"
+        assert ksp_solver.getIterationNumber() <= 32
+
+
+@pytest.mark.fenics
+def test_constant_nullspace(setup_test):  # noqa: F811
+    mesh = UnitSquareMesh(10, 10)
+    space_0 = FunctionSpace(mesh, "Lagrange", 1)
+    space_1 = FunctionSpace(mesh, "Lagrange", 2)
+
+    test_0, trial_0 = TestFunction(space_0), TrialFunction(space_0)
+    test_1, trial_1 = TestFunction(space_1), TrialFunction(space_1)
+
+    block_00 = inner(grad(trial_0), grad(test_0)) * dx
+    block_01 = None
+    block_10 = None
+    block_11 = inner(trial_1, test_1) * dx
+
+    system = System(
+        (space_0, space_1), (space_0, space_1),
+        {(0, 0): block_00, (0, 1): block_01,
+         (1, 0): block_10, (1, 1): block_11},
+        nullspaces=(ConstantNullspace(), None))
+
+    u_0_ref = Function(space_0)
+    u_0_ref.interpolate(Expression("x[0] * exp(x[1])",
+                                   element=space_0.ufl_element()))
+    u_1_ref = Function(space_1)
+    u_1_ref.interpolate(Expression("sin(pi * x[0]) * sin(2.0 * pi * x[1])",
+                                   element=space_1.ufl_element()))
+
+    b_0 = Function(space_0)
+    assemble(inner(grad(u_0_ref), grad(test_0)) * dx, tensor=b_0.vector())
+    b_1 = Function(space_1)
+    assemble(inner(u_1_ref, test_1) * dx, tensor=b_1.vector())
+
+    u_0 = Function(space_0)
+    u_0.assign(Constant(1.0))
+    u_1 = Function(space_1)
+
+    _ = system.solve(
+        (u_0, u_1), (b_0, b_1),
+        solver_parameters={"linear_solver": "cg",
+                           "relative_tolerance": 1.0e-14,
+                           "absolute_tolerance": 1.0e-14})
+
+    u_0_sum = u_0.vector().sum()
+    assert abs(u_0_sum) < 1.0e-13
+
+    u_0_error_norm = np.sqrt(abs(assemble(inner(grad(u_0 - u_0_ref),
+                                                grad(u_0 - u_0_ref)) * dx)))
+    assert u_0_error_norm < 1.0e-13
+
+    u_1_error_norm = np.sqrt(abs(assemble(inner(u_1 - u_1_ref,
+                                                u_1 - u_1_ref) * dx)))
+    assert u_1_error_norm < 1.0e-12
+
+
+@pytest.mark.fenics
+def test_unity_nullspace(setup_test):  # noqa: F811
+    mesh = UnitSquareMesh(10, 10)
+    space_0 = FunctionSpace(mesh, "Lagrange", 1)
+    space_1 = FunctionSpace(mesh, "Lagrange", 2)
+
+    test_0, trial_0 = TestFunction(space_0), TrialFunction(space_0)
+    test_1, trial_1 = TestFunction(space_1), TrialFunction(space_1)
+
+    block_00 = inner(grad(trial_0), grad(test_0)) * dx
+    block_01 = None
+    block_10 = None
+    block_11 = inner(trial_1, test_1) * dx
+
+    system = System(
+        (space_0, space_1), (space_0, space_1),
+        {(0, 0): block_00, (0, 1): block_01,
+         (1, 0): block_10, (1, 1): block_11},
+        nullspaces=(UnityNullspace(space_0), None))
+
+    u_0_ref = Function(space_0)
+    u_0_ref.interpolate(Expression("x[0] * exp(x[1])",
+                                   element=space_0.ufl_element()))
+    u_1_ref = Function(space_1)
+    u_1_ref.interpolate(Expression("sin(pi * x[0]) * sin(2.0 * pi * x[1])",
+                                   element=space_1.ufl_element()))
+
+    b_0 = Function(space_0)
+    assemble(inner(grad(u_0_ref), grad(test_0)) * dx, tensor=b_0.vector())
+    b_1 = Function(space_1)
+    assemble(inner(u_1_ref, test_1) * dx, tensor=b_1.vector())
+
+    u_0 = Function(space_0)
+    u_0.assign(Constant(1.0))
+    u_1 = Function(space_1)
+
+    _ = system.solve(
+        (u_0, u_1), (b_0, b_1),
+        solver_parameters={"linear_solver": "cg",
+                           "relative_tolerance": 1.0e-14,
+                           "absolute_tolerance": 1.0e-14})
+
+    u_0_int = assemble(u_0 * dx)
+    assert abs(u_0_int) < 1.0e-14
+
+    u_0_error_norm = np.sqrt(abs(assemble(inner(grad(u_0 - u_0_ref),
+                                                grad(u_0 - u_0_ref)) * dx)))
+    assert u_0_error_norm < 1.0e-13
+
+    u_1_error_norm = np.sqrt(abs(assemble(inner(u_1 - u_1_ref,
+                                                u_1 - u_1_ref) * dx)))
+    assert u_1_error_norm < 1.0e-12
+
+
+@pytest.mark.fenics
+def test_dirichlet_bc_nullspace(setup_test):  # noqa: F811
+    mesh = UnitSquareMesh(10, 10)
+    space_0 = FunctionSpace(mesh, "Lagrange", 1)
+    space_1 = FunctionSpace(mesh, "Lagrange", 2)
+
+    test_0, trial_0 = TestFunction(space_0), TrialFunction(space_0)
+    test_1, trial_1 = TestFunction(space_1), TrialFunction(space_1)
+
+    block_00 = inner(grad(trial_0), grad(test_0)) * dx
+    block_01 = None
+    block_10 = None
+    block_11 = inner(trial_1, test_1) * dx
+
+    system = System(
+        (space_0, space_1), (space_0, space_1),
+        {(0, 0): block_00, (0, 1): block_01,
+         (1, 0): block_10, (1, 1): block_11},
+        nullspaces=(DirichletBCNullspace(DirichletBC(space_0, 0.0, "on_boundary")),  # noqa: E501
+                    None))
+
+    u_0_ref = Function(space_0)
+    u_0_ref.interpolate(Expression("x[0] * exp(x[1]) * sin(pi * x[0]) * sin(2.0 * pi * x[1])",  # noqa: E501
+                                   element=space_0.ufl_element()))
+    u_1_ref = Function(space_1)
+    u_1_ref.interpolate(Expression("sin(3.0 * pi * x[0]) * sin(4.0 * pi * x[1])",  # noqa: E501
+                                   element=space_1.ufl_element()))
+
+    b_0 = Function(space_0)
+    assemble(inner(grad(u_0_ref), grad(test_0)) * dx, tensor=b_0.vector())
+    b_1 = Function(space_1)
+    assemble(inner(u_1_ref, test_1) * dx, tensor=b_1.vector())
+
+    u_0 = Function(space_0)
+    u_0.assign(Constant(1.0))
+    u_1 = Function(space_1)
+
+    _ = system.solve(
+        (u_0, u_1), (b_0, b_1),
+        solver_parameters={"linear_solver": "cg",
+                           "relative_tolerance": 1.0e-14,
+                           "absolute_tolerance": 1.0e-14})
+
+    u_0_bc_error_norm = np.sqrt(abs(assemble(inner(u_0, u_0) * ds)))
+    assert u_0_bc_error_norm < 1.0e-15
+
+    u_0_error_norm = np.sqrt(abs(assemble(inner(u_0 - u_0_ref,
+                                                u_0 - u_0_ref) * dx)))
+    assert u_0_error_norm < 1.0e-14
+
+    u_1_error_norm = np.sqrt(abs(assemble(inner(u_1 - u_1_ref,
+                                                u_1 - u_1_ref) * dx)))
+    assert u_1_error_norm < 1.0e-12
+
+
+@pytest.mark.fenics
+def test_pressure_projection(setup_test):  # noqa: F811
+    mesh = UnitSquareMesh(10, 10)
+    space_0 = VectorFunctionSpace(mesh, "Lagrange", 2)
+    space_1 = FunctionSpace(mesh, "Lagrange", 1)
+
+    test_0, trial_0 = TestFunction(space_0), TrialFunction(space_0)
+    test_1, trial_1 = TestFunction(space_1), TrialFunction(space_1)
+
+    block_00 = inner(trial_0, test_0) * dx
+    block_01 = inner(grad(trial_1), test_0) * dx
+    block_10 = adjoint(block_01)
+    block_11 = None
+
+    system = System(
+        (space_0, space_1), (space_0, space_1),
+        {(0, 0): block_00, (0, 1): block_01,
+         (1, 0): block_10, (1, 1): block_11},
+        nullspaces=(DirichletBCNullspace(DirichletBC(space_0, (0.0, 0.0), "on_boundary")),  # noqa: E501
+                    ConstantNullspace()))
+
+    psi_0_ref = Function(space_1)
+    psi_0_ref.interpolate(Expression("x[0] * exp(x[1]) * sin(pi * x[0]) * sin(2.0 * pi * x[1])",  # noqa: E501
+                          element=space_1.ufl_element()))
+
+    u_s = Function(space_0)
+    solve(inner(trial_0, test_0) * dx
+          == inner(ufl.perp(grad(psi_0_ref)), test_0) * dx,
+          u_s, DirichletBC(space_0, (0.0, 0.0), "on_boundary"),
+          solver_parameters={"linear_solver": "cg",
+                             "preconditioner": "jacobi",
+                             "krylov_solver": {"absolute_tolerance": 1.0e-14,
+                                               "relative_tolerance": 1.0e-14}})
+
+    u_0 = Function(space_0)
+    u_1 = Function(space_1)
+
+    b_0 = Function(space_0)
+    assemble(inner(u_s, test_0) * dx, tensor=b_0.vector())
+    b_1 = None
+
+    _ = system.solve(
+        (u_0, u_1), (b_0, b_1),
+        solver_parameters={"linear_solver": "minres",
+                           "relative_tolerance": 1.0e-14,
+                           "absolute_tolerance": 1.0e-14})
+
+    u_0_bc_error_norm = np.sqrt(abs(assemble(inner(u_0, u_0) * ds)))
+    assert u_0_bc_error_norm == 0.0
+
+    u_1_sum = u_1.vector().sum()
+    assert abs(u_1_sum) < 1.0e-14
+
+    u_div = Function(space_1)
+    solve(inner(trial_1, test_1) * dx == -action(block_10, u_0),
+          u_div,
+          solver_parameters={"linear_solver": "cg",
+                             "preconditioner": "jacobi",
+                             "krylov_solver": {"absolute_tolerance": 1.0e-14,
+                                               "relative_tolerance": 1.0e-14}})
+
+    u_div_error_norm = np.sqrt(abs(assemble(inner(u_div,
+                                                  u_div) * dx)))
+    assert u_div_error_norm < 1.0e-13
+
+    grad_u_1 = Function(space_0)
+    solve(inner(trial_0, test_0) * dx
+          == inner(grad(u_1), test_0) * dx,
+          grad_u_1, DirichletBC(space_0, (0.0, 0.0), "on_boundary"),
+          solver_parameters={"linear_solver": "cg",
+                             "preconditioner": "jacobi",
+                             "krylov_solver": {"absolute_tolerance": 1.0e-14,
+                                               "relative_tolerance": 1.0e-14}})
+
+    u_orthogonality_error_norm = abs(assemble(inner(grad_u_1, u_0) * dx))
+    assert u_orthogonality_error_norm < 1.0e-15
+
+    u_0_error_norm = np.sqrt(abs(assemble(inner(u_s - u_0 - grad_u_1,
+                                                u_s - u_0 - grad_u_1) * dx)))
+    assert u_0_error_norm < 1.0e-12
+
+
+@pytest.mark.fenics
+def test_mass(setup_test):  # noqa: F811
+    mesh = UnitSquareMesh(10, 10)
+    space = FunctionSpace(mesh, "Lagrange", 1)
+    test, trial = TestFunction(space), TrialFunction(space)
+    bc = DirichletBC(space, 0.0, "on_boundary")
+
+    y = Function(space, name="y")
+    y.interpolate(Expression("exp(x[0]) * sin(pi * x[0]) * sin(2.0 * pi * x[1])",  # noqa: E501
+                             element=space.ufl_element()))
+
+    u = Function(space, name="u")
+    b = Function(space)
+    assemble(inner(y, test) * dx, tensor=b.vector())
+
+    system = System(
+        space, space,
+        inner(trial, test) * dx, nullspaces=DirichletBCNullspace(bc))
+
+    _ = system.solve(
+        u, b,
+        solver_parameters={"linear_solver": "cg",
+                           "relative_tolerance": 1.0e-14,
+                           "absolute_tolerance": 1.0e-14})
+
+    u_error_norm = np.sqrt(abs(assemble(inner(u - y, u - y) * dx)))
+    assert u_error_norm < 1.0e-13
+
+
+@pytest.mark.fenics
+def test_sub_block(setup_test):  # noqa: F811
+    mesh = UnitSquareMesh(10, 10)
+    space_0 = FunctionSpace(mesh, "Lagrange", 1)
+    space_1 = FunctionSpace(mesh, "Lagrange", 2)
+    space_1 = FunctionSpace(mesh,
+                            space_0.ufl_element() * space_1.ufl_element())
+    space_2 = FunctionSpace(mesh, "Lagrange", 3)
+
+    test_0, trial_0 = TestFunction(space_0), TrialFunction(space_0)
+    test_1, trial_1 = TestFunction(space_1), TrialFunction(space_1)
+    test_2, trial_2 = TestFunction(space_2), TrialFunction(space_2)
+
+    block_00 = BlockMatrix((space_0, space_1), (space_0, space_1))
+    block_00[(0, 0)] = inner(trial_0, test_0) * dx
+    block_00[(1, 1)] = inner(trial_1, test_1) * dx
+    block_11 = inner(trial_2, test_2) * dx
+
+    u_0_ref = Function(space_0)
+    u_0_ref.interpolate(Expression("x[0] * exp(x[1])",
+                                   element=space_0.ufl_element()))
+    u_1_ref = Function(space_1)
+    u_1_ref.interpolate(Expression(("x[1] * exp(x[0])",
+                                    "x[0] * x[1] * sin(2.0 * pi * x[1])"),
+                                   element=space_1.ufl_element()))
+    u_2_ref = Function(space_2)
+    u_2_ref.interpolate(Expression("sin(3.0 * pi * x[0]) * sin(4.0 * pi * x[1])",  # noqa: E501
+                                   element=space_2.ufl_element()))
+
+    b_0 = Function(space_0)
+    b_1 = Function(space_1)
+    b_2 = Function(space_2)
+    assemble(inner(u_0_ref, test_0) * dx, tensor=b_0.vector())
+    assemble(inner(u_1_ref, test_1) * dx, tensor=b_1.vector())
+    assemble(inner(u_2_ref, test_2) * dx, tensor=b_2.vector())
+
+    nullspace_2 = DirichletBCNullspace(
+        DirichletBC(space_2, 0.0, "on_boundary"))
+
+    system = System(
+        ((space_0, space_1), space_2), ((space_0, space_1), space_2),
+        {(0, 0): block_00, (1, 1): block_11},
+        nullspaces=(None, nullspace_2))
+
+    u_0 = Function(space_0)
+    u_1 = Function(space_1)
+    u_2 = Function(space_2)
+
+    def pc_fn(u, b):
+        (u_0, u_1), u_2 = u
+        (b_0, b_1), b_2 = b
+        assert u_0.function_space() == space_0
+        assert u_1.function_space() == space_1
+        assert u_2.function_space() == space_2
+        assert b_0.function_space() == space_0
+        assert b_1.function_space() == space_1
+        assert b_2.function_space() == space_2
+        u_0.assign(b_0)
+        u_1.assign(b_1)
+        u_2.assign(b_2)
+
+    _ = system.solve(
+        ((u_0, u_1), u_2), ((b_0, b_1), b_2),
+        pc_fn=pc_fn,
+        solver_parameters={"linear_solver": "cg",
+                           "relative_tolerance": 1.0e-14,
+                           "absolute_tolerance": 1.0e-14})
+
+    u_2_bc_error_norm = np.sqrt(abs(assemble(inner(u_2, u_2) * ds)))
+    assert u_2_bc_error_norm == 0.0
+
+    u_0_error_norm = np.sqrt(abs(assemble(inner(u_0 - u_0_ref,
+                                                u_0 - u_0_ref) * dx)))
+    assert u_0_error_norm < 1.0e-13
+
+    u_1_error_norm = np.sqrt(abs(assemble(inner(u_1 - u_1_ref,
+                                                u_1 - u_1_ref) * dx)))
+    assert u_1_error_norm < 1.0e-12
+
+    u_2_error_norm = np.sqrt(abs(assemble(inner(u_2 - u_2_ref,
+                                                u_2 - u_2_ref) * dx)))
+    assert u_2_error_norm < 1.0e-12

--- a/tests/fenics/test_eigendecomposition.py
+++ b/tests/fenics/test_eigendecomposition.py
@@ -34,8 +34,9 @@ def test_HEP(setup_test, test_leaks):
         return y
 
     import slepc4py.SLEPc as SLEPc
-    lam, V = eigendecompose(space, M_action, action_type="conjugate_dual",
-                            problem_type=SLEPc.EPS.ProblemType.HEP)
+    lam, V = eigendecompose(
+        space, M_action, action_space_type="conjugate_dual",
+        problem_type=SLEPc.EPS.ProblemType.HEP)
 
     assert (lam > 0.0).all()
 
@@ -63,7 +64,8 @@ def test_NHEP(setup_test, test_leaks):
         assemble(inner(x.dx(0), test) * dx, tensor=function_vector(y))
         return y
 
-    lam, V = eigendecompose(space, N_action, action_type="conjugate_dual")
+    lam, V = eigendecompose(
+        space, N_action, action_space_type="conjugate_dual")
 
     assert abs(lam.real).max() < 1.0e-15
 

--- a/tests/fenics/test_gauss_newton.py
+++ b/tests/fenics/test_gauss_newton.py
@@ -52,7 +52,7 @@ def test_GaussNewton(setup_test, test_leaks):
 
     def B_inv_action(x):
         y = function_new_conjugate_dual(x)
-        assemble(eps * inner(ufl.conj(x), test) * dx,
+        assemble(ufl.conj(eps) * inner(ufl.conj(x), test) * dx,
                  tensor=function_vector(y))
         return y
 
@@ -115,7 +115,7 @@ def test_CachedGaussNewton(setup_test):
 
     def B_inv_action(x):
         y = function_new_conjugate_dual(x)
-        assemble(eps * inner(ufl.conj(x), test) * dx,
+        assemble(ufl.conj(eps) * inner(ufl.conj(x), test) * dx,
                  tensor=function_vector(y))
         return y
 

--- a/tests/fenics/test_hessian_system.py
+++ b/tests/fenics/test_hessian_system.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from fenics import *
+from tlm_adjoint.fenics import *
+from tlm_adjoint.fenics.backend_code_generator_interface import \
+    assemble_linear_solver, function_vector
+
+from .test_base import *
+
+import mpi4py.MPI as MPI
+import numpy as np
+import pytest
+import ufl
+
+pytestmark = pytest.mark.skipif(
+    MPI.COMM_WORLD.size not in [1, 4],
+    reason="tests must be run in serial, or with 4 processes")
+
+
+@pytest.mark.fenics
+@pytest.mark.skipif(complex_mode, reason="real only")
+@pytest.mark.parametrize("N_eigenvalues", [0, 5, 16])
+def test_hessian_solve(setup_test,
+                       N_eigenvalues):
+    configure_checkpointing("memory", {"drop_references": False})
+
+    mesh = UnitSquareMesh(5, 5)
+    X = SpatialCoordinate(mesh)
+    space = FunctionSpace(mesh, "Lagrange", 1)
+    test, trial = TestFunction(space), TrialFunction(space)
+    bc = DirichletBC(space, 0.0, "on_boundary")
+
+    alpha = Constant(1.0 / np.sqrt(2.0))
+    beta = Constant(1.0 / np.sqrt(5.0))
+
+    def B_inv(u):
+        b = Function(space, space_type="conjugate_dual")
+        assemble(ufl.conj(beta) * inner(ufl.conj(u), test) * dx,
+                 tensor=function_vector(b))
+        return b
+
+    def B(b):
+        u = Function(space)
+        solver, _, _ = assemble_linear_solver(
+            ufl.conj(beta) * inner(ufl.conj(trial), test) * dx, bcs=bc,
+            linear_solver_parameters=ls_parameters_cg)
+        solver.solve(function_vector(u), function_vector(function_copy(b)))
+        return u
+
+    def forward(u_ref, m):
+        m_1 = Function(space, name="m_1")
+        DirichletBCApplication(m_1, m, "on_boundary").solve()
+        m_0 = Function(space, name="m_0")
+        LinearCombination(m_0, (1.0, m), (-1.0, m_1)).solve()
+        m = m_0
+        del m_0, m_1
+        assert np.sqrt(abs(assemble(inner(m, m) * ds))) == 0.0
+
+        u = Function(space, name="u")
+        solve(inner(grad(trial), grad(test)) * dx == inner(m + m * m, test) * dx,  # noqa: E501
+              u, bc,
+              solver_parameters=ls_parameters_cg)
+
+        J_mismatch = Functional(name="J")
+        J_mismatch.assign(0.5 * alpha * dot(u - u_ref, u - u_ref) * dx)
+
+        J = Functional(name="J")
+        J.assign(J_mismatch.function())
+        J.addto(0.5 * beta * dot(m, m) * dx)
+
+        return u, J, J_mismatch
+
+    def forward_J(m):
+        _, J, _ = forward(u_ref, m)
+        return J
+
+    u_ref = Function(space, name="u_ref")
+    interpolate_expression(
+        u_ref,
+        sin(2.0 * pi * X[0]) * sin(3.0 * pi * X[1]) * exp(4.0 * X[0] * X[1]))
+
+    m0 = Function(space, name="m0")
+    m, _ = minimize_l_bfgs(
+        forward_J, m0,
+        s_atol=0.0, g_atol=1.0e-10,
+        H_0_action=B, M_action=B_inv, M_inv_action=B)
+
+    b_ref = Function(space, name="b_ref", space_type="conjugate_dual")
+    assemble(inner((sin(5.0 * pi * X[0]) * sin(7.0 * pi * X[1])) ** 2, test) * dx,  # noqa: E501
+             tensor=function_vector(b_ref))
+    bc.apply(function_vector(b_ref))
+
+    start_manager()
+    _, J, J_mismatch = forward(u_ref, m)
+    stop_manager()
+    H = CachedHessian(J)
+    H_mismatch = CachedHessian(J_mismatch)
+    nullspace = DirichletBCNullspace(bc)
+
+    v = Function(space, name="v")
+    system = HessianSystem(H, m, nullspace=nullspace)
+
+    if N_eigenvalues == 0:
+        pc_fn = None
+    else:
+        import slepc4py.SLEPc as SLEPc
+
+        Lam, V = hessian_eigendecompose(
+            H_mismatch, m, B_inv, B, nullspace=nullspace,
+            N_eigenvalues=N_eigenvalues,
+            solver_type=SLEPc.EPS.Type.KRYLOVSCHUR,
+            which=SLEPc.EPS.Which.LARGEST_MAGNITUDE,
+            tolerance=1.0e-14)
+
+        diag_error_norm, off_diag_error_norm = B_inv_orthonormality_test(V, B_inv)  # noqa: E501
+        assert diag_error_norm < 1.0e-15
+        assert off_diag_error_norm < 1.0e-12
+
+        pc_fn = hessian_eigendecomposition_pc(B, Lam, V)
+
+    ksp = system.solve(
+        v, b_ref, pc_fn=pc_fn,
+        solver_parameters={"linear_solver": "cg",
+                           "absolute_tolerance": 1.0e-12,
+                           "relative_tolerance": 1.0e-12})
+
+    if N_eigenvalues == 0:
+        assert ksp.getIterationNumber() <= 14
+    elif N_eigenvalues == 5:
+        assert ksp.getIterationNumber() <= 7
+    elif N_eigenvalues == 16:
+        assert ksp.getIterationNumber() == 1
+
+    H = Hessian(forward_J)
+    _, _, b = H.action(m, v)
+    b_error = function_copy(b, name="b_error")
+    function_axpy(b_error, -1.0, b_ref)
+    assert function_linf_norm(b_error) < 1.0e-13

--- a/tests/firedrake/test_block_system.py
+++ b/tests/firedrake/test_block_system.py
@@ -1,0 +1,492 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from .test_base import setup_test  # noqa: F401
+
+import mpi4py.MPI as MPI  # noqa: N817
+import numpy as np
+import petsc4py.PETSc as PETSc
+import pytest
+import ufl
+
+pytestmark = pytest.mark.skipif(
+    MPI.COMM_WORLD.size not in [1, 4],
+    reason="tests must be run in serial, or with 4 processes")
+
+from tlm_adjoint.firedrake.block_system import (  # noqa: E402
+    BlockMatrix, ConstantNullspace, DirichletBCNullspace, System as _System,
+    UnityNullspace)
+
+from firedrake import (  # noqa: E402
+    Constant, ConvergenceError, DirichletBC, Function, FunctionSpace,
+    LinearSolver, SpatialCoordinate, TestFunction, TrialFunction,
+    UnitSquareMesh, VectorFunctionSpace, action, adjoint, assemble, ds, dx,
+    exp, grad, inner, pi, sin, solve)
+
+
+class System(_System):
+    def solve(self, *args, **kwargs):
+        return super().solve(
+            *args, correct_initial_guess=False, correct_solution=False,
+            **kwargs)
+
+
+@pytest.mark.firedrake
+@pytest.mark.parametrize("pc", ["none", "block_jacobi", "block_chebyshev"])
+def test_block_diagonal(setup_test, pc):  # noqa: F811
+    mesh = UnitSquareMesh(10, 10)
+    X = SpatialCoordinate(mesh)
+    space_0 = FunctionSpace(mesh, "Lagrange", 1)
+    space_1 = FunctionSpace(mesh, "Lagrange", 2)
+
+    test_0, trial_0 = TestFunction(space_0), TrialFunction(space_0)
+    test_1, trial_1 = TestFunction(space_1), TrialFunction(space_1)
+
+    block_00 = inner(trial_0, test_0) * dx
+    block_01 = None
+    block_10 = None
+    block_11 = inner(trial_1, test_1) * dx
+
+    system = System(
+        (space_0, space_1), (space_0, space_1),
+        {(0, 0): block_00, (0, 1): block_01,
+         (1, 0): block_10, (1, 1): block_11})
+
+    u_0_ref = Function(space_0)
+    u_0_ref.interpolate(X[0] * exp(X[1]))
+    u_1_ref = Function(space_1)
+    u_1_ref.interpolate(sin(pi * X[0]) * sin(2.0 * pi * X[1]))
+
+    b_0 = assemble(inner(u_0_ref, test_0) * dx)
+    b_1 = assemble(inner(u_1_ref, test_1) * dx)
+
+    u_0 = Function(space_0)
+    u_1 = Function(space_1)
+
+    if pc == "none":
+        pc_fn = None
+    elif pc == "block_jacobi":
+        def pc_fn(u, b):
+            u_0, u_1 = u
+            b_0, b_1 = b
+            solver_0 = LinearSolver(
+                assemble(block_00),
+                solver_parameters={"ksp_type": "preonly",
+                                   "pc_type": "jacobi",
+                                   "ksp_max_it": 1,
+                                   "ksp_atol": 0.0,
+                                   "ksp_rtol": 0.0})
+            solver_1 = LinearSolver(
+                assemble(block_11),
+                solver_parameters={"ksp_type": "preonly",
+                                   "pc_type": "jacobi",
+                                   "ksp_max_it": 1,
+                                   "ksp_atol": 0.0,
+                                   "ksp_rtol": 0.0})
+            solver_0.solve(u_0, b_0.copy(deepcopy=True))
+            solver_1.solve(u_1, b_1.copy(deepcopy=True))
+    else:
+        assert pc == "block_chebyshev"
+
+        def pc_fn(u, b):
+            u_0, u_1 = u
+            b_0, b_1 = b
+            # Eigenvalue bounds: 0.0006819477595146459, 0.009730121547766488
+            solver_0 = LinearSolver(
+                assemble(block_00),
+                solver_parameters={"ksp_type": "chebyshev",
+                                   "ksp_chebyshev_eigenvalues": "0.0005,0.01",
+                                   "ksp_chebyshev_esteig": "0.0,0.0,0.0,0.0",
+                                   "ksp_chebyshev_esteig_steps": 0,
+                                   "ksp_chebyshev_esteig_noisy": False,
+                                   "pc_type": "none",
+                                   "ksp_max_it": 8,
+                                   "ksp_atol": 0.0,
+                                   "ksp_rtol": 0.0})
+            # Eigenvalue bounds: 0.00015115459477735448, 0.0035778617188465087
+            solver_1 = LinearSolver(
+                assemble(block_11),
+                solver_parameters={"ksp_type": "chebyshev",
+                                   "ksp_chebyshev_eigenvalues": "0.0001,0.004",
+                                   "ksp_chebyshev_esteig": "0.0,0.0,0.0,0.0",
+                                   "ksp_chebyshev_esteig_steps": 0,
+                                   "ksp_chebyshev_esteig_noisy": False,
+                                   "pc_type": "none",
+                                   "ksp_max_it": 8,
+                                   "ksp_atol": 0.0,
+                                   "ksp_rtol": 0.0})
+            try:
+                solver_0.solve(u_0, b_0.copy(deepcopy=True))
+            except ConvergenceError:
+                assert solver_0.ksp.getConvergedReason() == PETSc.KSP.ConvergedReason.DIVERGED_MAX_IT  # noqa: E501
+            try:
+                solver_1.solve(u_1, b_1.copy(deepcopy=True))
+            except ConvergenceError:
+                assert solver_1.ksp.getConvergedReason() == PETSc.KSP.ConvergedReason.DIVERGED_MAX_IT  # noqa: E501
+
+    ksp_solver = system.solve(
+        (u_0, u_1), (b_0, b_1),
+        solver_parameters={"linear_solver": "cg",
+                           "relative_tolerance": 1.0e-14,
+                           "absolute_tolerance": 1.0e-14},
+        pc_fn=pc_fn)
+
+    u_0_error_norm = np.sqrt(abs(assemble(inner(u_0 - u_0_ref,
+                                                u_0 - u_0_ref) * dx)))
+    assert u_0_error_norm < 1.0e-12
+
+    u_1_error_norm = np.sqrt(abs(assemble(inner(u_1 - u_1_ref,
+                                                u_1 - u_1_ref) * dx)))
+    assert u_1_error_norm < 1.0e-12
+
+    if pc == "none":
+        assert ksp_solver.getIterationNumber() <= 69
+    elif pc == "block_jacobi":
+        assert ksp_solver.getIterationNumber() <= 31
+    else:
+        assert pc == "block_chebyshev"
+        assert ksp_solver.getIterationNumber() <= 13
+
+
+@pytest.mark.firedrake
+def test_constant_nullspace(setup_test):  # noqa: F811
+    mesh = UnitSquareMesh(10, 10)
+    X = SpatialCoordinate(mesh)
+    space_0 = FunctionSpace(mesh, "Lagrange", 1)
+    space_1 = FunctionSpace(mesh, "Lagrange", 2)
+
+    test_0, trial_0 = TestFunction(space_0), TrialFunction(space_0)
+    test_1, trial_1 = TestFunction(space_1), TrialFunction(space_1)
+
+    block_00 = inner(grad(trial_0), grad(test_0)) * dx
+    block_01 = None
+    block_10 = None
+    block_11 = inner(trial_1, test_1) * dx
+
+    system = System(
+        (space_0, space_1), (space_0, space_1),
+        {(0, 0): block_00, (0, 1): block_01,
+         (1, 0): block_10, (1, 1): block_11},
+        nullspaces=(ConstantNullspace(), None))
+
+    u_0_ref = Function(space_0)
+    u_0_ref.interpolate(X[0] * exp(X[1]))
+    u_1_ref = Function(space_1)
+    u_1_ref.interpolate(sin(pi * X[0]) * sin(2.0 * pi * X[1]))
+
+    b_0 = assemble(inner(grad(u_0_ref), grad(test_0)) * dx)
+    b_1 = assemble(inner(u_1_ref, test_1) * dx)
+
+    u_0 = Function(space_0)
+    u_0.assign(Constant(1.0))
+    u_1 = Function(space_1)
+
+    _ = system.solve(
+        (u_0, u_1), (b_0, b_1),
+        solver_parameters={"linear_solver": "cg",
+                           "relative_tolerance": 1.0e-14,
+                           "absolute_tolerance": 1.0e-14})
+
+    with u_0.dat.vec_ro as u_0_v:
+        u_0_sum = u_0_v.sum()
+    assert abs(u_0_sum) < 1.0e-13
+
+    u_0_error_norm = np.sqrt(abs(assemble(inner(grad(u_0 - u_0_ref),
+                                                grad(u_0 - u_0_ref)) * dx)))
+    assert u_0_error_norm < 1.0e-13
+
+    u_1_error_norm = np.sqrt(abs(assemble(inner(u_1 - u_1_ref,
+                                                u_1 - u_1_ref) * dx)))
+    assert u_1_error_norm < 1.0e-12
+
+
+@pytest.mark.firedrake
+def test_unity_nullspace(setup_test):  # noqa: F811
+    mesh = UnitSquareMesh(10, 10)
+    X = SpatialCoordinate(mesh)
+    space_0 = FunctionSpace(mesh, "Lagrange", 1)
+    space_1 = FunctionSpace(mesh, "Lagrange", 2)
+
+    test_0, trial_0 = TestFunction(space_0), TrialFunction(space_0)
+    test_1, trial_1 = TestFunction(space_1), TrialFunction(space_1)
+
+    block_00 = inner(grad(trial_0), grad(test_0)) * dx
+    block_01 = None
+    block_10 = None
+    block_11 = inner(trial_1, test_1) * dx
+
+    system = System(
+        (space_0, space_1), (space_0, space_1),
+        {(0, 0): block_00, (0, 1): block_01,
+         (1, 0): block_10, (1, 1): block_11},
+        nullspaces=(UnityNullspace(space_0), None))
+
+    u_0_ref = Function(space_0)
+    u_0_ref.interpolate(X[0] * exp(X[1]))
+    u_1_ref = Function(space_1)
+    u_1_ref.interpolate(sin(pi * X[0]) * sin(2.0 * pi * X[1]))
+
+    b_0 = assemble(inner(grad(u_0_ref), grad(test_0)) * dx)
+    b_1 = assemble(inner(u_1_ref, test_1) * dx)
+
+    u_0 = Function(space_0)
+    u_0.assign(Constant(1.0))
+    u_1 = Function(space_1)
+
+    _ = system.solve(
+        (u_0, u_1), (b_0, b_1),
+        solver_parameters={"linear_solver": "cg",
+                           "relative_tolerance": 1.0e-14,
+                           "absolute_tolerance": 1.0e-14})
+
+    u_0_int = assemble(u_0 * dx)
+    assert abs(u_0_int) < 1.0e-14
+
+    u_0_error_norm = np.sqrt(abs(assemble(inner(grad(u_0 - u_0_ref),
+                                                grad(u_0 - u_0_ref)) * dx)))
+    assert u_0_error_norm < 1.0e-13
+
+    u_1_error_norm = np.sqrt(abs(assemble(inner(u_1 - u_1_ref,
+                                                u_1 - u_1_ref) * dx)))
+    assert u_1_error_norm < 1.0e-12
+
+
+@pytest.mark.firedrake
+def test_dirichlet_bc_nullspace(setup_test):  # noqa: F811
+    mesh = UnitSquareMesh(10, 10)
+    X = SpatialCoordinate(mesh)
+    space_0 = FunctionSpace(mesh, "Lagrange", 1)
+    space_1 = FunctionSpace(mesh, "Lagrange", 2)
+
+    test_0, trial_0 = TestFunction(space_0), TrialFunction(space_0)
+    test_1, trial_1 = TestFunction(space_1), TrialFunction(space_1)
+
+    block_00 = inner(grad(trial_0), grad(test_0)) * dx
+    block_01 = None
+    block_10 = None
+    block_11 = inner(trial_1, test_1) * dx
+
+    system = System(
+        (space_0, space_1), (space_0, space_1),
+        {(0, 0): block_00, (0, 1): block_01,
+         (1, 0): block_10, (1, 1): block_11},
+        nullspaces=(DirichletBCNullspace(DirichletBC(space_0, 0.0, "on_boundary")),  # noqa: E501
+                    None))
+
+    u_0_ref = Function(space_0)
+    u_0_ref.interpolate(X[0] * exp(X[1]) * sin(pi * X[0]) * sin(2.0 * pi * X[1]))  # noqa: E501
+    u_1_ref = Function(space_1)
+    u_1_ref.interpolate(sin(3.0 * pi * X[0]) * sin(4.0 * pi * X[1]))
+
+    b_0 = assemble(inner(grad(u_0_ref), grad(test_0)) * dx)
+    b_1 = assemble(inner(u_1_ref, test_1) * dx)
+
+    u_0 = Function(space_0)
+    u_0.assign(Constant(1.0))
+    u_1 = Function(space_1)
+
+    _ = system.solve(
+        (u_0, u_1), (b_0, b_1),
+        solver_parameters={"linear_solver": "cg",
+                           "relative_tolerance": 1.0e-14,
+                           "absolute_tolerance": 1.0e-14})
+
+    u_0_bc_error_norm = np.sqrt(abs(assemble(inner(u_0, u_0) * ds)))
+    assert u_0_bc_error_norm < 1.0e-15
+
+    u_0_error_norm = np.sqrt(abs(assemble(inner(u_0 - u_0_ref,
+                                                u_0 - u_0_ref) * dx)))
+    assert u_0_error_norm < 1.0e-14
+
+    u_1_error_norm = np.sqrt(abs(assemble(inner(u_1 - u_1_ref,
+                                                u_1 - u_1_ref) * dx)))
+    assert u_1_error_norm < 1.0e-12
+
+
+@pytest.mark.firedrake
+def test_pressure_projection(setup_test):  # noqa: F811
+    mesh = UnitSquareMesh(10, 10)
+    X = SpatialCoordinate(mesh)
+    space_0 = VectorFunctionSpace(mesh, "Lagrange", 2)
+    space_1 = FunctionSpace(mesh, "Lagrange", 1)
+
+    test_0, trial_0 = TestFunction(space_0), TrialFunction(space_0)
+    test_1, trial_1 = TestFunction(space_1), TrialFunction(space_1)
+
+    block_00 = inner(trial_0, test_0) * dx
+    block_01 = inner(grad(trial_1), test_0) * dx
+    block_10 = adjoint(block_01)
+    block_11 = None
+
+    system = System(
+        (space_0, space_1), (space_0, space_1),
+        {(0, 0): block_00, (0, 1): block_01,
+         (1, 0): block_10, (1, 1): block_11},
+        nullspaces=(DirichletBCNullspace(DirichletBC(space_0, 0.0, "on_boundary")),  # noqa: E501
+                    ConstantNullspace()))
+
+    psi_0_ref = Function(space_1)
+    psi_0_ref.interpolate(X[0] * exp(X[1]) * sin(pi * X[0]) * sin(2.0 * pi * X[1]))  # noqa: E501
+
+    u_s = Function(space_0)
+    solve(inner(trial_0, test_0) * dx
+          == inner(ufl.perp(grad(psi_0_ref)), test_0) * dx,
+          u_s, DirichletBC(space_0, (0.0, 0.0), "on_boundary"),
+          solver_parameters={"ksp_type": "cg",
+                             "pc_type": "jacobi",
+                             "ksp_atol": 1.0e-14,
+                             "ksp_rtol": 1.0e-14})
+
+    u_0 = Function(space_0)
+    u_1 = Function(space_1)
+
+    b_0 = assemble(inner(u_s, test_0) * dx)
+    b_1 = None
+
+    _ = system.solve(
+        (u_0, u_1), (b_0, b_1),
+        solver_parameters={"linear_solver": "minres",
+                           "relative_tolerance": 1.0e-14,
+                           "absolute_tolerance": 1.0e-14})
+
+    u_0_bc_error_norm = np.sqrt(abs(assemble(inner(u_0, u_0) * ds)))
+    assert u_0_bc_error_norm == 0.0
+
+    with u_1.dat.vec_ro as u_1_v:
+        u_1_sum = u_1_v.sum()
+    assert abs(u_1_sum) < 1.0e-13
+
+    u_div = Function(space_1)
+    solve(inner(trial_1, test_1) * dx == -action(block_10, u_0),
+          u_div,
+          solver_parameters={"ksp_type": "cg",
+                             "pc_type": "jacobi",
+                             "ksp_atol": 1.0e-14,
+                             "ksp_rtol": 1.0e-14})
+
+    u_div_error_norm = np.sqrt(abs(assemble(inner(u_div,
+                                                  u_div) * dx)))
+    assert u_div_error_norm < 1.0e-12
+
+    grad_u_1 = Function(space_0)
+    solve(inner(trial_0, test_0) * dx
+          == inner(grad(u_1), test_0) * dx,
+          grad_u_1, DirichletBC(space_0, (0.0, 0.0), "on_boundary"),
+          solver_parameters={"ksp_type": "cg",
+                             "pc_type": "jacobi",
+                             "ksp_atol": 1.0e-14,
+                             "ksp_rtol": 1.0e-14})
+
+    u_orthogonality_error_norm = abs(assemble(inner(grad_u_1, u_0) * dx))
+    assert u_orthogonality_error_norm < 1.0e-14
+
+    u_0_error_norm = np.sqrt(abs(assemble(inner(u_s - u_0 - grad_u_1,
+                                                u_s - u_0 - grad_u_1) * dx)))
+    assert u_0_error_norm < 1.0e-12
+
+
+@pytest.mark.firedrake
+def test_mass(setup_test):  # noqa: F811
+    mesh = UnitSquareMesh(10, 10)
+    X = SpatialCoordinate(mesh)
+    space = FunctionSpace(mesh, "Lagrange", 1)
+    test, trial = TestFunction(space), TrialFunction(space)
+    bc = DirichletBC(space, 0.0, (1, 2, 3, 4))
+
+    y = Function(space, name="y")
+    y.interpolate(exp(X[0]) * sin(pi * X[0]) * sin(2.0 * pi * X[1]))
+
+    u = Function(space, name="u")
+    b = assemble(inner(y, test) * dx)
+
+    system = System(
+        space, space,
+        inner(trial, test) * dx, nullspaces=DirichletBCNullspace(bc))
+
+    _ = system.solve(
+        u, b,
+        solver_parameters={"linear_solver": "cg",
+                           "relative_tolerance": 1.0e-14,
+                           "absolute_tolerance": 1.0e-14})
+
+    u_error_norm = np.sqrt(abs(assemble(inner(u - y, u - y) * dx)))
+    assert u_error_norm < 1.0e-13
+
+
+@pytest.mark.firedrake
+def test_sub_block(setup_test):  # noqa: F811
+    mesh = UnitSquareMesh(10, 10)
+    X = SpatialCoordinate(mesh)
+    space_0 = FunctionSpace(mesh, "Lagrange", 1)
+    space_1 = FunctionSpace(mesh, "Lagrange", 2)
+    space_1 = FunctionSpace(mesh,
+                            space_0.ufl_element() * space_1.ufl_element())
+    space_2 = FunctionSpace(mesh, "Lagrange", 3)
+
+    test_0, trial_0 = TestFunction(space_0), TrialFunction(space_0)
+    test_1, trial_1 = TestFunction(space_1), TrialFunction(space_1)
+    test_2, trial_2 = TestFunction(space_2), TrialFunction(space_2)
+
+    block_00 = BlockMatrix((space_0, space_1), (space_0, space_1))
+    block_00[(0, 0)] = inner(trial_0, test_0) * dx
+    block_00[(1, 1)] = inner(trial_1, test_1) * dx
+    block_11 = inner(trial_2, test_2) * dx
+
+    u_0_ref = Function(space_0)
+    u_0_ref.interpolate(X[0] * exp(X[1]))
+    u_1_ref = Function(space_1)
+    u_1_ref.sub(0).interpolate(X[1] * exp(X[0]))
+    u_1_ref.sub(1).interpolate(X[0] * X[1] * sin(2.0 * pi * X[1]))
+    u_2_ref = Function(space_2)
+    u_2_ref.interpolate(sin(3.0 * pi * X[0]) * sin(4.0 * pi * X[1]))
+
+    b_0 = assemble(inner(u_0_ref, test_0) * dx)
+    b_1 = assemble(inner(u_1_ref, test_1) * dx)
+    b_2 = assemble(inner(u_2_ref, test_2) * dx)
+
+    nullspace_2 = DirichletBCNullspace(
+        DirichletBC(space_2, 0.0, "on_boundary"))
+
+    system = System(
+        ((space_0, space_1), space_2), ((space_0, space_1), space_2),
+        {(0, 0): block_00, (1, 1): block_11},
+        nullspaces=(None, nullspace_2))
+
+    u_0 = Function(space_0)
+    u_1 = Function(space_1)
+    u_2 = Function(space_2)
+
+    def pc_fn(u, b):
+        (u_0, u_1), u_2 = u
+        (b_0, b_1), b_2 = b
+        assert u_0.function_space() == space_0
+        assert u_1.function_space() == space_1
+        assert u_2.function_space() == space_2
+        assert b_0.function_space() == space_0
+        assert b_1.function_space() == space_1
+        assert b_2.function_space() == space_2
+        u_0.assign(b_0)
+        u_1.assign(b_1)
+        u_2.assign(b_2)
+
+    _ = system.solve(
+        ((u_0, u_1), u_2), ((b_0, b_1), b_2),
+        pc_fn=pc_fn,
+        solver_parameters={"linear_solver": "cg",
+                           "relative_tolerance": 1.0e-14,
+                           "absolute_tolerance": 1.0e-14})
+
+    u_2_bc_error_norm = np.sqrt(abs(assemble(inner(u_2, u_2) * ds)))
+    assert u_2_bc_error_norm == 0.0
+
+    u_0_error_norm = np.sqrt(abs(assemble(inner(u_0 - u_0_ref,
+                                                u_0 - u_0_ref) * dx)))
+    assert u_0_error_norm < 1.0e-13
+
+    u_1_error_norm = np.sqrt(abs(assemble(inner(u_1 - u_1_ref,
+                                                u_1 - u_1_ref) * dx)))
+    assert u_1_error_norm < 1.0e-12
+
+    u_2_error_norm = np.sqrt(abs(assemble(inner(u_2 - u_2_ref,
+                                                u_2 - u_2_ref) * dx)))
+    assert u_2_error_norm < 1.0e-12

--- a/tests/firedrake/test_eigendecomposition.py
+++ b/tests/firedrake/test_eigendecomposition.py
@@ -34,8 +34,9 @@ def test_HEP(setup_test, test_leaks):
         return y
 
     import slepc4py.SLEPc as SLEPc
-    lam, V = eigendecompose(space, M_action, action_type="conjugate_dual",
-                            problem_type=SLEPc.EPS.ProblemType.HEP)
+    lam, V = eigendecompose(
+        space, M_action, action_space_type="conjugate_dual",
+        problem_type=SLEPc.EPS.ProblemType.HEP)
 
     assert (lam > 0.0).all()
 
@@ -63,7 +64,8 @@ def test_NHEP(setup_test, test_leaks):
         assemble(inner(x.dx(0), test) * dx, tensor=function_vector(y))
         return y
 
-    lam, V = eigendecompose(space, N_action, action_type="conjugate_dual",)
+    lam, V = eigendecompose(
+        space, N_action, action_space_type="conjugate_dual",)
 
     assert abs(lam.real).max() < 1.0e-15
 

--- a/tests/firedrake/test_gauss_newton.py
+++ b/tests/firedrake/test_gauss_newton.py
@@ -53,7 +53,7 @@ def test_GaussNewton(setup_test, test_leaks):
 
     def B_inv_action(x):
         y = function_new_conjugate_dual(x)
-        assemble(eps * inner(ufl.conj(x), test) * dx,
+        assemble(ufl.conj(eps) * inner(ufl.conj(x), test) * dx,
                  tensor=function_vector(y))
         return y
 
@@ -116,7 +116,7 @@ def test_CachedGaussNewton(setup_test):
 
     def B_inv_action(x):
         y = function_new_conjugate_dual(x)
-        assemble(eps * inner(ufl.conj(x), test) * dx,
+        assemble(ufl.conj(eps) * inner(ufl.conj(x), test) * dx,
                  tensor=function_vector(y))
         return y
 

--- a/tests/firedrake/test_hessian_system.py
+++ b/tests/firedrake/test_hessian_system.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from firedrake import *
+from tlm_adjoint.firedrake import *
+from tlm_adjoint.firedrake.backend_code_generator_interface import \
+    assemble_linear_solver, function_vector
+
+from .test_base import *
+
+import mpi4py.MPI as MPI
+import numpy as np
+import pytest
+import ufl
+
+pytestmark = pytest.mark.skipif(
+    MPI.COMM_WORLD.size not in [1, 4],
+    reason="tests must be run in serial, or with 4 processes")
+
+
+@pytest.mark.firedrake
+@pytest.mark.skipif(complex_mode, reason="real only")
+@pytest.mark.parametrize("N_eigenvalues", [0, 5, 16])
+def test_hessian_solve(setup_test,
+                       N_eigenvalues):
+    configure_checkpointing("memory", {"drop_references": False})
+
+    mesh = UnitSquareMesh(5, 5)
+    X = SpatialCoordinate(mesh)
+    space = FunctionSpace(mesh, "Lagrange", 1)
+    test, trial = TestFunction(space), TrialFunction(space)
+    bc = DirichletBC(space, 0.0, "on_boundary")
+
+    alpha = Constant(1.0 / np.sqrt(2.0))
+    beta = Constant(1.0 / np.sqrt(5.0))
+
+    def B_inv(u):
+        b = Function(space, space_type="conjugate_dual")
+        assemble(ufl.conj(beta) * inner(ufl.conj(u), test) * dx,
+                 tensor=function_vector(b))
+        return b
+
+    def B(b):
+        u = Function(space)
+        solver, _, _ = assemble_linear_solver(
+            ufl.conj(beta) * inner(ufl.conj(trial), test) * dx, bcs=bc,
+            linear_solver_parameters=ls_parameters_cg)
+        solver.solve(function_vector(u), function_vector(function_copy(b)))
+        return u
+
+    def forward(u_ref, m):
+        m_1 = Function(space, name="m_1")
+        DirichletBCApplication(m_1, m, "on_boundary").solve()
+        m_0 = Function(space, name="m_0")
+        LinearCombination(m_0, (1.0, m), (-1.0, m_1)).solve()
+        m = m_0
+        del m_0, m_1
+        assert np.sqrt(abs(assemble(inner(m, m) * ds))) == 0.0
+
+        u = Function(space, name="u")
+        solve(inner(grad(trial), grad(test)) * dx == inner(m + m * m, test) * dx,  # noqa: E501
+              u, bc,
+              solver_parameters=ls_parameters_cg)
+
+        J_mismatch = Functional(name="J")
+        J_mismatch.assign(0.5 * alpha * dot(u - u_ref, u - u_ref) * dx)
+
+        J = Functional(name="J")
+        J.assign(J_mismatch.function())
+        J.addto(0.5 * beta * dot(m, m) * dx)
+
+        return u, J, J_mismatch
+
+    def forward_J(m):
+        _, J, _ = forward(u_ref, m)
+        return J
+
+    u_ref = Function(space, name="u_ref")
+    interpolate_expression(
+        u_ref,
+        sin(2.0 * pi * X[0]) * sin(3.0 * pi * X[1]) * exp(4.0 * X[0] * X[1]))
+
+    m0 = Function(space, name="m0")
+    m, _ = minimize_l_bfgs(
+        forward_J, m0,
+        s_atol=0.0, g_atol=1.0e-10,
+        H_0_action=B, M_action=B_inv, M_inv_action=B)
+
+    b_ref = Function(space, name="b_ref", space_type="conjugate_dual")
+    assemble(inner((sin(5.0 * pi * X[0]) * sin(7.0 * pi * X[1])) ** 2, test) * dx,  # noqa: E501
+             tensor=function_vector(b_ref))
+    bc.apply(function_vector(b_ref))
+
+    start_manager()
+    _, J, J_mismatch = forward(u_ref, m)
+    stop_manager()
+    H = CachedHessian(J)
+    H_mismatch = CachedHessian(J_mismatch)
+    nullspace = DirichletBCNullspace(bc)
+
+    v = Function(space, name="v")
+    system = HessianSystem(H, m, nullspace=nullspace)
+
+    if N_eigenvalues == 0:
+        pc_fn = None
+    else:
+        import slepc4py.SLEPc as SLEPc
+
+        Lam, V = hessian_eigendecompose(
+            H_mismatch, m, B_inv, B, nullspace=nullspace,
+            N_eigenvalues=N_eigenvalues,
+            solver_type=SLEPc.EPS.Type.KRYLOVSCHUR,
+            which=SLEPc.EPS.Which.LARGEST_MAGNITUDE,
+            tolerance=1.0e-14)
+
+        diag_error_norm, off_diag_error_norm = B_inv_orthonormality_test(V, B_inv)  # noqa: E501
+        assert diag_error_norm < 1.0e-14
+        assert off_diag_error_norm < 1.0e-14
+
+        pc_fn = hessian_eigendecomposition_pc(B, Lam, V)
+
+    ksp = system.solve(
+        v, b_ref, pc_fn=pc_fn,
+        solver_parameters={"linear_solver": "cg",
+                           "absolute_tolerance": 1.0e-12,
+                           "relative_tolerance": 1.0e-12})
+
+    if N_eigenvalues == 0:
+        assert ksp.getIterationNumber() <= 14
+    elif N_eigenvalues == 5:
+        assert ksp.getIterationNumber() <= 6
+    elif N_eigenvalues == 16:
+        assert ksp.getIterationNumber() == 1
+
+    H = Hessian(forward_J)
+    _, _, b = H.action(m, v)
+    b_error = function_copy(b, name="b_error")
+    function_axpy(b_error, -1.0, b_ref)
+    assert function_linf_norm(b_error) < 1.0e-13

--- a/tlm_adjoint/_code_generator/block_system.py
+++ b/tlm_adjoint/_code_generator/block_system.py
@@ -1,0 +1,1319 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+r"""This module is used by both the FEniCS and Firedrake backends, and
+implements solvers for linear systems defined in mixed spaces.
+
+The :class:`System` class defines the block structure of the linear system, and
+solves the system using an outer Krylov solver. A custom preconditioner can be
+defined via the `pc_fn` callback to :meth:`System.solve`, and this
+preconditioner can itself e.g. make use of further Krylov solvers. This
+provides a Python interface for custom block preconditioners.
+
+Given a linear problem with a potentially singular matrix :math:`A`
+
+.. math::
+
+    A u = b,
+
+a :class:`System` instead solves the linear problem
+
+.. math::
+
+    \left[ (I - M U (U^* M U)^{-1} U^*) A (I - V (V^* C V)^{-1} V^* C)
+        + M U S V^* C \right] u = (I - M U (U^* M U)^{-1} U^*) b.
+
+Here
+
+    - :math:`U` is a full rank matrix whose columns span the left nullspace for
+      a modified system matrix :math:`\tilde{A}`.
+    - :math:`V` is a full rank matrix with the same number of columns as
+      :math:`U`, whose columns span the nullspace for :math:`\tilde{A}`.
+    - :math:`V^* C V` and :math:`S` are invertible matrices.
+    - :math:`M` is a Hermitian positive definite matrix.
+
+Here the left nullspace for a matrix is defined to be the nullspace for its
+Hermitian transpose, and the modified system matrix :math:`\tilde{A}` is
+defined
+
+.. math::
+
+    \tilde{A} = (I - M U (U^* M U)^{-1} U^*) A (I - V (V^* C V)^{-1} V^* C).
+
+This has two primary use cases:
+
+  1. Where a matrix :math:`A` and right-hand-side :math:`b` are constructed via
+     finite element assembly on superspaces of the test space and trial space.
+     The typical example is in the application of homogeneous essential
+     Dirichlet boundary conditions.
+
+  2. Where the matrix :math:`A` is singular and :math:`b` is orthogonal to the
+     left nullspace of :math:`A`. Typically one would then choose :math:`U` and
+     :math:`V` so that their columns respectively span the left nullspace and
+     nullspace of :math:`A`, and the :class:`System` then seeks a solution to
+     the original problem subject to the linear constraints :math:`V^* C u =
+     0`.
+
+Function spaces are defined via backend function spaces, and :class:`Sequence`
+objects containing backend function spaces or similar :class:`Sequence`
+objects. Similarly functions are defined via backend :class:`Function` objects,
+or :class:`Sequence` objects containing backend :class:`Function` objects or
+similar :class:`Sequence` objects. This defines a basic tree structure which is
+useful e.g. when defining block matrices in terms of sub-block matrices.
+
+Elements of the tree are accessed in a consistent order using a depth first
+search. Hence e.g.
+
+.. code-block:: python
+
+    ((u_0, u_1), u_2)
+
+and
+
+.. code-block:: python
+
+    (u_0, u_1, u_2)
+
+where `u_0`, `u_1`, and `u_2` are backend :class:`Function` objects, are both
+valid representations of a mixed space solution.
+
+Code in this module is written to use only backend functionality, and does not
+use tlm_adjoint interfaces. Consequently if used directly, and in combination
+with other tlm_adjoint code, space type warnings may be encountered.
+"""
+
+# This is the only import from other tlm_adjoint modules that is permitted in
+# this module
+from .backend import backend
+
+if backend == "Firedrake":
+    from firedrake import (Constant, DirichletBC, Function, FunctionSpace,
+                           TestFunction, assemble)
+elif backend == "FEniCS":
+    from fenics import (Constant, DirichletBC, Function, FunctionSpace,
+                        TestFunction, assemble)
+    from fenics import FunctionAssigner, as_backend_type
+    from dolfin.cpp.function import Constant as cpp_Constant
+else:
+    raise ImportError(f"Unexpected backend: {backend}")
+
+import petsc4py.PETSc as PETSc
+import ufl
+
+from abc import ABC, abstractmethod
+from collections import deque
+from collections.abc import Sequence
+from contextlib import contextmanager
+from enum import Enum
+from functools import cached_property, wraps
+import logging
+import weakref
+
+__all__ = \
+    [
+        "MixedSpace",
+        "BackendMixedSpace",
+
+        "Nullspace",
+        "NoneNullspace",
+        "ConstantNullspace",
+        "UnityNullspace",
+        "DirichletBCNullspace",
+        "BlockNullspace",
+
+        "Matrix",
+        "PETScMatrix",
+        "BlockMatrix",
+        "form_matrix",
+
+        "ConvergenceError",
+        "System"
+    ]
+
+_error_flag = False
+
+
+def flag_errors(fn):
+    @wraps(fn)
+    def wrapped_fn(*args, **kwargs):
+        global _error_flag
+        try:
+            return fn(*args, **kwargs)
+        except Exception:
+            _error_flag = True
+            raise
+    return wrapped_fn
+
+
+# Following naming of PyOP2 Dat.vec_context access types
+class Access(Enum):
+    RW = "RW"
+    READ = "READ"
+    WRITE = "WRITE"
+
+
+def iter_sub(iterable, *, expand=None):
+    if expand is None:
+        def expand(e):
+            return e
+
+    q = deque(map(expand, iterable))
+    while len(q) > 0:
+        e = q.popleft()
+        if isinstance(e, Sequence) and not isinstance(e, str):
+            q.extendleft(map(expand, reversed(e)))
+        else:
+            yield e
+
+
+def zip_sub(*iterables):
+    iterators = map(iter_sub, iterables)
+    yield from zip(*iterators)
+
+    for iterator in iterators:
+        try:
+            next(iterator)
+            raise ValueError("Non-equal lengths")
+        except StopIteration:
+            pass
+
+
+def tuple_sub(iterable, sequence):
+    iterator = iter_sub(iterable)
+
+    def tuple_sub(iterator, value):
+        if isinstance(value, Sequence) and not isinstance(value, str):
+            return tuple(tuple_sub(iterator, e) for e in value)
+        return next(iterator)
+
+    t = tuple_sub(iterator, sequence)
+
+    try:
+        next(iterator)
+        raise ValueError("Non-equal lengths")
+    except StopIteration:
+        pass
+
+    return t
+
+
+class MixedSpace(ABC):
+    """Used to map between mixed and split versions of spaces.
+
+    This class defines three representations for the space:
+
+        1. As a 'mixed space': A single function space defined using a UFL
+           :class:`MixedElement`.
+        2. As a 'split space': A tree defining the mixed space. Stored using
+           backend function space and :class:`tuple` objects, each
+           corresponding to a node in the tree. Function spaces correspond to
+           leaf nodes, and :class:`tuple` objects to other nodes in the tree.
+        3. As a 'flattened space': A :class:`Sequence` containing leaf nodes of
+           the split space with an ordering determined using a depth first
+           search.
+
+    This allows, for example, the construction:
+
+    .. code-block:: python
+
+        u_0 = Function(space_0, name='u_0')
+        u_1 = Function(space_1, name='u_1')
+        u_2 = Function(space_2, name='u_2')
+
+        mixed_space = BackendMixedSpace(((space_0, space_1), space_2))
+        u_fn = mixed_space.new_mixed()
+
+    and then data can be copied to the function in the mixed space via
+
+    .. code-block:: python
+
+        mixed_space.split_to_mixed(u_fn, ((u_0, u_1), u_2))
+
+    and from the function in the mixed space via
+
+    .. code-block:: python
+
+        mixed_space.mixed_to_split(((u_0, u_1), u_2), u_fn)
+
+    :arg spaces: The split space.
+    """
+
+    def __init__(self, spaces):
+        if isinstance(spaces, Sequence):
+            spaces = tuple(spaces)
+        else:
+            spaces = (spaces,)
+        spaces = tuple_sub(spaces, spaces)
+        flattened_spaces = tuple(iter_sub(spaces))
+
+        mesh = flattened_spaces[0].mesh()
+        for space in flattened_spaces[1:]:
+            if space.mesh() != mesh:
+                raise ValueError("Invalid mesh")
+
+        if len(flattened_spaces) == 1:
+            mixed_space, = flattened_spaces
+        else:
+            mixed_element = ufl.classes.MixedElement(
+                *(space.ufl_element() for space in flattened_spaces))
+            mixed_space = FunctionSpace(mesh, mixed_element)
+
+        with vec(Function(mixed_space), Access.READ) as v:
+            n = v.getLocalSize()
+            N = v.getSize()
+
+        self._mesh = mesh
+        self._spaces = spaces
+        self._flattened_spaces = flattened_spaces
+        self._mixed_space = mixed_space
+        self._sizes = (n, N)
+
+    def mesh(self):
+        """
+        :returns: The mesh associated with the space.
+        """
+
+        return self._mesh
+
+    def split_space(self):
+        """
+        :returns: The split space.
+        """
+
+        return self._spaces
+
+    def flattened_space(self):
+        """
+        :returns: The flattened space.
+        """
+
+        return self._flattened_spaces
+
+    def mixed_space(self):
+        """
+        :returns: The mixed space.
+        """
+
+        return self._mixed_space
+
+    def new_split(self, *args, **kwargs):
+        """
+        :returns: A new function in the split space.
+
+        Arguments are passed to the backend :class:`Function` constructor.
+        """
+
+        return tuple_sub((Function(space, *args, **kwargs)
+                          for space in self._flattened_spaces),
+                         self._spaces)
+
+    def new_mixed(self, *args, **kwargs):
+        """
+        :returns: A new function in the mixed space.
+
+        Arguments are passed to the backend :class:`Function` constructor.
+        """
+
+        return Function(self._mixed_space, *args, **kwargs)
+
+    def sizes(self):
+        """
+        :returns: A :class:`tuple`, `(n, N)`, where `n` is the number of
+            process local degrees of freedom and `N` is the number of global
+            degrees of freedom, each for the mixed space.
+        """
+
+        return self._sizes
+
+    @abstractmethod
+    def mixed_to_split(self, u, u_fn):
+        """Copy data out of the mixed space representation.
+
+        :arg u: A function in a compatible split space.
+        :arg u_fn: The function in the mixed space.
+        """
+
+        raise NotImplementedError
+
+    @abstractmethod
+    def split_to_mixed(self, u_fn, u):
+        """Copy data into the mixed space representation.
+
+        :arg u_fn: The function in the mixed space.
+        :arg u: A function in a compatible split space.
+        """
+
+        raise NotImplementedError
+
+
+if backend == "Firedrake":
+    def mesh_comm(mesh):
+        return mesh.comm
+
+    class BackendMixedSpace(MixedSpace):
+        @staticmethod
+        def _iter_sub_fn(iterable):
+            def expand(e):
+                if isinstance(e, Function):
+                    space = e.function_space()
+                    if hasattr(space, "num_sub_spaces"):
+                        return tuple(e.sub(i)
+                                     for i in range(space.num_sub_spaces()))
+                return e
+
+            return iter_sub(iterable, expand=expand)
+
+        def mixed_to_split(self, u, u_fn):
+            if len(self._flattened_spaces) == 1:
+                u, = tuple(iter_sub(u))
+                u.assign(u_fn)
+            else:
+                for i, u_i in enumerate(self._iter_sub_fn(u)):
+                    u_i.assign(u_fn.sub(i))
+
+        def split_to_mixed(self, u_fn, u):
+            if len(self._flattened_spaces) == 1:
+                u, = tuple(iter_sub(u))
+                u_fn.assign(u)
+            else:
+                for i, u_i in enumerate(self._iter_sub_fn(u)):
+                    u_fn.sub(i).assign(u_i)
+
+    def mat(a):
+        return a.petscmat
+
+    @contextmanager
+    def vec(u, mode=Access.RW):
+        attribute_name = {Access.RW: "vec",
+                          Access.READ: "vec_ro",
+                          Access.WRITE: "vec_wo"}[mode]
+        with getattr(u.dat, attribute_name) as u_v:
+            yield u_v
+
+    def bc_space(bc):
+        return bc.function_space()
+
+    def bc_is_homogeneous(bc):
+        return isinstance(bc.function_arg, ufl.classes.Zero)
+
+    def bc_domain_args(bc):
+        return (bc.sub_domain,)
+
+    def apply_bcs(u, bcs):
+        if not isinstance(bcs, Sequence):
+            bcs = (bcs,)
+        for bc in bcs:
+            bc.apply(u)
+elif backend == "FEniCS":
+    def mesh_comm(mesh):
+        return mesh.mpi_comm()
+
+    class BackendMixedSpace(MixedSpace):
+        @cached_property
+        def _mixed_to_split_assigner(self):
+            return FunctionAssigner(list(self._flattened_spaces),
+                                    self._mixed_space)
+
+        @cached_property
+        def _split_to_mixed_assigner(self):
+            return FunctionAssigner(self._mixed_space,
+                                    list(self._flattened_spaces))
+
+        def mixed_to_split(self, u, u_fn):
+            if len(self._flattened_spaces) == 1:
+                u, = tuple(iter_sub(u))
+                u.assign(u_fn)
+            else:
+                self._mixed_to_split_assigner.assign(list(iter_sub(u)),
+                                                     u_fn)
+
+        def split_to_mixed(self, u_fn, u):
+            if len(self._flattened_spaces) == 1:
+                u, = tuple(iter_sub(u))
+                u_fn.assign(u)
+            else:
+                self._split_to_mixed_assigner.assign(u_fn,
+                                                     list(iter_sub(u)))
+
+    def mat(a):
+        matrix = as_backend_type(a).mat()
+        if not isinstance(matrix, PETSc.Mat):
+            raise RuntimeError("PETSc backend required")
+        return matrix
+
+    @contextmanager
+    def vec(u, mode=Access.RW):
+        if isinstance(u, Function):
+            u = u.vector()
+        u_v = as_backend_type(u).vec()
+        if not isinstance(u_v, PETSc.Vec):
+            raise RuntimeError("PETSc backend required")
+
+        yield u_v
+
+        if mode in {Access.RW, Access.WRITE}:
+            u.update_ghost_values()
+
+    def bc_space(bc):
+        return FunctionSpace(bc.function_space())
+
+    def bc_is_homogeneous(bc):
+        # A weaker check with FEniCS, as the constant might be modified
+        return (isinstance(bc.value(), cpp_Constant)
+                and (bc.value().values() == 0.0).all())
+
+    def bc_domain_args(bc):
+        return (bc.sub_domain, bc.method())
+
+    def apply_bcs(u, bcs):
+        if not isinstance(bcs, Sequence):
+            bcs = (bcs,)
+        for bc in bcs:
+            bc.apply(u.vector())
+else:
+    raise ImportError(f"Unexpected backend: {backend}")
+
+
+class Nullspace(ABC):
+    """Represents a matrix nullspace and left nullspace.
+    """
+
+    @abstractmethod
+    def apply_nullspace_transformation_lhs_right(self, x):
+        r"""Apply the nullspace transformation associated with a matrix action
+        on :math:`x`,
+
+        .. math::
+
+            x \rightarrow (I - V (V^* C V)^{-1} V^* C) x.
+
+        :arg x: Defines :math:`x`.
+        """
+
+        raise NotImplementedError
+
+    @abstractmethod
+    def apply_nullspace_transformation_lhs_left(self, y):
+        r"""Apply the left nullspace transformation associated with a matrix
+        action,
+
+        .. math::
+
+            y \rightarrow (I - M U (U^* M U)^{-1} U^*) y.
+
+        :arg y: Defines :math:`y`.
+        """
+
+        raise NotImplementedError
+
+    @abstractmethod
+    def constraint_correct_lhs(self, x, y):
+        r"""Add the linear constraint term to :math:`y`,
+
+        .. math::
+
+            y \rightarrow y + M U S V^* C x.
+
+        :arg x: Defines :math:`x`.
+        :arg y: Defines :math:`y`.
+        """
+
+        raise NotImplementedError
+
+    @abstractmethod
+    def pc_constraint_correct_soln(self, u, b):
+        r"""Add the preconditioner linear constraint term to :math:`u`,
+
+        .. math::
+
+            u \rightarrow u + V \tilde{S}^{-1} U^* b,
+
+        with
+
+        .. math::
+
+            \tilde{S}^{-1} =
+                \left( V^* C V \right)^{-1}
+                S^{-1}
+                \left( U^* M U \right)^{-1}.
+
+        :arg u: Defines :math:`u`.
+        :arg b: Defines :math:`b`.
+        """
+
+        raise NotImplementedError
+
+    def correct_soln(self, x):
+        """Correct the linear system solution so that it is orthogonal to
+        space spanned by the columns of :math:`V`.
+
+        :arg x: The linear system solution, to be corrected.
+        """
+
+        self.apply_nullspace_transformation_lhs_right(x)
+
+    def pre_mult_correct_lhs(self, x):
+        """Apply the pre-left-multiplication nullspace transformation.
+
+        :arg x: Defines the vector on which the matrix action is computed.
+        """
+
+        self.apply_nullspace_transformation_lhs_right(x)
+
+    def post_mult_correct_lhs(self, x, y):
+        """Apply the post-left-multiplication nullspace transformation, and add
+        the linear constraint term.
+
+        :arg x: Defines the vector on which the matrix action is computed, and
+            used to add the linear constraint term. If `None` is supplied then
+            the linear constraint term is not added.
+        :arg y: Defines the result of the matrix action on `x`.
+        """
+
+        self.apply_nullspace_transformation_lhs_left(y)
+        if x is not None:
+            self.constraint_correct_lhs(x, y)
+
+    def correct_rhs(self, b):
+        """Correct the linear system right-hand-side so that it is orthogonal
+        to the space spanned by the columns of :math:`U`.
+
+        :arg b: The linear system right-hand-side, to be corrected.
+        """
+
+        self.apply_nullspace_transformation_lhs_left(b)
+
+    def pc_pre_mult_correct(self, b):
+        """Apply the pre-preconditioner-application nullspace transformation.
+
+        :arg b: Defines the vector on which the preconditioner action is
+            computed.
+        """
+
+        self.apply_nullspace_transformation_lhs_left(b)
+
+    def pc_post_mult_correct(self, u, b):
+        """Apply the post-preconditioner-application left nullspace
+        transformation, and add the linear constraint term.
+
+        :arg u: Defines the result of the preconditioner action on `b`.
+        :arg b: Defines the vector on which the preconditioner action is
+            computed, and used to add the linear constraint term. If `None` is
+            supplied then the linear constraint term is not added.
+        """
+
+        self.apply_nullspace_transformation_lhs_right(u)
+        if b is not None:
+            self.pc_constraint_correct_soln(u, b)
+
+
+class NoneNullspace(Nullspace):
+    """An empty nullspace and left nullspace.
+    """
+
+    def apply_nullspace_transformation_lhs_right(self, x):
+        pass
+
+    def apply_nullspace_transformation_lhs_left(self, y):
+        pass
+
+    def constraint_correct_lhs(self, x, y):
+        pass
+
+    def pc_constraint_correct_soln(self, u, b):
+        pass
+
+
+class ConstantNullspace(Nullspace):
+    r"""A nullspace and left nullspace spanned by the vector of ones.
+
+    Here :math:`V = U`, :math:`U` is a single column matrix whose elements are
+    ones, :math:`C = M`, and :math:`M` is an identity matrix.
+
+    :arg alpha: Defines the linear constraint matrix :math:`S = \left( \alpha /
+        N \right)` where :math:`N` is the length of the vector of ones.
+    """
+
+    def __init__(self, *, alpha=1.0):
+        super().__init__()
+        self._alpha = alpha
+
+    @staticmethod
+    def _correct(x, y, *, alpha=1.0):
+        with vec(x, Access.READ) as x_v:
+            x_sum = x_v.sum()
+            N = x_v.getSize()
+
+        with vec(y) as y_v:
+            y_v.shift(alpha * x_sum / float(N))
+
+    def apply_nullspace_transformation_lhs_right(self, x):
+        self._correct(x, x, alpha=-1.0)
+
+    def apply_nullspace_transformation_lhs_left(self, y):
+        self._correct(y, y, alpha=-1.0)
+
+    def constraint_correct_lhs(self, x, y):
+        self._correct(x, y, alpha=self._alpha)
+
+    def pc_constraint_correct_soln(self, u, b):
+        self._correct(b, u, alpha=1.0 / self._alpha)
+
+
+class UnityNullspace(Nullspace):
+    r"""A nullspace and left nullspace defined by the unity-valued function.
+
+    Here :math:`V = U`, :math:`U` is a single column matrix containing the
+    degree-of-freedom vector for the unity-valued function, :math:`C = M`,
+    and :math:`M` is the mass matrix.
+
+    :arg space: A scalar-valued function space containing the unity-valued
+        function.
+    :arg alpha: Defines the linear constraint matrix :math:`S = \alpha \left(
+        U^* M U \right)^{-1}`.
+    """
+
+    def __init__(self, space, *, alpha=1.0):
+        U = Function(space, name="U")
+        U.assign(Constant(1.0))
+        MU = assemble(ufl.inner(U, TestFunction(space)) * ufl.dx)
+        UMU = assemble(ufl.inner(U, U) * ufl.dx)
+
+        self._alpha = alpha
+        self._U = U
+        self._MU = MU
+        self._UMU = UMU
+
+    @staticmethod
+    def _correct(x, y, u, v, *, alpha=1.0):
+        with vec(x, Access.READ) as x_v, vec(u, Access.READ) as u_v:
+            u_x = x_v.dot(u_v)
+
+        with vec(y) as y_v, vec(v, Access.READ) as v_v:
+            y_v.axpy(alpha * u_x, v_v)
+
+    def apply_nullspace_transformation_lhs_right(self, x):
+        self._correct(
+            x, x, self._MU, self._U, alpha=-1.0 / self._UMU)
+
+    def apply_nullspace_transformation_lhs_left(self, y):
+        self._correct(
+            y, y, self._U, self._MU, alpha=-1.0 / self._UMU)
+
+    def constraint_correct_lhs(self, x, y):
+        self._correct(
+            x, y, self._MU, self._MU, alpha=self._alpha / self._UMU)
+
+    def pc_constraint_correct_soln(self, u, b):
+        self._correct(
+            b, u, self._U, self._U, alpha=1.0 / (self._alpha * self._UMU))
+
+
+class DirichletBCNullspace(Nullspace):
+    r"""A nullspace and left nullspace associated with homogeneous Dirichlet
+    boundary conditions.
+
+    Here :math:`V = U`, :math:`U` is a zero-one matrix with exactly one
+    non-zero per column corresponding to one boundary condition
+    degree-of-freedom, :math:`C = M`, and :math:`M` is an identity matrix.
+
+    :arg bcs: The Dirichlet boundary conditions.
+    :arg alpha: Defines the linear constraint matrix :math:`S = \alpha M`.
+    """
+
+    def __init__(self, bcs, *, alpha=1.0):
+        if isinstance(bcs, Sequence):
+            bcs = tuple(bcs)
+        else:
+            bcs = (bcs,)
+
+        space = bc_space(bcs[0])
+        for bc in bcs:
+            if bc_space(bc) != space:
+                raise ValueError("Invalid space")
+            if not bc_is_homogeneous(bc):
+                raise ValueError("Homogeneous boundary conditions required")
+
+        super().__init__()
+        self._bcs = bcs
+        self._alpha = alpha
+        self._c = Function(space)
+
+    def apply_nullspace_transformation_lhs_right(self, x):
+        apply_bcs(x, self._bcs)
+
+    def apply_nullspace_transformation_lhs_left(self, y):
+        apply_bcs(y, self._bcs)
+
+    def _constraint_correct_lhs(self, x, y, *, alpha=1.0):
+        with vec(self._c, Access.WRITE) as c_v:
+            c_v.zeroEntries()
+
+        apply_bcs(self._c,
+                  tuple(DirichletBC(x.function_space(), x, *bc_domain_args(bc))
+                        for bc in self._bcs))
+
+        with vec(self._c, Access.READ) as c_v, vec(y) as y_v:
+            y_v.axpy(alpha, c_v)
+
+    def constraint_correct_lhs(self, x, y):
+        self._constraint_correct_lhs(x, y, alpha=self._alpha)
+
+    def pc_constraint_correct_soln(self, u, b):
+        self._constraint_correct_lhs(b, u, alpha=1.0 / self._alpha)
+
+
+class BlockNullspace(Nullspace):
+    """Nullspaces for a mixed space.
+
+    :arg nullspaces: A :class:`Nullspace` or a :class:`Sequence` of
+        :class:`Nullspace` objects defining the nullspace. `None` indicates a
+        :class:`NoneNullspace`.
+    """
+
+    def __init__(self, nullspaces):
+        if not isinstance(nullspaces, Sequence):
+            nullspaces = (nullspaces,)
+
+        nullspaces = list(nullspaces)
+        for i, nullspace in enumerate(nullspaces):
+            if nullspace is None:
+                nullspaces[i] = NoneNullspace()
+        nullspaces = tuple(nullspaces)
+
+        super().__init__()
+        self._nullspaces = nullspaces
+
+    def __new__(cls, nullspaces):
+        if not isinstance(nullspaces, Sequence):
+            nullspaces = (nullspaces,)
+        for nullspace in nullspaces:
+            if nullspace is not None \
+                    and not isinstance(nullspace, NoneNullspace):
+                break
+        else:
+            return NoneNullspace()
+        return super().__new__(cls)
+
+    def __getitem__(self, key):
+        return self._nullspaces[key]
+
+    def __iter__(self):
+        yield from self._nullspaces
+
+    def __len__(self):
+        return len(self._nullspaces)
+
+    def apply_nullspace_transformation_lhs_right(self, x):
+        assert len(self._nullspaces) == len(x)
+        for nullspace, x_i in zip(self._nullspaces, x):
+            nullspace.apply_nullspace_transformation_lhs_right(x_i)
+
+    def apply_nullspace_transformation_lhs_left(self, y):
+        assert len(self._nullspaces) == len(y)
+        for nullspace, y_i in zip(self._nullspaces, y):
+            nullspace.apply_nullspace_transformation_lhs_left(y_i)
+
+    def constraint_correct_lhs(self, x, y):
+        assert len(self._nullspaces) == len(x)
+        assert len(self._nullspaces) == len(y)
+        for nullspace, x_i, y_i in zip(self._nullspaces, x, y):
+            nullspace.constraint_correct_lhs(x_i, y_i)
+
+    def pc_constraint_correct_soln(self, u, b):
+        assert len(self._nullspaces) == len(u)
+        assert len(self._nullspaces) == len(b)
+        for nullspace, u_i, b_i in zip(self._nullspaces, u, b):
+            nullspace.pc_constraint_correct_soln(u_i, b_i)
+
+
+class Matrix(ABC):
+    r"""Represents a matrix :math:`A` mapping :math:`V \rightarrow W`.
+
+    Note that :math:`V` and :math:`W` need not correspond directly to discrete
+    function spaces as defined by `arg_space` and `action_space`, but may
+    instead e.g. be defined via one or more antidual spaces.
+
+    :arg arg_space: Defines the space `V`.
+    :arg action_space: Defines the space `W`.
+    """
+
+    def __init__(self, arg_space, action_space):
+        if isinstance(arg_space, Sequence):
+            arg_space = tuple(arg_space)
+            arg_space = tuple_sub(arg_space, arg_space)
+        if isinstance(action_space, Sequence):
+            action_space = tuple(action_space)
+            action_space = tuple_sub(action_space, action_space)
+
+        self._arg_space = arg_space
+        self._action_space = action_space
+
+    def arg_space(self):
+        """
+        :returns: The space defining :math:`V`.
+        """
+
+        return self._arg_space
+
+    def action_space(self):
+        """
+        :returns: The space defining :math:`W`.
+        """
+
+        return self._action_space
+
+    @abstractmethod
+    def mult_add(self, x, y):
+        """Add :math:`A x` to :math:`y`.
+
+        :arg x: Defines :math:`x`. Should not be modified.
+        :arg y: Defines :math:`y`.
+        """
+
+        raise NotImplementedError
+
+
+class PETScMatrix(Matrix):
+    r"""A :class:`Matrix` associated with a PETSc matrix :math:`A` mapping
+    :math:`V \rightarrow W`.
+
+    :arg arg_space: Defines the space `V`.
+    :arg action_space: Defines the space `W`.
+    :arg a: The PETSc matrix.
+    """
+
+    def __init__(self, arg_space, action_space, a):
+        super().__init__(arg_space, action_space)
+        self._matrix = a
+
+    def mult_add(self, x, y):
+        matrix = mat(self._matrix)
+        with vec(x, Access.READ) as x_v, vec(y) as y_v:
+            matrix.multAdd(x_v, y_v, y_v)
+
+
+def form_matrix(a, *args, **kwargs):
+    """Return a :class:`PETScMatrix` associated with a given sesquilinear form.
+
+    :arg a: A UFL :class:`Form` defining the sesquilinear form.
+
+    Remaining arguments are passed to the backend :func:`assemble`.
+    """
+
+    test, trial = a.arguments()
+    assert test.number() < trial.number()
+
+    return PETScMatrix(
+        trial.function_space(), test.function_space(),
+        assemble(a, *args, **kwargs))
+
+
+class BlockMatrix(Matrix):
+    r"""A matrix :math:`A` mapping :math:`V \rightarrow W`, where :math:`V` and
+    :math:`W` are defined by mixed spaces.
+
+    :arg arg_spaces: Defines the space `V`.
+    :arg action_spaces: Defines the space `W`.
+    :arg block: A :class:`Mapping` defining the blocks of the matrix. Items are
+        `((i, j), block)` defining a UFL :class:`Form` or :class:`Matrix` for
+        the block in row `i` and column `j`. A value for `block` of `None`
+        indicates a zero block.
+    """
+
+    def __init__(self, arg_spaces, action_spaces, blocks=None):
+        if not isinstance(blocks, BlockMatrix) \
+                and isinstance(blocks, (Matrix, ufl.classes.Form)):
+            blocks = {(0, 0): blocks}
+
+        super().__init__(arg_spaces, action_spaces)
+        self._blocks = {}
+
+        if blocks is not None:
+            self.update(blocks)
+
+    def __contains__(self, key):
+        i, j = key
+        return (i, j) in self._blocks
+
+    def __iter__(self):
+        yield from self.keys()
+
+    def __getitem__(self, key):
+        i, j = key
+        return self._blocks[(i, j)]
+
+    def __setitem__(self, key, value):
+        i, j = key
+        if value is None:
+            self.pop((i, j))
+        else:
+            if isinstance(value, ufl.classes.Form):
+                value = form_matrix(value)
+            if value.arg_space() != self._arg_space[j]:
+                raise ValueError("Invalid space")
+            if value.action_space() != self._action_space[i]:
+                raise ValueError("Invalid space")
+            self._blocks[(i, j)] = value
+
+    def __delitem__(self, key):
+        i, j = key
+        del self._blocks[(i, j)]
+
+    def __len__(self):
+        return len(self.__blocks)
+
+    def keys(self):
+        yield from sorted(self._blocks)
+
+    def values(self):
+        for (i, j) in self:
+            yield self[(i, j)]
+
+    def items(self):
+        for (i, j) in self:
+            yield ((i, j), self[(i, j)])
+
+    def update(self, other):
+        for (i, j), block in other.items():
+            self[(i, j)] = block
+
+    def pop(self, key, default=None):
+        i, j = key
+        return self._blocks.pop((i, j), default)
+
+    def mult_add(self, x, y):
+        for (i, j), block in self.items():
+            block.mult_add(x[j], y[i])
+
+
+class PETScInterface:
+    def __init__(self, arg_space, action_space, nullspace):
+        self._arg_space = arg_space
+        self._action_space = action_space
+        self._nullspace = nullspace
+
+        self._x = arg_space.new_split()
+        self._y = action_space.new_split()
+
+        if len(arg_space.flattened_space()) == 1:
+            self._x_fn, = tuple(iter_sub(self._x))
+        else:
+            self._x_fn = arg_space.new_mixed()
+        if len(action_space.flattened_space()) == 1:
+            self._y_fn, = tuple(iter_sub(self._y))
+        else:
+            self._y_fn = action_space.new_mixed()
+
+        if isinstance(self._nullspace, NoneNullspace):
+            self._x_c = self._x
+        else:
+            self._x_c = arg_space.new_split()
+
+    def _pre_mult(self, x_petsc):
+        with vec(self._x_fn, Access.WRITE) as x_v:
+            # assert x_petsc.getSizes() == x_v.getSizes()
+            x_petsc.copy(result=x_v)
+        if len(self._arg_space.flattened_space()) != 1:
+            self._arg_space.mixed_to_split(self._x, self._x_fn)
+
+        if not isinstance(self._nullspace, NoneNullspace):
+            for x_i, x_c_i in zip_sub(self._x, self._x_c):
+                x_c_i.assign(x_i)
+
+        for y_i in iter_sub(self._y):
+            with vec(y_i, Access.WRITE) as y_i_v:
+                y_i_v.zeroEntries()
+
+    def _post_mult(self, y_petsc):
+        if len(self._action_space.flattened_space()) != 1:
+            self._action_space.split_to_mixed(self._y_fn, self._y)
+
+        with vec(self._y_fn, Access.READ) as y_v:
+            assert y_petsc.getSizes() == y_v.getSizes()
+            y_v.copy(result=y_petsc)
+
+
+class SystemMatrix(PETScInterface):
+    def __init__(self, arg_space, action_space, matrix, nullspace):
+        if matrix.arg_space() != arg_space.split_space():
+            raise ValueError("Invalid space")
+        if matrix.action_space() != action_space.split_space():
+            raise ValueError("Invalid space")
+
+        super().__init__(arg_space, action_space, nullspace)
+        self._matrix = matrix
+
+    @flag_errors
+    def mult(self, A, x, y):
+        self._pre_mult(x)
+
+        if not isinstance(self._nullspace, NoneNullspace):
+            self._nullspace.pre_mult_correct_lhs(self._x_c)
+        self._matrix.mult_add(self._x_c, self._y)
+        if not isinstance(self._nullspace, NoneNullspace):
+            self._nullspace.post_mult_correct_lhs(self._x, self._y)
+
+        self._post_mult(y)
+
+
+class Preconditioner(PETScInterface):
+    def __init__(self, arg_space, action_space, pc_fn, nullspace):
+        super().__init__(arg_space, action_space, nullspace)
+        self._pc_fn = pc_fn
+
+    @flag_errors
+    def apply(self, pc, x, y):
+        self._pre_mult(x)
+
+        if not isinstance(self._nullspace, NoneNullspace):
+            self._nullspace.pc_pre_mult_correct(self._x_c)
+        self._pc_fn(self._y, self._x_c)
+        if not isinstance(self._nullspace, NoneNullspace):
+            self._nullspace.pc_post_mult_correct(
+                self._y, self._x)
+
+        self._post_mult(y)
+
+
+class ConvergenceError(RuntimeError):
+    """An outer Krylov solver convergence error. The PETSc KSP can be accessed
+    via the `ksp` attribute.
+    """
+
+    def __init__(self, *args, ksp, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.ksp = ksp
+
+
+class System:
+    """A linear system
+
+    .. math::
+
+        A u = b.
+
+    :arg arg_spaces: Defines the space for `u`.
+    :arg action_spaces: Defines the space for `b`.
+    :arg blocks: One of
+
+        - A :class:`Matrix` or UFL :class:`Form` defining :math:`A`.
+        - A :class:`Mapping` with items `((i, j), block)` where the matrix
+          associated with the block in the `i` th and `j` th column is defined
+          by `block`. Each `block` is a :class:`Matrix` or UFL :class:`Form`,
+          or `None` to indicate a zero block.
+
+    :arg nullspaces: A :class:`Nullspace` or a :class:`Sequence` of
+        :class:`Nullspace` objects defining the nullspace and left nullspace of
+        :math:`A`. `None` indicates a :class:`NoneNullspace`.
+    :arg comm: MPI communicator.
+    """
+
+    def __init__(self, arg_spaces, action_spaces, blocks, *,
+                 nullspaces=None, comm=None):
+        if isinstance(arg_spaces, MixedSpace):
+            arg_space = arg_spaces
+        else:
+            arg_space = BackendMixedSpace(arg_spaces)
+        arg_spaces = arg_space.split_space()
+        if isinstance(action_spaces, MixedSpace):
+            action_space = action_spaces
+        else:
+            action_space = BackendMixedSpace(action_spaces)
+        action_spaces = action_space.split_space()
+
+        matrix = BlockMatrix(arg_spaces, action_spaces, blocks)
+
+        nullspace = BlockNullspace(nullspaces)
+        if isinstance(nullspace, BlockNullspace):
+            if len(nullspace) != len(arg_spaces):
+                raise ValueError("Invalid space")
+            if len(nullspace) != len(action_spaces):
+                raise ValueError("Invalid space")
+
+        if comm is None:
+            self._comm = mesh_comm(arg_space.mesh())
+        else:
+            self._comm = comm
+        self._arg_space = arg_space
+        self._action_space = action_space
+        self._matrix = matrix
+        self._nullspace = nullspace
+
+    def solve(self, u, b, *,
+              solver_parameters=None, pc_fn=None, configure=None,
+              correct_initial_guess=True, correct_solution=True):
+        """Solve the linear system.
+
+        :arg u: Defines the solution :math:`u`.
+        :arg b: Defines the right-hand-side :math:`b`.
+        :arg solver_parameters: A :class:`Mapping` defining outer Krylov solver
+            parameters. Parameters (a number of which are based on FEniCS
+            solver parameters) are:
+
+            - `'linear_solver'`: The Krylov solver type, default `'fgmres'`.
+            - `'pc_side'`: Overrides the PETSc default preconditioning side.
+            - `'relative_tolerance'`: Relative tolerance. Required.
+            - `'absolute_tolerance'`: Absolute tolerance. Required.
+            - `'divergence_limit'`: Overrides the default divergence limit.
+            - `'maximum_iterations'`: Maximum number of iterations. Default
+              1000.
+            - `'norm_type'`: Overrides the default convergence norm definition.
+            - `'nonzero_initial_guess'`: Whether to use a non-zero initial
+              guess, defined by the input `u`. Default `True`.
+            - `'gmres_restart'`: Overrides the default GMRES restart parameter.
+
+        :arg pc_fn: Defines the application of a preconditioner. A callable
+
+            .. code-block:: python
+
+                def pc_fn(u, b):
+
+            The preconditioner is applied to `b`, and the result stored in `u`.
+            Defaults to an identity.
+        :arg configure: A callable accepting the PETSc :class:`KSP`.
+
+            .. code-block:: python
+
+                def configure(ksp):
+
+            Called after all other configuration of the :class:`KSP`, but
+            before :meth:`KSP.setUp`.
+        :arg correct_initial_guess: Whether to apply a nullspace correction to
+            the initial guess.
+        :arg correct_solution: Whether to apply a nullspace correction to
+            the solution.
+        :returns: The PETSc :class:`KSP`.
+        """
+
+        if solver_parameters is None:
+            solver_parameters = {}
+
+        if isinstance(u, Sequence):
+            u = tuple(u)
+        else:
+            u = (u,)
+
+            if pc_fn is not None:
+                pc_fn_u = pc_fn
+
+                @wraps(pc_fn_u)
+                def pc_fn(u, b):
+                    u, = tuple(iter_sub(u))
+                    return pc_fn_u(u, b)
+        u = tuple_sub(u, self._arg_space.split_space())
+
+        if isinstance(b, Sequence):
+            b = tuple(b)
+        else:
+            b = (b,)
+
+            if pc_fn is not None:
+                pc_fn_b = pc_fn
+
+                @wraps(pc_fn_b)
+                def pc_fn(u, b):
+                    b, = tuple(iter_sub(b))
+                    return pc_fn_b(u, b)
+        b = tuple_sub(b, self._action_space.split_space())
+
+        if tuple(u_i.function_space() for u_i in iter_sub(u)) \
+                != self._arg_space.flattened_space():
+            raise ValueError("Invalid space")
+        for b_i, space in zip_sub(b, self._action_space.split_space()):
+            if b_i is not None and b_i.function_space() != space:
+                raise ValueError("Invalid space")
+
+        b_c = self._action_space.new_split()
+        for b_c_i, b_i in zip_sub(b_c, b):
+            if b_i is not None:
+                b_c_i.assign(b_i)
+
+        A = SystemMatrix(self._arg_space, self._action_space,
+                         self._matrix, self._nullspace)
+
+        mat_A = PETSc.Mat().createPython(
+            (self._action_space.sizes(), self._arg_space.sizes()), A,
+            comm=self._comm)
+        mat_A.setUp()
+
+        if pc_fn is not None:
+            A_pc = Preconditioner(self._action_space, self._arg_space,
+                                  pc_fn, self._nullspace)
+            pc = PETSc.PC().createPython(
+                A_pc, comm=self._comm)
+            pc.setOperators(mat_A)
+            pc.setUp()
+
+        ksp_solver = PETSc.KSP().create(comm=self._comm)
+        weakref.finalize(ksp_solver, lambda comm: None,
+                         self._comm)  # Hold a reference to the communicator
+        ksp_solver.setType(solver_parameters.get("linear_solver", "fgmres"))
+        if pc_fn is not None:
+            ksp_solver.setPC(pc)
+        if "pc_side" in solver_parameters:
+            ksp_solver.setPCSide(solver_parameters["pc_side"])
+        ksp_solver.setOperators(mat_A)
+        ksp_solver.setTolerances(
+            rtol=solver_parameters["relative_tolerance"],
+            atol=solver_parameters["absolute_tolerance"],
+            divtol=solver_parameters.get("divergence_limit", None),
+            max_it=solver_parameters.get("maximum_iterations", 1000))
+        ksp_solver.setInitialGuessNonzero(
+            solver_parameters.get("nonzero_initial_guess", True))
+        ksp_solver.setNormType(
+            solver_parameters.get(
+                "norm_type", PETSc.KSP.NormType.DEFAULT))
+        if "gmres_restart" in solver_parameters:
+            ksp_solver.setGMRESRestart(solver_parameters["gmres_restart"])
+
+        logger = logging.getLogger("tlm_adjoint.System")
+
+        def monitor(ksp_solver, it, r_norm):
+            logger.debug(f"KSP: "
+                         f"iteration {it:d}, "
+                         f"residual norm {r_norm:.16e}")
+
+        ksp_solver.setMonitor(monitor)
+
+        if configure is not None:
+            configure(ksp_solver)
+        ksp_solver.setUp()
+
+        if correct_initial_guess:
+            self._nullspace.correct_soln(u)
+        self._nullspace.correct_rhs(b_c)
+
+        if len(self._arg_space.flattened_space()) == 1:
+            u_fn, = tuple(iter_sub(u))
+        else:
+            u_fn = self._arg_space.new_mixed()
+            self._arg_space.split_to_mixed(u_fn, u)
+        if len(self._action_space.flattened_space()) == 1:
+            b_fn, = tuple(iter_sub(b_c))
+        else:
+            b_fn = self._action_space.new_mixed()
+            self._action_space.split_to_mixed(b_fn, b_c)
+        del b_c
+
+        assert not _error_flag
+        with vec(u_fn) as u_v, vec(b_fn) as b_v:
+            ksp_solver.solve(b_v, u_v)
+        del b_fn
+
+        if len(self._arg_space.flattened_space()) != 1:
+            self._arg_space.mixed_to_split(u, u_fn)
+        del u_fn
+
+        if correct_solution:
+            # Not needed if the linear problem were to be solved exactly
+            self._nullspace.correct_soln(u)
+
+        if ksp_solver.getConvergedReason() <= 0:
+            raise ConvergenceError("Solver failed to converge",
+                                   ksp=ksp_solver)
+        if _error_flag:
+            raise ConvergenceError("Error encountered in PETSc solve",
+                                   ksp=ksp_solver)
+
+        return ksp_solver

--- a/tlm_adjoint/_code_generator/hessian_system.py
+++ b/tlm_adjoint/_code_generator/hessian_system.py
@@ -1,0 +1,444 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from ..interface import (
+    check_space_types, check_space_types_conjugate, comm_dup, function_assign,
+    function_axpy, function_copy, function_dtype, function_get_values,
+    function_inner, function_new_conjugate, function_set_values,
+    function_space, function_space_type, is_function, space_comm, space_dtype)
+
+from ..eigendecomposition import eigendecompose
+
+from .block_system import (
+    BackendMixedSpace, BlockNullspace, Matrix, NoneNullspace, Preconditioner,
+    System, iter_sub, tuple_sub)
+from .functions import Function
+
+from collections.abc import Sequence
+import numpy as np
+import petsc4py.PETSc as PETSc
+import warnings
+
+__all__ = \
+    [
+        "HessianSystem",
+        "hessian_eigendecompose",
+        "B_inv_orthonormality_test",
+        "hessian_eigendecomposition_pc",
+    ]
+
+
+class MixedSpace(BackendMixedSpace):
+    def __init__(self, spaces, space_types=None):
+        if isinstance(spaces, Sequence):
+            spaces = tuple(spaces)
+        else:
+            spaces = (spaces,)
+        spaces = tuple_sub(spaces, spaces)
+
+        if space_types is None:
+            space_types = "primal"
+        if space_types in {"primal", "conjugate", "dual", "conjugate_dual"}:
+            space_types = tuple(space_types for _ in iter_sub(spaces))
+        else:
+            space_types = tuple(iter_sub(space_types))
+
+        super().__init__(spaces)
+        if len(space_types) != len(self.flattened_space()):
+            raise ValueError("Invalid space types")
+        self._space_types = space_types
+
+    def new_split(self, *args, **kwargs):
+        flattened_space = self.flattened_space()
+        assert len(flattened_space) == len(self._space_types)
+        return tuple_sub((Function(space, *args, space_type=space_type, **kwargs)  # noqa: E501
+                          for space, space_type in zip(flattened_space, self._space_types)),  # noqa: E501
+                         self.split_space())
+
+    def new_mixed(self, *args, **kwargs):
+        space_type = self._space_types[0]
+        return Function(self.mixed_space(), space_type=space_type,
+                        *args, **kwargs)
+
+
+# Complex note: It is convenient to define a Hessian matrix action in terms of
+# the *conjugate* of the action, i.e. (H \zeta)^{*,T}, e.g. this is the form
+# returned by reverse-over-forward AD. However complex conjugation is then
+# needed in a number of places (e.g. one cannot define an eigenproblem directly
+# in terms of the conjugate of an action, as this is antilinear, rather than
+# linear). The following functions are used to apply complex conjugation where
+# needed. In the real case these are used to avoid space type warnings.
+
+
+def function_copy_conjugate(x):
+    y = function_new_conjugate(x)
+    function_set_values(y, function_get_values(x).conjugate())
+    return y
+
+
+def function_assign_conjugate(x, y):
+    check_space_types_conjugate(x, y)
+    function_set_values(x, function_get_values(y).conjugate())
+
+
+def function_axpy_conjugate(y, alpha, x, /):
+    check_space_types_conjugate(y, x)
+    function_set_values(
+        y, function_get_values(y) + alpha * function_get_values(x).conjugate())
+
+
+class HessianMatrix(Matrix):
+    def __init__(self, H, M):
+        if is_function(M):
+            M = (M,)
+        else:
+            M = tuple(M)
+        space = tuple(map(function_space, M))
+
+        super().__init__(space, space)
+        self._H = H
+        self._M = M
+
+    def mult_add(self, x, y):
+        if is_function(x):
+            x = (x,)
+        if is_function(y):
+            y = (y,)
+
+        if len(x) != len(self._M):
+            raise ValueError("Invalid Hessian argument")
+        for x_i, m in zip(x, self._M):
+            check_space_types(x_i, m)
+
+        _, _, ddJ = self._H.action(self._M, x)
+
+        if len(y) != len(ddJ):
+            raise ValueError("Invalid Hessian action")
+        for y_i, ddJ_i in zip(y, ddJ):
+            function_axpy_conjugate(y_i, 1.0, ddJ_i)
+
+
+class HessianSystem(System):
+    """Defines a linear system involving a Hessian matrix,
+
+    .. math::
+
+        H u = b.
+
+    :arg H: A :class:`tlm_adjoint.hessian.Hessian` defining :math:`H`.
+    :arg M: A function or a :class:`Sequence` of functions defining the
+        control.
+    :arg nullspace: A
+        :class:`tlm_adjoint._code_generator.block_system.Nullspace` or a
+        :class:`Sequence` of
+        :class:`tlm_adjoint._code_generator.block_system.Nullspace` objects
+        defining the nullspace and left nullspace of the Hessian matrix. `None`
+        indicates a
+        :class:`tlm_adjoint._code_generator.block_system.NoneNullspace`.
+    :arg comm: MPI communicator.
+    """
+
+    def __init__(self, H, M, *,
+                 nullspace=None, comm=None):
+        if is_function(M):
+            M = (M,)
+
+        arg_spaces = MixedSpace(
+            (tuple(map(function_space, M)),),
+            space_types=tuple(map(function_space_type, M)))
+        action_spaces = MixedSpace(
+            (tuple(map(function_space, M)),),
+            space_types=tuple(function_space_type(m, rel_space_type="dual")
+                              for m in M))
+
+        matrix = HessianMatrix(H, M)
+
+        if comm is None:
+            comm = space_comm(arg_spaces.mixed_space())
+        comm = comm_dup(comm)
+
+        super().__init__(
+            arg_spaces, action_spaces, matrix,
+            nullspaces=BlockNullspace(nullspace), comm=comm)
+
+    def solve(self, u, b, **kwargs):
+        """Solve a linear system involving a Hessian matrix,
+
+        .. math::
+
+            H u = b.
+
+        :arg u: A function or a :class:`Sequence` of functions defining the
+            solution :math:`u`.
+        :arg b: A function or a :class:`Sequence` of functions defining the
+            conjugate of the right-hand-side :math:`b`.
+
+        Remaining arguments are handed to the base class :meth:`solve` method.
+        """
+
+        if is_function(b):
+            b = function_copy_conjugate(b)
+        else:
+            b = tuple_sub(map(function_copy_conjugate, iter_sub(b)), b)
+        return super().solve(u, b, **kwargs)
+
+
+def hessian_eigendecompose(
+        H, m, B_inv_action, B_action, *,
+        nullspace=None, problem_type=None, configure=None,
+        correct_eigenvectors=True, **kwargs):
+    r"""Interface with SLEPc via slepc4py, for the matrix free solution of
+    generalized eigenproblems
+
+    .. math::
+
+        H v = \lambda B^{-1} v,
+
+    where :math:`H` is a Hessian matrix.
+
+    Despite the notation :math:`B^{-1}` may be singular, defining an inverse
+    operator only on an appropriate subspace.
+
+    :arg H: A :class:`tlm_adjoint.hessian.Hessian`.
+    :arg m: A backend :class:`Function` defining the control.
+    :arg B_inv_action: A callable accepting a backend :class:`Function`
+        defining `v` and computing the conjugate of the action of
+        :math:`B^{-1}` on :math:`v`, returning the result as a backend
+        :class:`Function`.
+    :arg B_action: A callable accepting a backend :class:`Function` defining
+        :math:`v` and computing the action of :math:`B` on the conjugate of
+        :math:`v`, returning the result as a backend :class:`Function`.
+    :arg nullspace: A
+        :class:`tlm_adjoint._code_generator.block_system.Nullspace` defining
+        the nullspace and left nullspace of :math:`H` and :math:`B^{-1}`.
+    :arg problem_type: The eigenproblem type -- see
+        :class:`slepc4py.SLEPc.EPS.ProblemType`. Defaults to
+        `slepc4py.SLEPc.EPS.ProblemType.GHEP` in the real case and
+        `slepc4py.SLEPc.EPS.ProblemType.GNHEP` in the complex case.
+    :arg configure: A callable accepting a single :class:`slepc4py.SLEPc.EPS`
+        argument. Used for detailed manual configuration. Called after all
+        other configuration options are set, but before the :meth:`EPS.setUp`
+        method is called.
+    :arg correct_eigenvectors: Whether to apply a nullspace correction to the
+        eigenvectors.
+
+    Remaining keyword arguments are passed to
+    :func:`tlm_adjoint.eigendecomposition.eigendecompose`.
+    """
+
+    space = function_space(m)
+
+    arg_space_type = function_space_type(m)
+    arg_space = MixedSpace(space, space_types=arg_space_type)
+    assert arg_space.split_space() == (space,)
+    assert arg_space.flattened_space() == (space,)
+    assert arg_space.mixed_space() == space
+
+    action_space_type = function_space_type(m, rel_space_type="dual")
+    action_space = MixedSpace(space, space_types=action_space_type)
+    assert action_space.split_space() == (space,)
+    assert action_space.flattened_space() == (space,)
+    assert action_space.mixed_space() == space
+
+    if nullspace is None:
+        nullspace = NoneNullspace()
+
+    def H_action(x):
+        x = function_copy(x)
+        nullspace.pre_mult_correct_lhs(x)
+        _, _, y = H.action(m, x)
+        y = function_copy_conjugate(y)
+        nullspace.post_mult_correct_lhs(None, y)
+        return y
+
+    B_inv_action_arg = B_inv_action
+
+    def B_inv_action(x):
+        x = function_copy(x)
+        nullspace.pre_mult_correct_lhs(x)
+        y = B_inv_action_arg(function_copy(x))
+        y = function_copy_conjugate(y)
+        nullspace.post_mult_correct_lhs(x, y)
+        return y
+
+    B_action_arg = B_action
+
+    def B_action(x, y):
+        x, = x
+        y, = tuple(map(function_copy_conjugate, y))
+        # Nullspace corrections applied by the Preconditioner class
+        function_assign(x, B_action_arg(y))
+
+    configure_arg = configure
+
+    def configure(eps):
+        _, B_inv = eps.getOperators()
+        ksp_solver = eps.getST().getKSP()
+
+        B_pc = Preconditioner(
+            action_space, arg_space,
+            B_action, BlockNullspace(nullspace))
+        pc = PETSc.PC().createPython(
+            B_pc, comm=ksp_solver.comm)
+        pc.setOperators(B_inv)
+        pc.setUp()
+
+        ksp_solver.setType(PETSc.KSP.Type.PREONLY)
+        ksp_solver.setTolerances(rtol=0.0, atol=0.0, divtol=None, max_it=1)
+        ksp_solver.setPC(pc)
+        ksp_solver.setUp()
+
+        if hasattr(eps, "setPurify"):
+            eps.setPurify(False)
+        else:
+            warnings.warn("slepc4py.SLEPc.EPS.setPurify not available",
+                          RuntimeWarning)
+
+        if configure_arg is not None:
+            configure_arg(eps)
+
+    if problem_type is None:
+        import slepc4py.SLEPc as SLEPc
+        if issubclass(space_dtype(space), (float, np.floating)):
+            problem_type = SLEPc.EPS.ProblemType.GHEP
+        else:
+            problem_type = SLEPc.EPS.ProblemType.GNHEP
+
+    Lam, V = eigendecompose(
+        space, H_action, B_action=B_inv_action, space_type=arg_space_type,
+        action_type=action_space_type, problem_type=problem_type,
+        configure=configure, **kwargs)
+
+    if correct_eigenvectors:
+        if len(V) > 0 and isinstance(V[0], Sequence):
+            assert len(V[0]) == len(V[1])
+            for V_r, V_i in zip(*V):
+                nullspace.correct_soln(V_r)
+                nullspace.correct_soln(V_i)
+        else:
+            for V_r in V:
+                nullspace.correct_soln(V_r)
+
+    return Lam, V
+
+
+def B_inv_orthonormality_test(V, B_inv_action):
+    """Check for :math:`B^{-1}`-orthonormality.
+
+    Requires real spaces.
+
+    :arg B_inv_action: A callable accepting a backend :class:`Function`
+        defining `v` and computing the action of :math:`B^{-1}` on :math:`v`,
+        returning the result as a backend :class:`Function`.
+    :arg V: A :class:`Sequence` of functions to test for
+        :math:`B^{-1}`-orthonormality.
+    :returns: A :class:`tuple` `(max_diagonal_error_norm,
+        max_off_diagonal_error_norm)` with
+
+            - `max_diagonal_error_norm`: The maximum :math:`B^{-1}`
+              normalization error magnitude.
+            - `max_diagonal_error_norm`: The maximum :math:`B^{-1}`
+              orthogonality error magnitude.
+    """
+
+    if len(V) > 0 and isinstance(V[0], Sequence):
+        raise ValueError("Cannot supply separate real/complex eigenvector "
+                         "components")
+
+    B_inv_V = []
+    for v in V:
+        if not issubclass(function_dtype(v), (float, np.floating)):
+            raise ValueError("Real dtype required")
+        B_inv_V.append(B_inv_action(function_copy(v)))
+        if not issubclass(function_dtype(B_inv_V[-1]), (float, np.floating)):
+            raise ValueError("Real dtype required")
+
+    max_diagonal_error_norm = 0.0
+    max_off_diagonal_error_norm = 0.0
+    assert len(V) == len(B_inv_V)
+    for i, v in enumerate(V):
+        for j, B_inv_v in enumerate(B_inv_V):
+            if i == j:
+                max_diagonal_error_norm = max(
+                    max_diagonal_error_norm,
+                    abs(function_inner(v, B_inv_v) - 1.0))
+            else:
+                max_off_diagonal_error_norm = max(
+                    max_off_diagonal_error_norm,
+                    abs(function_inner(v, B_inv_v)))
+
+    return max_diagonal_error_norm, max_off_diagonal_error_norm
+
+
+def hessian_eigendecomposition_pc(B_action, Lam, V):
+    r"""Construct a Hessian matrix preconditioner using a partial spectrum
+    generalized eigendecomposition. Assumes that the Hessian matrix consists of
+    two terms
+
+    .. math::
+
+        H = R^{-1} + B^{-1},
+
+    where :math:`R` and :math:`B` are symmetric.
+
+    Assumes real spaces. Despite the notation :math:`R^{-1}` and :math:`B^{-1}`
+    (and later :math:`H^{-1}`) may be singular, defining inverse operators only
+    on an appropriate subspace. :math:`B` is assumed to define a symmetric
+    positive definite operator on that subspace.
+
+    The approximation is defined via
+
+    .. math::
+
+        H^{-1} \approx B + V \Lambda \left( I + \lambda \right)^{-1} V^T
+
+    where
+
+    .. math::
+
+        R^{-1} V = B^{-1} V \Lambda,
+
+    and where :math:`\Lambda` is a diagonal matrix and :math:`V` has
+    :math:`B^{-1}`-orthonormal columns, :math:`V^T B^{-1} V = I`.
+
+    This low rank update approximation for the Hessian matrix inverse is
+    described in
+
+        - Tobin Isaac, Noemi Petra, Georg Stadler, and Omar Ghattas, 'Scalable
+          and efficient algorithms for the propagation of uncertainty from data
+          through inference to prediction for large-scale problems, with
+          application to flow of the Antarctic ice sheet', Journal of
+          Computational Physics, 296, pp. 348--368, 2015, doi:
+          10.1016/j.jcp.2015.04.047
+
+    See in particular their equation (20).
+
+    :arg B_action: A callable accepting a backend :class:`Function` defining
+        :math:`v` and computing the action of :math:`B` on :math:`v`, returning
+        the result as a backend :class:`Function`.
+    :arg Lam: A :class:`Sequence` defining the diagonal of :math:`\Lambda`.
+    :arg V: A :class:`Sequence` of backend :class:`Function` objects defining
+        the columns of :math:`V`.
+    :returns: A callable suitable for use as the `pc_fn` argument to
+        :meth:`HessianSystem.solve`.
+    """
+
+    if len(V) > 0 and isinstance(V[0], Sequence):
+        raise ValueError("Cannot supply separate real/complex eigenvector "
+                         "components")
+
+    Lam = tuple(Lam)
+    V = tuple(V)
+    if len(Lam) != len(V):
+        raise ValueError("Invalid eigenpairs")
+
+    def pc_fn(u, b):
+        b = function_copy_conjugate(b)
+        function_assign(u, B_action(function_copy(b)))
+
+        assert len(Lam) == len(V)
+        for lam, v in zip(Lam, V):
+            alpha = -(lam / (1.0 + lam)) * function_inner(b, v)
+            function_axpy(u, alpha, v)
+
+    return pc_fn

--- a/tlm_adjoint/_code_generator/hessian_system.py
+++ b/tlm_adjoint/_code_generator/hessian_system.py
@@ -305,8 +305,8 @@ def hessian_eigendecompose(
             problem_type = SLEPc.EPS.ProblemType.GNHEP
 
     Lam, V = eigendecompose(
-        space, H_action, B_action=B_inv_action, space_type=arg_space_type,
-        action_type=action_space_type, problem_type=problem_type,
+        space, H_action, B_action=B_inv_action, arg_space_type=arg_space_type,
+        action_space_type=action_space_type, problem_type=problem_type,
         configure=configure, **kwargs)
 
     if correct_eigenvectors:

--- a/tlm_adjoint/alias.py
+++ b/tlm_adjoint/alias.py
@@ -16,10 +16,9 @@ __all__ = \
 def gc_disabled(fn):
     """Decorator to disable the Python garbage collector.
 
-    :arg fn: :class:`Callable` for which the Python garbage collector should be
+    :arg fn: A callable for which the Python garbage collector should be
         disabled.
-    :returns: A :class:`Callable` for which the Python garbage collector is
-        disabled.
+    :returns: A callable for which the Python garbage collector is disabled.
     """
 
     @functools.wraps(fn)

--- a/tlm_adjoint/cached_hessian.py
+++ b/tlm_adjoint/cached_hessian.py
@@ -142,11 +142,11 @@ class HessianOptimization:
 
 
 class CachedHessian(Hessian, HessianOptimization):
-    """Represents a Hessian associated with a given forward model. Uses a
-    cached forward calculation.
+    """Represents a Hessian matrix associated with a given forward model. Uses
+    a cached forward calculation.
 
     :arg J: A function or :class:`tlm_adjoint.functional.Functional` defining
-        the Hessian.
+        the Hessian matrix.
     :arg manager: The :class:`tlm_adjoint.tlm_adjoint.EquationManager` used to
         record the forward. This must have used `'memory'` checkpointing with
         automatic dropping of function references disabled. `manager()` is used
@@ -221,8 +221,8 @@ class SingleBlockHessian(CachedHessian):
 
 
 class CachedGaussNewton(GaussNewton, HessianOptimization):
-    """Represents a Gauss-Newton approximation to a Hessian associated with a
-    given forward model. Uses a cached forward calculation.
+    """Represents a Gauss-Newton approximation to a Hessian matrix associated
+    with a given forward model. Uses a cached forward calculation.
 
     :arg X: A function or a :class:`Sequence` of functions defining the state.
     :arg R_inv_action: See :class:`tlm_adjoint.hessian.GaussNewton`.

--- a/tlm_adjoint/caches.py
+++ b/tlm_adjoint/caches.py
@@ -66,9 +66,8 @@ def local_caches(fn):
     """Decorator clearing caches before and after calling the decorated
     callable.
 
-    :arg fn: :class:`Callable` for which caches should be cleared.
-    :returns: A :class:`Callable` where caches are cleared before and after
-        calling.
+    :arg fn: A callable for which caches should be cleared.
+    :returns: A callable where caches are cleared before and after calling.
     """
 
     @functools.wraps(fn)
@@ -190,8 +189,8 @@ class Cache:
         """Add a cache entry.
 
         :arg key: The key associated with the cache entry.
-        :arg value: A :class:`Callable`, taking no arguments, returning the
-            value associated with the cache entry. Only called to if no entry
+        :arg value: A callable, taking no arguments, returning the value
+            associated with the cache entry. Only called to if no entry
             associated with `key` exists.
         :arg deps: A :class:`Sequence` of functions, defining dependencies of
             the cache entry.

--- a/tlm_adjoint/eigendecomposition.py
+++ b/tlm_adjoint/eigendecomposition.py
@@ -135,12 +135,12 @@ def eigendecompose(space, A_action, *, B_action=None, arg_space_type="primal",
         OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
     :arg space: The space for each eigenvector.
-    :arg A_action: A :class:`Callable`. Accepts a single function argument, and
-        returns a function containing the result after left multiplication of
-        the input by :math:`A`.
-    :arg B_action: A :class:`Callable`. Accepts a single function argument, and
-        returns a function containing the result after left multiplication of
-        the input by :math:`B`.
+    :arg A_action: A callable. Accepts a single function argument, and returns
+        a function containing the result after left multiplication of the input
+        by :math:`A`.
+    :arg B_action: A callable. Accepts a single function argument, and returns
+        a function containing the result after left multiplication of the input
+        by :math:`B`.
     :arg arg_space_type: The space type of eigenvectors. `'primal'`, `'dual'`,
         `'conjugate'`, or `'conjugate_dual'`.
     :arg action_space_type: The space type of the result of multiplication by

--- a/tlm_adjoint/eigendecomposition.py
+++ b/tlm_adjoint/eigendecomposition.py
@@ -5,9 +5,10 @@
 # 3.6.0 demo demo/ex3.py. slepc4py 3.6.0 license information can be found in
 # the 'eigendecompose' docstring.
 
-from .interface import check_space_types, comm_dup, function_get_values, \
-    function_global_size, function_local_size, function_set_values, \
-    is_function, space_comm, space_new, space_type_warning
+from .interface import (
+    check_space_type, comm_dup, function_get_values, function_global_size,
+    function_local_size, function_set_values, is_function, relative_space_type,
+    space_comm, space_new)
 
 import functools
 import numpy as np
@@ -54,17 +55,17 @@ class PythonMatrix:
         y.setArray(y_a)
 
 
-def wrapped_action(space, space_type, action_type, action):
+def wrapped_action(space, arg_space_type, action_space_type, action):
     action_arg = action
 
     def action(x):
         x_a = x
-        x = space_new(space, space_type=space_type)
+        x = space_new(space, space_type=arg_space_type)
         function_set_values(x, x_a)
 
         y = action_arg(x)
         if is_function(y):
-            check_space_types(x, y, rel_space_type=action_type)
+            check_space_type(y, action_space_type)
             y_a = function_get_values(y)
         else:
             warnings.warn("Action callable should return a function",
@@ -76,10 +77,10 @@ def wrapped_action(space, space_type, action_type, action):
     return action
 
 
-def eigendecompose(space, A_action, *, B_action=None, space_type="primal",
-                   action_type="dual", N_eigenvalues=None, solver_type=None,
-                   problem_type=None, which=None, tolerance=1.0e-12,
-                   configure=None):
+def eigendecompose(space, A_action, *, B_action=None, arg_space_type="primal",
+                   action_space_type=None, N_eigenvalues=None,
+                   solver_type=None, problem_type=None, which=None,
+                   tolerance=1.0e-12, configure=None):
     # First written 2018-03-01
     r"""Interface with SLEPc via slepc4py, for the matrix free solution of
     eigenproblems
@@ -140,11 +141,12 @@ def eigendecompose(space, A_action, *, B_action=None, space_type="primal",
     :arg B_action: A :class:`Callable`. Accepts a single function argument, and
         returns a function containing the result after left multiplication of
         the input by :math:`B`.
-    :arg space_type: The space type of eigenvectors. `'primal'`, `'dual'`,
+    :arg arg_space_type: The space type of eigenvectors. `'primal'`, `'dual'`,
         `'conjugate'`, or `'conjugate_dual'`.
-    :arg action_type: The space type relative to `space_type` of the result of
-        multiplication by :math:`A` or :math:`B`. `'primal'`, `'dual'`, or
-        `'conjugate_dual'`.
+    :arg action_space_type: The space type of the result of multiplication by
+        :math:`A` or :math:`B`. `'primal'`, `'dual'`, `'conjugate'`, or
+        `'conjugate_dual'`. Defaults to the space type conjugate dual to
+        `arg_space_type`.
     :arg N_eigenvalues: An :class:`int`, the number of eigenvalues to attempt
         to compute. Defaults to the dimension of `space`.
     :arg problem_type: The eigenproblem type -- see
@@ -171,20 +173,16 @@ def eigendecompose(space, A_action, *, B_action=None, space_type="primal",
     import petsc4py.PETSc as PETSc
     import slepc4py.SLEPc as SLEPc
 
-    if space_type not in ["primal", "conjugate", "dual", "conjugate_dual"]:
+    if arg_space_type not in {"primal", "conjugate", "dual", "conjugate_dual"}:
         raise ValueError("Invalid space type")
-    if action_type not in ["primal", "dual", "conjugate_dual"]:
-        raise ValueError("Invalid action type")
+    if action_space_type is None:
+        action_space_type = relative_space_type(arg_space_type, "conjugate_dual")  # noqa: E501
+    elif action_space_type not in {"primal", "conjugate", "dual", "conjugate_dual"}:  # noqa: E501
+        raise ValueError("Invalid space type")
 
-    A_action = wrapped_action(space, space_type, action_type, A_action)
-    if B_action is None:
-        if action_type in ["dual", "conjugate_dual"]:
-            space_type_warning("B_action argument expected with action type "
-                               "'dual' or 'conjugate_dual'")
-        else:
-            assert action_type == "primal"
-    else:
-        B_action = wrapped_action(space, space_type, action_type, B_action)
+    A_action = wrapped_action(space, arg_space_type, action_space_type, A_action)  # noqa: E501
+    if B_action is not None:
+        B_action = wrapped_action(space, arg_space_type, action_space_type, B_action)  # noqa: E501
 
     if problem_type is None:
         if B_action is None:
@@ -194,7 +192,7 @@ def eigendecompose(space, A_action, *, B_action=None, space_type="primal",
     if which is None:
         which = SLEPc.EPS.Which.LARGEST_MAGNITUDE
 
-    X = space_new(space, space_type=space_type)
+    X = space_new(space, space_type=arg_space_type)
     n, N = function_local_size(X), function_global_size(X)
     del X
     N_ev = N if N_eigenvalues is None else N_eigenvalues
@@ -245,7 +243,7 @@ def eigendecompose(space, A_action, *, B_action=None, space_type="primal",
                   dtype=PETSc.RealType if esolver.isHermitian()
                   else PETSc.ComplexType)
     v_r = A_matrix.getVecRight()
-    V_r = tuple(space_new(space, space_type=space_type)
+    V_r = tuple(space_new(space, space_type=arg_space_type)
                 for n in range(N_ev))
     if issubclass(PETSc.ScalarType, (complex, np.complexfloating)):
         v_i = None
@@ -255,7 +253,7 @@ def eigendecompose(space, A_action, *, B_action=None, space_type="primal",
         if esolver.isHermitian():
             V_i = None
         else:
-            V_i = tuple(space_new(space, space_type=space_type)
+            V_i = tuple(space_new(space, space_type=arg_space_type)
                         for n in range(N_ev))
     for i in range(lam.shape[0]):
         lam_i = esolver.getEigenpair(i, v_r, v_i)

--- a/tlm_adjoint/eigendecomposition.py
+++ b/tlm_adjoint/eigendecomposition.py
@@ -81,9 +81,8 @@ def eigendecompose(space, A_action, *, B_action=None, space_type="primal",
                    problem_type=None, which=None, tolerance=1.0e-12,
                    configure=None):
     # First written 2018-03-01
-    r"""
-    Matrix-free interface with SLEPc via slepc4py, for the matrix free solution
-    of eigenproblems
+    r"""Interface with SLEPc via slepc4py, for the matrix free solution of
+    eigenproblems
 
     .. math::
 

--- a/tlm_adjoint/fenics/__init__.py
+++ b/tlm_adjoint/fenics/__init__.py
@@ -11,7 +11,8 @@ modules = [("backend", "tlm_adjoint.fenics"),
            ("equations", "tlm_adjoint._code_generator"),
            ("backend_interface", "tlm_adjoint.fenics"),
            ("backend_overrides", "tlm_adjoint.fenics"),
-           ("fenics_equations", "tlm_adjoint.fenics")]
+           ("fenics_equations", "tlm_adjoint.fenics"),
+           ("block_system", "tlm_adjoint._code_generator")]
 
 for module_name, package in modules:
     if package == "tlm_adjoint._code_generator":
@@ -36,6 +37,8 @@ from .backend import backend, backend_ScalarType  # noqa: E402,F401
 from .backend_code_generator_interface import linear_solver  # noqa: E402,F401
 from .backend_interface import *   # noqa: E402,F401
 from .backend_overrides import *   # noqa: E402,F401
+from .block_system import \
+    (ConstantNullspace, DirichletBCNullspace, NoneNullspace, UnityNullspace)  # noqa: E402,E501,F401
 from .caches import *              # noqa: E402,F401
 from .equations import *           # noqa: E402,F401
 from .fenics_equations import *    # noqa: E402,F401

--- a/tlm_adjoint/fenics/__init__.py
+++ b/tlm_adjoint/fenics/__init__.py
@@ -12,7 +12,8 @@ modules = [("backend", "tlm_adjoint.fenics"),
            ("backend_interface", "tlm_adjoint.fenics"),
            ("backend_overrides", "tlm_adjoint.fenics"),
            ("fenics_equations", "tlm_adjoint.fenics"),
-           ("block_system", "tlm_adjoint._code_generator")]
+           ("block_system", "tlm_adjoint._code_generator"),
+           ("hessian_system", "tlm_adjoint._code_generator")]
 
 for module_name, package in modules:
     if package == "tlm_adjoint._code_generator":
@@ -43,3 +44,4 @@ from .caches import *              # noqa: E402,F401
 from .equations import *           # noqa: E402,F401
 from .fenics_equations import *    # noqa: E402,F401
 from .functions import *           # noqa: E402,F401
+from .hessian_system import *      # noqa: E402,F401

--- a/tlm_adjoint/firedrake/__init__.py
+++ b/tlm_adjoint/firedrake/__init__.py
@@ -11,7 +11,8 @@ modules = [("backend", "tlm_adjoint.firedrake"),
            ("equations", "tlm_adjoint._code_generator"),
            ("backend_interface", "tlm_adjoint.firedrake"),
            ("backend_overrides", "tlm_adjoint.firedrake"),
-           ("firedrake_equations", "tlm_adjoint.firedrake")]
+           ("firedrake_equations", "tlm_adjoint.firedrake"),
+           ("block_system", "tlm_adjoint._code_generator")]
 
 for module_name, package in modules:
     if package == "tlm_adjoint._code_generator":
@@ -36,6 +37,8 @@ from .backend import backend, backend_ScalarType  # noqa: E402,F401
 from .backend_code_generator_interface import linear_solver  # noqa: E402,F401
 from .backend_interface import *    # noqa: E402,F401
 from .backend_overrides import *    # noqa: E402,F401
+from .block_system import \
+    (ConstantNullspace, DirichletBCNullspace, NoneNullspace, UnityNullspace)  # noqa: E402,E501,F401
 from .caches import *               # noqa: E402,F401
 from .equations import *            # noqa: E402,F401
 from .firedrake_equations import *  # noqa: E402,F401

--- a/tlm_adjoint/firedrake/__init__.py
+++ b/tlm_adjoint/firedrake/__init__.py
@@ -12,7 +12,8 @@ modules = [("backend", "tlm_adjoint.firedrake"),
            ("backend_interface", "tlm_adjoint.firedrake"),
            ("backend_overrides", "tlm_adjoint.firedrake"),
            ("firedrake_equations", "tlm_adjoint.firedrake"),
-           ("block_system", "tlm_adjoint._code_generator")]
+           ("block_system", "tlm_adjoint._code_generator"),
+           ("hessian_system", "tlm_adjoint._code_generator")]
 
 for module_name, package in modules:
     if package == "tlm_adjoint._code_generator":
@@ -43,3 +44,4 @@ from .caches import *               # noqa: E402,F401
 from .equations import *            # noqa: E402,F401
 from .firedrake_equations import *  # noqa: E402,F401
 from .functions import *            # noqa: E402,F401
+from .hessian_system import *       # noqa: E402,F401

--- a/tlm_adjoint/fixed_point.py
+++ b/tlm_adjoint/fixed_point.py
@@ -28,26 +28,24 @@ def l2_norm_sq(x):
 class CustomNormSq:
     r"""Defines the square of the norm of forward and adjoint solutions.
 
-    :class:`Callable` objects are used to define squared norms for the forward
-    and adjoint solutions of equations. The total squared norm is then the sum
-    of the squares.
+    Callables are used to define squared norms for the forward and adjoint
+    solutions of equations. The total squared norm is then the sum of the
+    squares.
 
     :arg eqs: A :class:`Sequence` of :class:`tlm_adjoint.equation.Equation`
         objects.
-    :arg norm_sqs: A :class:`Sequence`. Each element is either a
-        :class:`Callable`, or a :class:`Sequence` of :class:`Callable` objects.
-        The :class:`Callable` objects define the squared norm associated with
-        the corresponding components of the forward solution for the
-        corresponding :class:`tlm_adjoint.equation.Equation` in `eqs`. Each
-        :class:`Callable` accepts a single function and returns a
-        :class:`float`. Defaults to the square of the :math:`l_2` norm of the
-        degrees of freedom vector.
-    :arg adj_norm_sqs: A :class:`Sequence`. Each element is either a
-        :class:`Callable`, or a :class:`Sequence` of :class:`Callable` objects.
-        The :class:`Callable` objects define the squared norm associated with
-        the corresponding components of the adjoint solution for the
-        corresponding :class:`tlm_adjoint.equation.Equation` in `eqs`. Each
-        :class:`Callable` accepts a single function and returns a
+    :arg norm_sqs: A :class:`Sequence`. Each element is either a callable, or a
+        :class:`Sequence` of callables. The callables define the squared norm
+        associated with the corresponding components of the forward solution
+        for the corresponding :class:`tlm_adjoint.equation.Equation` in `eqs`.
+        Each callable accepts a single function and returns a :class:`float`.
+        Defaults to the square of the :math:`l_2` norm of the degrees of
+        freedom vector.
+    :arg adj_norm_sqs: A :class:`Sequence`. Each element is either a callable,
+        or a :class:`Sequence` of callables. The callables define the squared
+        norm associated with the corresponding components of the adjoint
+        solution for the corresponding :class:`tlm_adjoint.equation.Equation`
+        in `eqs`. Each callable accepts a single function and returns a
         :class:`float`. Defaults to the square of the :math:`l_2` norm of the
         degrees of freedom vector.
     """

--- a/tlm_adjoint/hessian.py
+++ b/tlm_adjoint/hessian.py
@@ -224,13 +224,13 @@ class GaussNewton(ABC):
     covariance.
 
     :arg R_inv_action: A :class:`Callable` which accepts one or more functions,
-        and returns the action of the operator corresponding to
-        :math:`R_\text{obs}^{-1}` on those functions, returning the result as a
-        function or a :class:`Sequence` of functions.
+        and returns the conjugate of the action of the operator corresponding
+        to :math:`R_\text{obs}^{-1}` on those functions, returning the
+        result as a function or a :class:`Sequence` of functions.
     :arg B_inv_action: A :class:`Callable` which accepts one or more functions,
-        and returns the action of the operator corresponding to :math:`B^{-1}`
-        on those functions, returning the result as a function or a
-        :class:`Sequence` of functions.
+        and returns the conjugate of the action of the operator corresponding
+        to :math:`B^{-1}` on those functions, returning the result as a
+        function or a :class:`Sequence` of functions.
     :arg J_space: The space for the functional. `FloatSpace(Float)` is used if
         not supplied.
     """

--- a/tlm_adjoint/hessian.py
+++ b/tlm_adjoint/hessian.py
@@ -38,8 +38,8 @@ def conjugate(X):
 
 
 class Hessian(ABC):
-    r"""Represents a Hessian associated with a given forward model. Abstract
-    base class.
+    r"""Represents a Hessian matrix associated with a given forward model.
+    Abstract base class.
     """
 
     def __init__(self):
@@ -62,9 +62,9 @@ class Hessian(ABC):
 
     @abstractmethod
     def action(self, M, dM, M0=None):
-        r"""Compute (the conjugate of) a Hessian action on some :math:`\zeta`
-        using an adjoint of a tangent-linear model. i.e. considering
-        derivatives to be column vectors, compute
+        r"""Compute (the conjugate of) a Hessian matrix action on some
+        :math:`\zeta` using an adjoint of a tangent-linear model. i.e.
+        considering derivatives to be column vectors, compute
 
         .. math::
 
@@ -74,30 +74,30 @@ class Hessian(ABC):
         :arg M: A function or a :class:`Sequence` of functions defining the
             control variable.
         :arg dM: A function or a :class:`Sequence` of functions defining
-            :math:`\zeta`. The (conjugate of the) Hessian action on
+            :math:`\zeta`. The (conjugate of the) Hessian matrix action on
             :math:`\zeta` is computed.
         :arg M0: A function or a :class:`Sequence` of functions defining the
             control value. `M` is used if not supplied.
         :returns: A tuple `(J, dJ, ddJ)`. `J` is the value of the functional.
             `dJ` is the value of :math:`\left( d \mathcal{J} / d m \right)^T
             \zeta`. `ddJ` stores the (conjugate of the) result of the Hessian
-            action on :math:`\zeta`, and is a function or a :class:`Sequence`
-            of functions depending on the type of `M`.
+            matrix action on :math:`\zeta`, and is a function or a
+            :class:`Sequence` of functions depending on the type of `M`.
         """
 
         raise NotImplementedError
 
     def action_fn(self, m, m0=None):
         """Return a :class:`Callable` which can be used to compute Hessian
-        actions.
+        matrix actions.
 
         :arg m: A function defining the control variable.
         :arg m0: A function defining the control value. `m` is used if not
             supplied.
         :returns: A :class:`Callable` which accepts a single function argument,
-            and returns the result of the Hessian action on that argument as a
-            function. Note that the result is *not* the conjugate of the
-            Hessian action on the input argument.
+            and returns the result of the Hessian matrix action on that
+            argument as a function. Note that the result is *not* the conjugate
+            of the Hessian matrix action on the input argument.
         """
 
         def action(dm):
@@ -108,8 +108,8 @@ class Hessian(ABC):
 
 
 class GeneralHessian(Hessian):
-    """Represents a Hessian associated with a given forward model. Calls to
-    :meth:`compute_gradient` or :meth:`action` re-run the forward.
+    """Represents a Hessian matrix associated with a given forward model. Calls
+    to :meth:`compute_gradient` or :meth:`action` re-run the forward.
 
     :arg forward: A :class:`Callable` which accepts one or more function
         arguments, and which returns a function or
@@ -209,10 +209,10 @@ class GeneralHessian(Hessian):
 
 
 class GaussNewton(ABC):
-    r"""Represents a Gauss-Newton approximation for a Hessian. Abstract base
-    class.
+    r"""Represents a Gauss-Newton approximation for a Hessian matrix. Abstract
+    base class.
 
-    In terms of matrices this defines a Hessian approximation
+    In terms of matrices this defines a Hessian matrix approximation
 
     .. math::
 
@@ -250,8 +250,9 @@ class GaussNewton(ABC):
 
     @restore_manager
     def action(self, M, dM, M0=None):
-        r"""Compute (the conjugate of) a Hessian action on some :math:`\zeta`,
-        using the Gauss-Newton approximation for the Hessian. i.e. compute
+        r"""Compute (the conjugate of) a Hessian matrix action on some
+        :math:`\zeta`, using the Gauss-Newton approximation for the Hessian
+        matrix. i.e. compute
 
         .. math::
 
@@ -260,13 +261,13 @@ class GaussNewton(ABC):
         :arg M: A function or a :class:`Sequence` of functions defining the
             control variable.
         :arg dM: A function or a :class:`Sequence` of functions defining
-            :math:`\zeta`. The (conjugate of the) approximated Hessian action
-            on :math:`\zeta` is computed.
+            :math:`\zeta`. The (conjugate of the) approximated Hessian matrix
+            action on :math:`\zeta` is computed.
         :arg M0: A function or a :class:`Sequence` of functions defining the
             control value. `M` is used if not supplied.
         :returns: The (conjugate of the) result of the approximated Hessian
-            action on :math:`\zeta`. A function or a :class:`Sequence` of
-            functions depending on the type of `M`.
+            matrix action on :math:`\zeta`. A function or a :class:`Sequence`
+            of functions depending on the type of `M`.
         """
 
         if not isinstance(M, Sequence):
@@ -321,15 +322,16 @@ class GaussNewton(ABC):
 
     def action_fn(self, m, m0=None):
         """Return a :class:`Callable` which can be used to compute Hessian
-        actions using the Gauss-Newton approximation.
+        matrix actions using the Gauss-Newton approximation.
 
         :arg m: A function defining the control variable.
         :arg m0: A function defining the control value. `m` is used if not
             supplied.
         :returns: A :class:`Callable` which accepts a single function argument,
-            and returns the result of the approximated Hessian action on that
-            argument as a function. Note that the result is *not* the conjugate
-            of the approximated Hessian action on the input argument.
+            and returns the result of the approximated Hessian matrix action on
+            that argument as a function. Note that the result is *not* the
+            conjugate of the approximated Hessian matrix action on the input
+            argument.
         """
 
         def action(dm):
@@ -339,8 +341,8 @@ class GaussNewton(ABC):
 
 
 class GeneralGaussNewton(GaussNewton):
-    """Represents a Gauss-Newton approximation to a Hessian associated with a
-    given forward model. Calls to :meth:`GaussNewton.action` re-run the
+    """Represents a Gauss-Newton approximation to a Hessian matrix associated
+    with a given forward model. Calls to :meth:`GaussNewton.action` re-run the
     forward.
 
     :arg forward: A :class:`Callable` which accepts one or more function

--- a/tlm_adjoint/hessian.py
+++ b/tlm_adjoint/hessian.py
@@ -88,16 +88,16 @@ class Hessian(ABC):
         raise NotImplementedError
 
     def action_fn(self, m, m0=None):
-        """Return a :class:`Callable` which can be used to compute Hessian
-        matrix actions.
+        """Return a callable which can be used to compute Hessian matrix
+        actions.
 
         :arg m: A function defining the control variable.
         :arg m0: A function defining the control value. `m` is used if not
             supplied.
-        :returns: A :class:`Callable` which accepts a single function argument,
-            and returns the result of the Hessian matrix action on that
-            argument as a function. Note that the result is *not* the conjugate
-            of the Hessian matrix action on the input argument.
+        :returns: A callable which accepts a single function argument, and
+            returns the result of the Hessian matrix action on that argument as
+            a function. Note that the result is *not* the conjugate of the
+            Hessian matrix action on the input argument.
         """
 
         def action(dm):
@@ -111,10 +111,9 @@ class GeneralHessian(Hessian):
     """Represents a Hessian matrix associated with a given forward model. Calls
     to :meth:`compute_gradient` or :meth:`action` re-run the forward.
 
-    :arg forward: A :class:`Callable` which accepts one or more function
-        arguments, and which returns a function or
-        :class:`tlm_adjoint.functional.Functional` defining the forward
-        functional.
+    :arg forward: A callable which accepts one or more function arguments, and
+        which returns a function or :class:`tlm_adjoint.functional.Functional`
+        defining the forward functional.
     :arg manager: A :class:`tlm_adjoint.tlm_adjoint.EquationManager` which
         should be used internally. `manager().new()` is used if not supplied.
     """
@@ -223,14 +222,14 @@ class GaussNewton(ABC):
     covariance and :math:`B^{-1}` corresponds to the background inverse
     covariance.
 
-    :arg R_inv_action: A :class:`Callable` which accepts one or more functions,
-        and returns the conjugate of the action of the operator corresponding
-        to :math:`R_\text{obs}^{-1}` on those functions, returning the
-        result as a function or a :class:`Sequence` of functions.
-    :arg B_inv_action: A :class:`Callable` which accepts one or more functions,
-        and returns the conjugate of the action of the operator corresponding
-        to :math:`B^{-1}` on those functions, returning the result as a
+    :arg R_inv_action: A callable which accepts one or more functions, and
+        returns the conjugate of the action of the operator corresponding to
+        :math:`R_\text{obs}^{-1}` on those functions, returning the result as a
         function or a :class:`Sequence` of functions.
+    :arg B_inv_action: A callable which accepts one or more functions, and
+        returns the conjugate of the action of the operator corresponding to
+        :math:`B^{-1}` on those functions, returning the result as a function
+        or a :class:`Sequence` of functions.
     :arg J_space: The space for the functional. `FloatSpace(Float)` is used if
         not supplied.
     """
@@ -321,14 +320,14 @@ class GaussNewton(ABC):
         return ddJ
 
     def action_fn(self, m, m0=None):
-        """Return a :class:`Callable` which can be used to compute Hessian
-        matrix actions using the Gauss-Newton approximation.
+        """Return a callable which can be used to compute Hessian matrix
+        actions using the Gauss-Newton approximation.
 
         :arg m: A function defining the control variable.
         :arg m0: A function defining the control value. `m` is used if not
             supplied.
-        :returns: A :class:`Callable` which accepts a single function argument,
-            and returns the result of the approximated Hessian matrix action on
+        :returns: A callable which accepts a single function argument, and
+            returns the result of the approximated Hessian matrix action on
             that argument as a function. Note that the result is *not* the
             conjugate of the approximated Hessian matrix action on the input
             argument.
@@ -345,9 +344,9 @@ class GeneralGaussNewton(GaussNewton):
     with a given forward model. Calls to :meth:`GaussNewton.action` re-run the
     forward.
 
-    :arg forward: A :class:`Callable` which accepts one or more function
-        arguments, and which returns a function or :class:`Sequence` of
-        functions defining the state.
+    :arg forward: A callable which accepts one or more function arguments, and
+        which returns a function or :class:`Sequence` of functions defining the
+        state.
     :arg R_inv_action: See :class:`GaussNewton`.
     :arg B_inv_action: See :class:`GaussNewton`.
     :arg J_space: The space for the functional. `FloatSpace(Float)` is used if

--- a/tlm_adjoint/interface.py
+++ b/tlm_adjoint/interface.py
@@ -246,6 +246,7 @@ def comm_dup(comm):
     def finalize_callback(dup_comm_py2f):
         if MPI is not None and not MPI.Is_finalized():
             dup_comm = f2py(dup_comm_py2f)
+            garbage_cleanup(dup_comm)
             dup_comm.Free()
         _parent_comms.pop(dup_comm_py2f, None)
 
@@ -283,6 +284,7 @@ def comm_dup_cached(comm):
 
         def finalize_callback(comm_py2f, dup_comm):
             if MPI is not None and not MPI.Is_finalized():
+                garbage_cleanup(dup_comm)
                 dup_comm.Free()
             _parent_comms.pop(dup_comm.py2f(), None)
             _dup_comms.pop(comm_py2f, None)

--- a/tlm_adjoint/interface.py
+++ b/tlm_adjoint/interface.py
@@ -7,10 +7,10 @@ This is implemented via runtime binding of mixins. The
 interact with backend variables. The :class:`SpaceInterface` adds methods to
 'spaces' which define the vector spaces in which those 'functions' are defined.
 
-The extra methods are accessed using the :class:`Callable` objects defined in
-this module (which also handle some extra details, e.g. related to cache
-invalidation and space type checking). Typically these are prefixed with
-`space_` for spaces and `function_` for functions.
+The extra methods are accessed using the callables defined in this module
+(which also handle some extra details, e.g. related to cache invalidation and
+space type checking). Typically these are prefixed with `space_` for spaces and
+`function_` for functions.
 
 The term 'function' originates from finite element discrete functions, but
 there is no assumption that these correspond to actual functions defined on any
@@ -551,9 +551,8 @@ _check_space_types = 0
 def no_space_type_checking(fn):
     """Decorator to disable space type checking.
 
-    :arg fn: :class:`Callable` for which space type checking should be
-        disabled.
-    :returns: A :class:`Callable` for which space type checking is disabled.
+    :arg fn: A callable for which space type checking should be disabled.
+    :returns: A callable for which space type checking is disabled.
     """
 
     @functools.wraps(fn)

--- a/tlm_adjoint/manager.py
+++ b/tlm_adjoint/manager.py
@@ -67,7 +67,7 @@ def set_manager(manager):
 
 def restore_manager(fn):
     """Decorator to revert the default manager to the manager used prior to
-    calling the decorated :class:`Callable`. A typical use is
+    calling the decorated callable. A typical use is
 
     .. code-block:: python
 
@@ -76,9 +76,9 @@ def restore_manager(fn):
             set_manager(manager().new())
             forward(*M)
 
-    :arg fn: A decorated :class:`Callable`.
-    :returns: A :class:`Callable`, where the default manager on entry
-        is restored on exit.
+    :arg fn: A decorated callable.
+    :returns: A callable, where the default manager on entry is restored on
+        exit.
     """
 
     @functools.wraps(fn)

--- a/tlm_adjoint/optimization.py
+++ b/tlm_adjoint/optimization.py
@@ -250,10 +250,10 @@ def wrapped_action(M, *,
 
 
 class LBFGSHessianApproximation:
-    """L-BFGS Hessian approximation.
+    """L-BFGS Hessian matrix approximation.
 
     :arg m: Maximum number of vector pairs to retain in the L-BFGS Hessian
-        approximation.
+        matrix approximation.
     """
 
     def __init__(self, m):
@@ -291,10 +291,10 @@ class LBFGSHessianApproximation:
 
     def inverse_action(self, X, *,
                        H_0_action=None, theta=1.0):
-        """Compute the action of the approximate Hessian inverse on some
+        """Compute the action of the approximate Hessian matrix inverse on some
         given direction.
 
-        Implements the L-BFGS Hessian inverse action approximation as in
+        Implements the L-BFGS Hessian matrix inverse action approximation as in
         Algorithm 7.4 of
 
             - Jorge Nocedal and Stephen J. Wright, 'Numerical optimization',
@@ -309,10 +309,10 @@ class LBFGSHessianApproximation:
               doi: 10.1137/0916069
 
         :arg X: A function or a :class:`Sequence` of functions defining the
-            direction on which to compute the approximate Hessian inverse
-            action.
+            direction on which to compute the approximate Hessian matrix
+            inverse action.
         :arg H_0_action: A :class:`Callable` defining the action of the
-            non-updated Hessian inverse approximation on some direction.
+            non-updated Hessian matrix inverse approximation on some direction.
             Accepts one or more functions as arguments, defining the direction,
             and returns a function or a :class:`Sequence` of functions defining
             the action on this direction. Should correspond to a positive
@@ -525,9 +525,9 @@ def l_bfgs(F, Fp, X0, *,
 
     in a more general inner product space.
 
-    By default uses 'theta scaling' to define the initial Hessian inverse
-    approximation, based on the approach in equation (3.7) and point 7 on p.
-    1204 of
+    By default uses 'theta scaling' to define the initial Hessian matrix
+    inverse approximation, based on the approach in equation (3.7) and point 7
+    on p. 1204 of
 
         - Richard H. Byrd, Peihuang Lu, and Jorge Nocedal, and Ciyou Zhu, 'A
           limited memory algorithm for bound constrained optimization', SIAM
@@ -541,8 +541,8 @@ def l_bfgs(F, Fp, X0, *,
           Springer, New York, NY, 2006, Second edition,
           doi: 10.1007/978-0-387-40065-5
 
-    Precisely the Hessian inverse approximation, before being updated, is
-    scaled by :math:`1 / \theta` with, on the first iteration,
+    Precisely the Hessian matrix inverse approximation, before being updated,
+    is scaled by :math:`1 / \theta` with, on the first iteration,
 
     .. math::
 
@@ -568,7 +568,7 @@ def l_bfgs(F, Fp, X0, *,
     :arg X0: A function or a :class:`Sequence` of functions defining the
         initial guess for the parameters.
     :arg m: The maximum number of step + gradient change pairs to use in the
-        Hessian inverse approximation.
+        Hessian matrix inverse approximation.
     :arg s_atol: Absolute tolerance for the step change norm convergence
         criterion.
     :arg g_atol: Absolute tolerance for the gradient norm convergence
@@ -598,10 +598,10 @@ def l_bfgs(F, Fp, X0, *,
         converged.
     :arg max_its: The maximum number of iterations.
     :arg H_0_action: A :class:`Callable` defining the action of the non-updated
-        Hessian inverse approximation on some direction. Accepts one or more
-        functions as arguments, defining the direction, and returns a function
-        or a :class:`Sequence` of functions defining the action on this
-        direction. Should correspond to a positive definite operator. An
+        Hessian matrix inverse approximation on some direction. Accepts one or
+        more functions as arguments, defining the direction, and returns a
+        function or a :class:`Sequence` of functions defining the action on
+        this direction. Should correspond to a positive definite operator. An
         identity is used if not supplied.
     :arg theta_scale: Whether to apply 'theta scaling', discussed above.
     :arg delta: Controls the initial value of :math:`\theta` in 'theta

--- a/tlm_adjoint/optimization.py
+++ b/tlm_adjoint/optimization.py
@@ -45,10 +45,9 @@ def minimize_scipy(forward, M0, *,
     **Important note:** No exception is raised if `return_value.success` is
     `False`. Calling code should check this attribute.
 
-    :arg forward: A :class:`Callable` which accepts one or more function
-        arguments, and which returns a function or
-        :class:`tlm_adjoint.functional.Functional` defining the forward
-        functional.
+    :arg forward: A callable which accepts one or more function arguments, and
+        which returns a function or :class:`tlm_adjoint.functional.Functional`
+        defining the forward functional.
     :arg M0: A function or :class:`Sequence` of functions defining the control
         variable, and the initial guess for the optimization.
     :arg manager: A :class:`tlm_adjoint.tlm_adjoint.EquationManager` which
@@ -311,12 +310,12 @@ class LBFGSHessianApproximation:
         :arg X: A function or a :class:`Sequence` of functions defining the
             direction on which to compute the approximate Hessian matrix
             inverse action.
-        :arg H_0_action: A :class:`Callable` defining the action of the
-            non-updated Hessian matrix inverse approximation on some direction.
-            Accepts one or more functions as arguments, defining the direction,
-            and returns a function or a :class:`Sequence` of functions defining
-            the action on this direction. Should correspond to a positive
-            definite operator. An identity is used if not supplied.
+        :arg H_0_action: A callable defining the action of the non-updated
+            Hessian matrix inverse approximation on some direction. Accepts one
+            or more functions as arguments, defining the direction, and returns
+            a function or a :class:`Sequence` of functions defining the action
+            on this direction. Should correspond to a positive definite
+            operator. An identity is used if not supplied.
         :returns: A function or a :class:`Sequence` of functions storing the
             result.
         """
@@ -558,13 +557,13 @@ def l_bfgs(F, Fp, X0, *,
     gradient, gradient change, and step, and where :math:`M^{-1}` and
     :math:`H_0` are defined by `M_inv_action` and `H_0_action` respectively.
 
-    :arg F: A :class:`Callable` defining the functional. Accepts one or more
-        functions as arguments, and returns the value of the functional.
-        Input arguments should not be modified.
-    :arg Fp: A :class:`Callable` defining the functional gradient. Accepts one
-        or more functions as inputs, and returns a function or
-        :class:`Sequence` of functions storing the value of the gradient.
-        Input arguments should not be modified.
+    :arg F: A callable defining the functional. Accepts one or more functions
+        as arguments, and returns the value of the functional. Input arguments
+        should not be modified.
+    :arg Fp: A callable defining the functional gradient. Accepts one or more
+        functions as inputs, and returns a function or :class:`Sequence` of
+        functions storing the value of the gradient. Input arguments should not
+        be modified.
     :arg X0: A function or a :class:`Sequence` of functions defining the
         initial guess for the parameters.
     :arg m: The maximum number of step + gradient change pairs to use in the
@@ -573,8 +572,8 @@ def l_bfgs(F, Fp, X0, *,
         criterion.
     :arg g_atol: Absolute tolerance for the gradient norm convergence
         criterion.
-    :arg converged: A :class:`Callable` defining a callback, and which can be
-        used to define custom convergence criteria. Takes the form
+    :arg converged: A callable defining a callback, and which can be used to
+        define custom convergence criteria. Takes the form
 
         .. code-block:: python
 
@@ -597,17 +596,17 @@ def l_bfgs(F, Fp, X0, *,
         Returns a :class:`bool` indicating whether the optimization has
         converged.
     :arg max_its: The maximum number of iterations.
-    :arg H_0_action: A :class:`Callable` defining the action of the non-updated
-        Hessian matrix inverse approximation on some direction. Accepts one or
-        more functions as arguments, defining the direction, and returns a
-        function or a :class:`Sequence` of functions defining the action on
-        this direction. Should correspond to a positive definite operator. An
+    :arg H_0_action: A callable defining the action of the non-updated Hessian
+        matrix inverse approximation on some direction. Accepts one or more
+        functions as arguments, defining the direction, and returns a function
+        or a :class:`Sequence` of functions defining the action on this
+        direction. Should correspond to a positive definite operator. An
         identity is used if not supplied.
     :arg theta_scale: Whether to apply 'theta scaling', discussed above.
     :arg delta: Controls the initial value of :math:`\theta` in 'theta
         scaling'. If `None` then on the first iteration :math:`\theta` is set
         equal to one.
-    :arg M_action: A :class:`Callable` defining a primal space inner product,
+    :arg M_action: A callable defining a primal space inner product,
 
         .. math::
 
@@ -620,8 +619,8 @@ def l_bfgs(F, Fp, X0, *,
         defining the action of :math:`M` on this direction. An identity is used
         if not supplied. Required if `H_0_action` or `M_inv_action` are
         supplied.
-    :arg M_inv_action: A :class:`Callable` defining a (conjugate) dual space
-        inner product,
+    :arg M_inv_action: A callable defining a (conjugate) dual space inner
+        product,
 
         .. math::
 
@@ -829,10 +828,9 @@ def minimize_l_bfgs(forward, M0, *,
                     m=30, manager=None, **kwargs):
     """Functional minimization using the L-BFGS algorithm.
 
-    :arg forward: A :class:`Callable` which accepts one or more function
-        arguments, and which returns a function or
-        :class:`tlm_adjoint.functional.Functional` defining the forward
-        functional.
+    :arg forward: A callable which accepts one or more function arguments, and
+        which returns a function or :class:`tlm_adjoint.functional.Functional`
+        defining the forward functional.
     :arg M0: A function or :class:`Sequence` of functions defining the control
         variable, and the initial guess for the optimization.
     :arg manager: A :class:`tlm_adjoint.tlm_adjoint.EquationManager` which

--- a/tlm_adjoint/overloaded_float.py
+++ b/tlm_adjoint/overloaded_float.py
@@ -124,9 +124,9 @@ _overload = 0
 def no_float_overloading(fn):
     """Decorator to disable :class:`OverloadedFloat` operator overloading.
 
-    :arg fn: :class:`Callable` for which :class:`OverloadedFloat` operator
-        overloading should be disabled.
-    :returns: A :class:`Callable` for which :class:`OverloadedFloat` operator
+    :arg fn: A callable for which :class:`OverloadedFloat` operator overloading
+        should be disabled.
+    :returns: A callable for which :class:`OverloadedFloat` operator
         overloading is disabled.
     """
 

--- a/tlm_adjoint/tlm_adjoint.py
+++ b/tlm_adjoint/tlm_adjoint.py
@@ -330,7 +330,7 @@ class EquationManager:
               the corresponding arguments for the :func:`adj_checkpointing`
               function in dolfin-adjoint (see e.g. version 2017.1.0).
 
-            - :class:`Callable`: A :class:`Callable` returning a
+            - A callable: A callable returning a
               :class:`tlm_adjoint.checkpoint_schedules.schedule.CheckpointSchedule`.
               Options defined by `cp_parameters`:
 
@@ -340,7 +340,7 @@ class EquationManager:
                   data storage using the pickle module, or `'hdf5'`, for data
                   storage using the h5py library.
                 - Other parameters are passed as keyword arguments to the
-                  :class:`Callable`.
+                  callable.
         """
 
         if len(self._block) != 0 or len(self._blocks) != 0:
@@ -1128,7 +1128,7 @@ class EquationManager:
             differentiate.
         :arg M: A function or a :class:`Sequence` of functions defining the
             controls. Derivatives with respect to the controls are computed.
-        :arg callback: Diagnostic callback. A :class:`Callable` of the form
+        :arg callback: Diagnostic callback. A callable of the form
 
             .. code-block:: python
 

--- a/tlm_adjoint/verification.py
+++ b/tlm_adjoint/verification.py
@@ -146,11 +146,10 @@ def taylor_test(forward, M, J_val, *, dJ=None, ddJ=None, seed=1.0e-2, dM=None,
     the control value degree of freedom vector. The argument `seed` sets the
     value of :math:`\eta`, and the argument `size` sets the value of :math:`P`.
 
-    :arg forward: A :class:`Callable` which accepts one or more function
-        arguments, and which returns a function or
-        :class:`tlm_adjoint.functional.Functional` defining the forward
-        functional :math:`J`. Corresponds to the `J` argument in the
-        dolfin-adjoint :func:`taylor_test` function.
+    :arg forward: A callable which accepts one or more function arguments, and
+        which returns a function or :class:`tlm_adjoint.functional.Functional`
+        defining the forward functional :math:`J`. Corresponds to the `J`
+        argument in the dolfin-adjoint :func:`taylor_test` function.
     :arg M: A function or a :class:`Sequence` of functions defining the control
         variable :math:`m`. Corresponds to the `m` argument in the
         dolfin-adjoint :func:`taylor_test` function.
@@ -287,10 +286,9 @@ def taylor_test_tlm(forward, M, tlm_order, *, seed=1.0e-2, dMs=None, size=5,
     corrected Taylor remainder magnitude, is computed using a `tlm_order` th
     order tangent-linear.
 
-    :arg forward: A :class:`Callable` which accepts one or more function
-        arguments, and which returns a function or
-        :class:`tlm_adjoint.functional.Functional` defining the forward
-        functional :math:`K`.
+    :arg forward: A callable which accepts one or more function arguments, and
+        which returns a function or :class:`tlm_adjoint.functional.Functional`
+        defining the forward functional :math:`K`.
     :arg M: A function or a :class:`Sequence` of functions defining the control
         variable :math:`m` and its value.
     :arg tlm_order: An :class:`int` defining the tangent-linear order to
@@ -412,10 +410,9 @@ def taylor_test_tlm_adjoint(forward, M, adjoint_order, *, seed=1.0e-2,
     corrected Taylor remainder magnitude, is computed using an adjoint
     associated with an `(adjoint_order - 1)` th order tangent-linear.
 
-    :arg forward: A :class:`Callable` which accepts one or more function
-        arguments, and which returns a function or
-        :class:`tlm_adjoint.functional.Functional` defining the forward
-        functional :math:`K`.
+    :arg forward: A callable which accepts one or more function arguments, and
+        which returns a function or :class:`tlm_adjoint.functional.Functional`
+        defining the forward functional :math:`K`.
     :arg M: A function or a :class:`Sequence` of functions defining the control
         variable :math:`m` and its value.
     :arg adjoint_order: An :class:`int` defining the adjoint order to test.

--- a/tlm_adjoint/verification.py
+++ b/tlm_adjoint/verification.py
@@ -72,7 +72,7 @@ Logging is performed on a logging module logger, with name
 order computed for the corrected Taylor remainder magnitude is returned.
 
 A typical test considers tangent-linears and adjoints up to the relevant order,
-e.g. to verify Hessian calculations
+e.g. to verify Hessian matrix calculations
 
 .. code-block:: python
 
@@ -162,11 +162,11 @@ def taylor_test(forward, M, J_val, *, dJ=None, ddJ=None, seed=1.0e-2, dM=None,
         Required if `ddJ` is not supplied. Corresponds to the `dJdm` argument
         in the dolfin-adjoint :func:`taylor_test` function.
     :arg ddJ: A :class:`tlm_adjoint.hessian.Hessian` used to compute the
-        Hessian action on the considered perturbation direction. If supplied
-        then a higher order corrected Taylor remainder magnitude is computed.
-        If `dJ` is not supplied, also computes the first order directional
-        derivative. Corresponds to the `HJm` argument in the dolfin-adjoint
-        :func:`taylor_test` function.
+        Hessian matrix action on the considered perturbation direction. If
+        supplied then a higher order corrected Taylor remainder magnitude is
+        computed. If `dJ` is not supplied, also computes the first order
+        directional derivative. Corresponds to the `HJm` argument in the
+        dolfin-adjoint :func:`taylor_test` function.
     :arg seed: Defines the value of :math:`\eta`. Controls the magnitude of the
         perturbation. Corresponds to the `seed` argument in the dolfin-adjoint
         :func:`taylor_test` function.


### PR DESCRIPTION
Add functionality for the solution of linear systems defined by Hessian matrices, including partial spectrum preconditioning.

Built on top of a generic interface for solving block linear systems, handling mappings to and from appropriate mixed-spaces. Handles null spaces by constructing non-singular problems associated with consistent singular systems, and which can be constructed so that symmetry and positive semi-definiteness is preserved. This means that PETSc only sees the modified non-singular problem.

Also:
- A simpler interface for solving Hessian eigenproblems.
- Change to space type arguments for `eigendecompose`. The action space type is no longer relative. Breaks API.
- Add some defensive copying when using `minimize_l_bfgs` callable arguments.
- Documentation updates.