### PR TITLE
Fix block system memory leak

### DIFF
--- a/tests/fenics/test_base.py
+++ b/tests/fenics/test_base.py
@@ -171,6 +171,7 @@ def test_leaks():
     yield
 
     gc.collect()
+    garbage_cleanup(DEFAULT_COMM)
 
     # Clear some internal storage that is allowed to keep references
     clear_caches()
@@ -182,6 +183,7 @@ def test_leaks():
     manager._adj_cache.clear()
 
     gc.collect()
+    garbage_cleanup(DEFAULT_COMM)
 
     refs = 0
     for F in referenced_functions():

--- a/tests/firedrake/test_base.py
+++ b/tests/firedrake/test_base.py
@@ -164,6 +164,7 @@ def test_leaks():
     yield
 
     gc.collect()
+    garbage_cleanup(DEFAULT_COMM)
 
     # Clear some internal storage that is allowed to keep references
     clear_caches()
@@ -179,6 +180,7 @@ def test_leaks():
                 del eq._interp
 
     gc.collect()
+    garbage_cleanup(DEFAULT_COMM)
 
     refs = 0
     for F in referenced_functions():

--- a/tlm_adjoint/_code_generator/block_system.py
+++ b/tlm_adjoint/_code_generator/block_system.py
@@ -1185,6 +1185,8 @@ class System:
         :returns: The PETSc :class:`KSP`.
         """
 
+        global _error_flag
+
         if solver_parameters is None:
             solver_parameters = {}
 
@@ -1293,7 +1295,7 @@ class System:
             self._action_space.split_to_mixed(b_fn, b_c)
         del b_c
 
-        assert not _error_flag
+        _error_flag = False
         with vec(u_fn) as u_v, vec(b_fn) as b_v:
             ksp_solver.solve(b_v, u_v)
         del b_fn

--- a/tlm_adjoint/_code_generator/hessian_system.py
+++ b/tlm_adjoint/_code_generator/hessian_system.py
@@ -391,7 +391,7 @@ def hessian_eigendecomposition_pc(B_action, Lam, V):
 
     .. math::
 
-        H^{-1} \approx B + V \Lambda \left( I + \lambda \right)^{-1} V^T
+        H^{-1} \approx B + V \Lambda \left( I + \Lambda \right)^{-1} V^T
 
     where
 

--- a/tlm_adjoint/eigendecomposition.py
+++ b/tlm_adjoint/eigendecomposition.py
@@ -171,6 +171,7 @@ def eigendecompose(space, A_action, *, B_action=None, arg_space_type="primal",
 
     import petsc4py.PETSc as PETSc
     import slepc4py.SLEPc as SLEPc
+    global _error_flag
 
     if arg_space_type not in {"primal", "conjugate", "dual", "conjugate_dual"}:
         raise ValueError("Invalid space type")
@@ -229,7 +230,7 @@ def eigendecompose(space, A_action, *, B_action=None, arg_space_type="primal",
         configure(esolver)
     esolver.setUp()
 
-    assert not _error_flag
+    _error_flag = False
     esolver.solve()
     if _error_flag:
         raise RuntimeError("Error encountered in SLEPc.EPS.solve")


### PR DESCRIPTION
Fix a memory leak by ensuring that `garbage_cleanup` is called for duplicated communicators.

Also reset `_error_flag` prior to PETSc/SLEPc calls, and fix a documentation typo.