### PR TITLE
Firedrake backend: Update for new Constant type

### DIFF
--- a/docs/source/examples/1_time_independent.ipynb
+++ b/docs/source/examples/1_time_independent.ipynb
@@ -186,7 +186,7 @@
    "outputs": [],
    "source": [
     "one = Function(space, name=\"one\")\n",
-    "one.assign(Constant(1.0))\n",
+    "one.assign(1.0)\n",
     "\n",
     "dJ_dm_one = function_inner(one, dJ_dm)\n",
     "\n",

--- a/docs/source/examples/3_time_dependent.ipynb
+++ b/docs/source/examples/3_time_dependent.ipynb
@@ -197,7 +197,7 @@
    "outputs": [],
    "source": [
     "one = Function(space, name=\"one\")\n",
-    "one.assign(Constant(1.0))\n",
+    "one.assign(1.0)\n",
     "\n",
     "dJ_dpsi_one = function_inner(one, dJ_dpsi)\n",
     "\n",

--- a/tests/fenics/test_equations.py
+++ b/tests/fenics/test_equations.py
@@ -213,6 +213,9 @@ def test_FixedPointSolver(setup_test, test_leaks):
     b = Constant(3.0, name="b", static=True)
 
     def forward(a, b):
+        x.assign(0.0)
+        z.assign(0.0)
+
         eqs = [LinearCombination(z, (1.0, x), (1.0, b)),
                ExprEvaluation(x, a / sqrt(z))]
 
@@ -894,10 +897,10 @@ def test_form_binding(setup_test, test_leaks,
     # With FEniCS u.split() creates new Coefficient objects
     u_split = u.split()
     form = test_form(u, u_split, test)
-    for c in form.coefficients():
+    for c in extract_coefficients(form):
         assert not function_is_replacement(c)
     form = unbound_form(form, test_form_deps(u, u_split))
-    for c in form.coefficients():
+    for c in extract_coefficients(form):
         assert function_is_replacement(c)
     del u, u_split
 
@@ -1037,7 +1040,7 @@ def test_eliminate_zeros_arity_1(setup_test, test_leaks,
     assert len(zero_form.integrals()) == 0
 
     zero_form = eliminate_zeros(form, force_non_empty_form=True)
-    assert F not in zero_form.coefficients()
+    assert F not in extract_coefficients(zero_form)
     b = Function(space, space_type="conjugate_dual")
     assemble(zero_form, tensor=function_vector(b))
     assert function_linf_norm(b) == 0.0

--- a/tests/fenics/test_minimize.py
+++ b/tests/fenics/test_minimize.py
@@ -273,7 +273,7 @@ def test_l_bfgs_multiple(setup_test, test_leaks):
     info(f"{F_calls=:d}")
     info(f"{Fp_calls=:d}")
 
-    assert abs(F(x, y)) < 1.0e-25
+    assert abs(F(x, y)) < 1.0e-24
     assert x_error_norm < 1.0e-12
     assert y_error_norm < 1.0e-11
     assert its <= 38

--- a/tests/fenics/test_models.py
+++ b/tests/fenics/test_models.py
@@ -243,7 +243,7 @@ def test_diffusion_1d(setup_test, test_leaks,
     if issubclass(function_dtype(kappa), (complex, np.complexfloating)):
         dm_kappa = None
     else:
-        dm_kappa = Constant(1.0, name="dm_kappa", static=True)
+        dm_kappa = Constant(1.0, domain=mesh, name="dm_kappa", static=True)
     for m, forward_J, dJ, dm in \
             [(T_0, lambda T_0: forward(T_0, kappa), dJs[0], None),
              (kappa, lambda kappa: forward(T_0, kappa), dJs[1], dm_kappa)]:

--- a/tests/fenics/test_overrides.py
+++ b/tests/fenics/test_overrides.py
@@ -2,8 +2,8 @@
 # -*- coding: utf-8 -*-
 
 from fenics import *
-from fenics import assemble as backend_assemble
 from tlm_adjoint.fenics import *
+from tlm_adjoint.fenics.backend import backend_assemble
 from tlm_adjoint.fenics.backend_code_generator_interface import (
     assemble as backend_code_generator_interface_assemble)
 

--- a/tests/firedrake/test_base.py
+++ b/tests/firedrake/test_base.py
@@ -4,9 +4,9 @@
 from firedrake import *
 from tlm_adjoint.firedrake import *
 from tlm_adjoint.firedrake import manager as _manager
-from tlm_adjoint.firedrake.backend import backend_Constant, backend_Function
-from tlm_adjoint.firedrake.backend_code_generator_interface import \
-    complex_mode, interpolate_expression
+from tlm_adjoint.firedrake.backend import backend_Function
+from tlm_adjoint.firedrake.backend_code_generator_interface import (
+    complex_mode, interpolate_expression)
 from tlm_adjoint.alias import gc_disabled
 
 import copy
@@ -139,15 +139,6 @@ def referenced_functions():
                  if F_ref is not None)
 
 
-def _Constant__init__(self, *args, **kwargs):
-    _Constant__init__orig(self, *args, **kwargs)
-    _function_ids[function_id(self)] = self
-
-
-_Constant__init__orig = backend_Constant.__init__
-backend_Constant.__init__ = _Constant__init__
-
-
 def _Function__init__(self, *args, **kwargs):
     _Function__init__orig(self, *args, **kwargs)
     _function_ids[function_id(self)] = self
@@ -184,8 +175,7 @@ def test_leaks():
 
     refs = 0
     for F in referenced_functions():
-        if function_name(F) != f"{DEFAULT_MESH_NAME:s}_coordinates" \
-                and not isinstance(F, ZeroConstant):
+        if function_name(F) != f"{DEFAULT_MESH_NAME:s}_coordinates":
             info(f"{function_name(F):s} referenced")
             refs += 1
     if refs == 0:

--- a/tests/firedrake/test_equations.py
+++ b/tests/firedrake/test_equations.py
@@ -214,6 +214,9 @@ def test_FixedPointSolver(setup_test, test_leaks):
     b = Constant(3.0, name="b", static=True)
 
     def forward(a, b):
+        x.assign(0.0)
+        z.assign(0.0)
+
         eqs = [LinearCombination(z, (1.0, x), (1.0, b)),
                ExprEvaluation(x, a / sqrt(z))]
 
@@ -886,10 +889,10 @@ def test_form_binding(setup_test, test_leaks,
     # With FEniCS u.split() creates new Coefficient objects
     u_split = u.subfunctions
     form = test_form(u, u_split, test)
-    for c in form.coefficients():
+    for c in extract_coefficients(form):
         assert not function_is_replacement(c)
     form = unbound_form(form, test_form_deps(u, u_split))
-    for c in form.coefficients():
+    for c in extract_coefficients(form):
         assert function_is_replacement(c)
     del u, u_split
 
@@ -1017,7 +1020,7 @@ def test_eliminate_zeros_arity_1(setup_test, test_leaks,
     assert len(zero_form.integrals()) == 0
 
     zero_form = eliminate_zeros(form, force_non_empty_form=True)
-    assert F not in zero_form.coefficients()
+    assert F not in extract_coefficients(zero_form)
     b = Function(space, space_type="conjugate_dual")
     assemble(zero_form, tensor=function_vector(b))
     assert function_linf_norm(b) == 0.0

--- a/tests/firedrake/test_manager.py
+++ b/tests/firedrake/test_manager.py
@@ -304,7 +304,7 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
             assert not b._references_dropped
             assert not M._references_dropped
             for dep in linear_eq.dependencies():
-                assert function_is_replacement(dep)
+                assert function_is_replacement(dep) or isinstance(dep, Constant)  # noqa: E501
             for dep in b.dependencies():
                 assert not function_is_replacement(dep)
 
@@ -338,7 +338,7 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
             assert b._references_dropped
             assert M._references_dropped
             for dep in b.dependencies():
-                assert function_is_replacement(dep)
+                assert function_is_replacement(dep) or isinstance(dep, Constant)  # noqa: E501
 
         M = IdentityMatrix()
 
@@ -462,7 +462,7 @@ def test_Referrers_FixedPointEquation(setup_test, test_leaks):
             assert len(manager._to_drop_references) == 0
             assert fp_eq._references_dropped
             for dep in fp_eq.dependencies():
-                assert function_is_replacement(dep)
+                assert function_is_replacement(dep) or isinstance(dep, Constant)  # noqa: E501
             for eq in [eq0, eq1]:
                 assert not eq._references_dropped
                 for dep in eq.dependencies():
@@ -496,7 +496,7 @@ def test_Referrers_FixedPointEquation(setup_test, test_leaks):
             for eq in [eq0, eq1]:
                 assert eq._references_dropped
                 for dep in eq.dependencies():
-                    assert function_is_replacement(dep)
+                    assert function_is_replacement(dep) or isinstance(dep, Constant)  # noqa: E501
             del eq
 
         J = Functional(name="J")

--- a/tests/firedrake/test_models.py
+++ b/tests/firedrake/test_models.py
@@ -190,10 +190,18 @@ def test_diffusion_1d(setup_test, test_leaks,
     X = SpatialCoordinate(mesh)
     space = FunctionSpace(mesh, "Lagrange", 1)
     test, trial = TestFunction(space), TrialFunction(space)
+
+    const_space = FunctionSpace(mesh, "R", 0)
+
+    def constant(value, *args, **kwargs):
+        F = Function(const_space, *args, **kwargs)
+        F.assign(value, annotate=False, tlm=False)
+        return F
+
     T_0 = Function(space, name="T_0", static=True)
     interpolate_expression(T_0, sin(pi * X[0]) + sin(10.0 * pi * X[0]))
     dt = Constant(0.01, static=True)
-    kappa = Constant(1.0, domain=mesh, name="kappa", static=True)
+    kappa = constant(1.0, name="kappa", static=True)
 
     def forward(T_0, kappa):
         import sympy as sp
@@ -238,7 +246,7 @@ def test_diffusion_1d(setup_test, test_leaks,
     if issubclass(function_dtype(kappa), (complex, np.complexfloating)):
         dm_kappa = None
     else:
-        dm_kappa = Constant(1.0, name="dm_kappa", static=True)
+        dm_kappa = constant(1.0, name="dm_kappa", static=True)
     for m, forward_J, dJ, dm in \
             [(T_0, lambda T_0: forward(T_0, kappa), dJs[0], None),
              (kappa, lambda kappa: forward(T_0, kappa), dJs[1], dm_kappa)]:
@@ -283,13 +291,21 @@ def test_diffusion_2d(setup_test, test_leaks,
     X = SpatialCoordinate(mesh)
     space = FunctionSpace(mesh, "Lagrange", 1)
     test, trial = TestFunction(space), TrialFunction(space)
+
+    const_space = FunctionSpace(mesh, "R", 0)
+
+    def constant(value, *args, **kwargs):
+        F = Function(const_space, *args, **kwargs)
+        F.assign(value, annotate=False, tlm=False)
+        return F
+
     T_0 = Function(space, name="T_0", static=True)
     interpolate_expression(T_0, sin(pi * X[0]) * sin(2.0 * pi * X[1]))
     dt = Constant(0.01, static=True)
-    kappa = [Constant(1.0, domain=mesh, name="kappa_00", static=True),
-             Constant(0.0, domain=mesh, name="kappa_10", static=True),
-             Constant(0.0, domain=mesh, name="kappa_01", static=True),
-             Constant(1.0, domain=mesh, name="kappa_11", static=True)]
+    kappa = [constant(1.0, name="kappa_00", static=True),
+             constant(0.0, name="kappa_10", static=True),
+             constant(0.0, name="kappa_01", static=True),
+             constant(1.0, name="kappa_11", static=True)]
     bc = HomogeneousDirichletBC(space, "on_boundary")
 
     def forward(kappa_00, kappa_01, kappa_10, kappa_11):

--- a/tests/firedrake/test_overrides.py
+++ b/tests/firedrake/test_overrides.py
@@ -2,8 +2,8 @@
 # -*- coding: utf-8 -*-
 
 from firedrake import *
-from firedrake import assemble as backend_assemble
 from tlm_adjoint.firedrake import *
+from tlm_adjoint.firedrake.backend import backend_assemble
 from tlm_adjoint.firedrake.backend_code_generator_interface import (
     assemble as backend_code_generator_interface_assemble)
 
@@ -284,7 +284,6 @@ def test_interpolate(setup_test, test_leaks,
         start_manager()
         y_1, J = forward(y_2)
         stop_manager()
-        manager_info()
 
         y_1_error = function_copy(y_1)
         function_axpy(y_1_error, -1.0, y_1_ref)

--- a/tlm_adjoint/_code_generator/block_system.py
+++ b/tlm_adjoint/_code_generator/block_system.py
@@ -960,7 +960,7 @@ class BlockMatrix(Matrix):
         del self._blocks[(i, j)]
 
     def __len__(self):
-        return len(self.__blocks)
+        return len(self._blocks)
 
     def keys(self):
         yield from sorted(self._blocks)

--- a/tlm_adjoint/fenics/backend.py
+++ b/tlm_adjoint/fenics/backend.py
@@ -1,13 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-from fenics import Cell, Constant, DirichletBC, Form, Function, \
-    FunctionSpace, LocalSolver, Mesh, MeshEditor, KrylovSolver, LUSolver, \
-    LinearVariationalSolver, NonlinearVariationalProblem, \
-    NonlinearVariationalSolver, Parameters, Point, TensorFunctionSpace, \
-    TestFunction, TrialFunction, UnitIntervalMesh, UserExpression, adjoint, \
-    as_backend_type, assemble, assemble_system, has_lu_solver_method, info, \
-    parameters, project, solve
+from fenics import *
 import fenics
 import numpy as np
 import petsc4py.PETSc as PETSc
@@ -37,54 +31,4 @@ backend_assemble_system = assemble_system
 backend_project = project
 backend_solve = solve
 
-cpp_LinearVariationalProblem = fenics.cpp.fem.LinearVariationalProblem
-cpp_NonlinearVariationalProblem = fenics.cpp.fem.NonlinearVariationalProblem
 cpp_PETScVector = fenics.cpp.la.PETScVector
-
-__all__ = \
-    [
-        "backend",
-
-        "backend_ScalarType",
-
-        "extract_args",
-
-        "backend_Constant",
-        "backend_DirichletBC",
-        "backend_Function",
-        "backend_FunctionSpace",
-        "backend_KrylovSolver",
-        "backend_LUSolver",
-        "backend_LinearVariationalSolver",
-        "backend_NonlinearVariationalProblem",
-        "backend_NonlinearVariationalSolver",
-        "backend_Matrix",
-        "backend_Vector",
-        "backend_assemble",
-        "backend_assemble_system",
-        "backend_project",
-        "backend_solve",
-
-        "cpp_LinearVariationalProblem",
-        "cpp_NonlinearVariationalProblem",
-        "cpp_PETScVector",
-
-        "Cell",
-        "Form",
-        "FunctionSpace",
-        "LocalSolver",
-        "Mesh",
-        "MeshEditor",
-        "Parameters",
-        "Point",
-        "TensorFunctionSpace",
-        "TestFunction",
-        "TrialFunction",
-        "UnitIntervalMesh",
-        "UserExpression",
-        "adjoint",
-        "as_backend_type",
-        "has_lu_solver_method",
-        "info",
-        "parameters"
-    ]

--- a/tlm_adjoint/fenics/backend_interface.py
+++ b/tlm_adjoint/fenics/backend_interface.py
@@ -1,23 +1,25 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-from .backend import FunctionSpace, UnitIntervalMesh, as_backend_type, \
-    backend, backend_Constant, backend_Function, backend_FunctionSpace, \
-    backend_ScalarType, backend_Vector, cpp_PETScVector, info
-from ..interface import DEFAULT_COMM, SpaceInterface, \
-    add_finalize_adjoint_derivative_action, add_functional_term_eq, \
-    add_interface, add_subtract_adjoint_derivative_action, check_space_types, \
-    comm_dup_cached, function_copy, function_new, function_space_type, \
-    new_function_id, new_space_id, space_id, space_new, \
-    subtract_adjoint_derivative_action
+from .backend import (
+    FunctionSpace, UnitIntervalMesh, as_backend_type, backend,
+    backend_Constant, backend_Function, backend_FunctionSpace,
+    backend_ScalarType, backend_Vector, cpp_PETScVector, info)
+from ..interface import (
+    DEFAULT_COMM, SpaceInterface, add_finalize_adjoint_derivative_action,
+    add_functional_term_eq, add_interface,
+    add_subtract_adjoint_derivative_action, check_space_types, comm_dup_cached,
+    function_copy, function_new, function_space, function_space_type,
+    new_function_id, new_space_id, space_id, space_new,
+    subtract_adjoint_derivative_action)
 from ..interface import FunctionInterface as _FunctionInterface
-from .backend_code_generator_interface import assemble, is_valid_r0_space, \
-    r0_space
+from .backend_code_generator_interface import (
+    assemble, is_valid_r0_space, r0_space)
 
 from .equations import Assembly
-from .functions import Caches, Constant, ConstantInterface, \
-    ConstantSpaceInterface, Function, ReplacementFunction, Zero, \
-    define_function_alias
+from .functions import (
+    Caches, Constant, ConstantInterface, ConstantSpaceInterface, Function,
+    ReplacementFunction, Zero, define_function_alias)
 from ..overloaded_float import SymbolicFloat
 
 import functools
@@ -60,10 +62,11 @@ def _Constant__init__(self, *args, domain=None, space=None,
                       {"comm": comm_dup_cached(comm), "domain": domain,
                        "dtype": backend_ScalarType, "id": new_space_id()})
     add_interface(self, ConstantInterface,
-                  {"id": new_function_id(), "state": 0,
-                   "space": space, "space_type": "primal",
-                   "dtype": backend_ScalarType, "static": False,
-                   "cache": False, "checkpoint": True})
+                  {"id": new_function_id(), "name": lambda x: x.name(),
+                   "state": 0, "space": space,
+                   "form_derivative_space": lambda x: r0_space(x),
+                   "space_type": "primal", "dtype": backend_ScalarType,
+                   "static": False, "cache": False, "checkpoint": True})
 
 
 assert not hasattr(backend_Constant, "_tlm_adjoint__orig___init__")
@@ -128,6 +131,9 @@ def check_vector_size(fn):
 class FunctionInterface(_FunctionInterface):
     def _space(self):
         return self._tlm_adjoint__function_interface_attrs["space"]
+
+    def _form_derivative_space(self):
+        return function_space(self)
 
     def _space_type(self):
         return self._tlm_adjoint__function_interface_attrs["space_type"]

--- a/tlm_adjoint/firedrake/backend.py
+++ b/tlm_adjoint/firedrake/backend.py
@@ -1,13 +1,8 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-from firedrake import Constant, DirichletBC, Function, FunctionSpace, \
-    Interpolator, LinearSolver, LinearVariationalProblem, \
-    LinearVariationalSolver, NonlinearVariationalSolver, Parameters, \
-    Projector, Tensor, TestFunction, TrialFunction, UnitIntervalMesh, Vector, \
-    VertexOnlyMesh, adjoint, assemble, homogenize, info, interpolate, \
-    parameters, project, solve
-from firedrake.utils import complex_mode
+from firedrake import *
+from firedrake.utils import complex_mode  # noqa: F401
 import firedrake
 
 backend = "Firedrake"
@@ -31,43 +26,3 @@ backend_assemble = assemble
 backend_interpolate = interpolate
 backend_project = project
 backend_solve = solve
-
-__all__ = \
-    [
-        "backend",
-
-        "backend_ScalarType",
-
-        "extract_args",
-        "extract_linear_solver_args",
-
-        "backend_Constant",
-        "backend_DirichletBC",
-        "backend_Function",
-        "backend_FunctionSpace",
-        "backend_LinearSolver",
-        "backend_LinearVariationalProblem",
-        "backend_LinearVariationalSolver",
-        "backend_Matrix",
-        "backend_NonlinearVariationalSolver",
-        "backend_Vector",
-        "backend_assemble",
-        "backend_interpolate",
-        "backend_project",
-        "backend_solve",
-
-        "FunctionSpace",
-        "Interpolator",
-        "Parameters",
-        "Projector",
-        "Tensor",
-        "TestFunction",
-        "TrialFunction",
-        "UnitIntervalMesh",
-        "VertexOnlyMesh",
-        "adjoint",
-        "complex_mode",
-        "homogenize",
-        "info",
-        "parameters"
-    ]

--- a/tlm_adjoint/firedrake/firedrake_equations.py
+++ b/tlm_adjoint/firedrake/firedrake_equations.py
@@ -5,20 +5,23 @@
 backend.
 """
 
-from .backend import FunctionSpace, Interpolator, Tensor, TestFunction, \
-    TrialFunction, VertexOnlyMesh, backend_Function, backend_assemble
-from ..interface import check_space_type, function_assign, function_comm, \
-    function_is_scalar, function_new_conjugate_dual, function_scalar_value, \
-    function_space, is_function, space_new, weakref_method
+from .backend import (
+    FunctionSpace, Interpolator, Tensor, TestFunction, TrialFunction,
+    VertexOnlyMesh, backend_Function, backend_assemble)
+from ..interface import (
+    check_space_type, function_assign, function_comm, function_is_scalar,
+    function_new_conjugate_dual, function_scalar_value, function_space,
+    is_function, space_new, weakref_method)
 from .backend_code_generator_interface import assemble, matrix_multiply
 
 from ..caches import Cache
 from ..equation import Equation, ZeroAssignment
+from ..manager import paused_manager
 from ..tangent_linear import get_tangent_linear
 
 from .caches import form_dependencies, form_key, parameters_key
-from .equations import EquationSolver, bind_form, derivative, unbind_form, \
-    unbound_form
+from .equations import (
+    EquationSolver, bind_form, derivative, unbind_form, unbound_form)
 from .functions import eliminate_zeros
 
 import itertools
@@ -315,7 +318,8 @@ class PointInterpolation(Equation):
         interp = _interp
         if interp is None:
             y_space = function_space(y)
-            vmesh = VertexOnlyMesh(y_space.mesh(), X_coords)
+            with paused_manager():
+                vmesh = VertexOnlyMesh(y_space.mesh(), X_coords)
             vspace = FunctionSpace(vmesh, "Discontinuous Lagrange", 0)
             interp = Interpolator(TestFunction(y_space), vspace)
             if not hasattr(interp, "_tlm_adjoint__vmesh_coords_map"):

--- a/tlm_adjoint/interface.py
+++ b/tlm_adjoint/interface.py
@@ -106,6 +106,7 @@ __all__ = \
         "function_comm",
         "function_copy",
         "function_dtype",
+        "function_form_derivative_space",
         "function_get_values",
         "function_global_size",
         "function_id",
@@ -648,13 +649,13 @@ class FunctionInterface:
     """
 
     prefix = "_tlm_adjoint__function_interface"
-    names = ("_comm", "_space", "_space_type", "_dtype", "_id", "_name",
-             "_state", "_update_state", "_is_static", "_is_cached",
-             "_is_checkpointed", "_caches", "_zero", "_assign", "_axpy",
-             "_inner", "_sum", "_linf_norm", "_local_size", "_global_size",
-             "_local_indices", "_get_values", "_set_values", "_new", "_copy",
-             "_replacement", "_is_replacement", "_is_scalar", "_scalar_value",
-             "_is_alias")
+    names = ("_comm", "_space", "_form_derivative_space", "_space_type",
+             "_dtype", "_id", "_name", "_state", "_update_state", "_is_static",
+             "_is_cached", "_is_checkpointed", "_caches", "_zero", "_assign",
+             "_axpy", "_inner", "_sum", "_linf_norm", "_local_size",
+             "_global_size", "_local_indices", "_get_values", "_set_values",
+             "_new", "_copy", "_replacement", "_is_replacement", "_is_scalar",
+             "_scalar_value", "_is_alias")
 
     def __init__(self):
         raise RuntimeError("Cannot instantiate FunctionInterface object")
@@ -663,6 +664,9 @@ class FunctionInterface:
         return space_comm(function_space(self))
 
     def _space(self):
+        raise NotImplementedError("Method not overridden")
+
+    def _form_derivative_space(self):
         raise NotImplementedError("Method not overridden")
 
     def _space_type(self):
@@ -784,6 +788,15 @@ def function_space(x):
     """
 
     return x._tlm_adjoint__function_interface_space()
+
+
+def function_form_derivative_space(x):
+    """
+    :returns: The space in which a derivative is defined when differentiating a
+        UFL :class:`Form` with respect to the function.
+    """
+
+    return x._tlm_adjoint__function_interface_form_derivative_space()
 
 
 def function_space_type(x, *, rel_space_type="primal"):


### PR DESCRIPTION
The Firedrake `Constant` class is no longer a subclass of `ufl.Coefficient`. This means that with the Firedrake backend:
- `Constant` objects no longer appear in the return value of `Form.coefficients` or `ufl.algorithms.extract_coefficients`.
- Expressions and forms cannot be differentiated with respect to `Constant` objects.
 
However tlm_adjoint allows `Constant` objects to be controls. To work around this:
- The tlm_adjoint `extract_coefficients` function is now used consistently throughout the code. This includes `Constant` objects in the return value.
- The tlm_adjoint `derivative` function is now used consistently throughout the code. This replaces `Constant` objects with `Coefficient` replacements as needed to allow differentiation.
- Similarly the new tlm_adjoint `diff` function is used in place of `ufl.diff`.

Note that with the Firedrake backend references to `Constant` objects are no longer dropped when `Referrer` objects (particularly `Equation` objects) are destroyed. This is due to the signature associated with a `Constant` depending up the `dat` attribute -- and `ReplacementConstant` objects do not call the `Constant` constructor, and so do not have this attribute.

Also:
- Replace `__` attribute prefix with `_tlm_adjoint__`.
- Bugfix to `BlockMatrix.__len__`.
- Communicator bugfixes in `assign` annotation.
- Some tidying.