### PR TITLE
*args bugfixes and tidying

### DIFF
--- a/tlm_adjoint/_code_generator/hessian_system.py
+++ b/tlm_adjoint/_code_generator/hessian_system.py
@@ -58,8 +58,8 @@ class MixedSpace(BackendMixedSpace):
 
     def new_mixed(self, *args, **kwargs):
         space_type = self._space_types[0]
-        return Function(self.mixed_space(), space_type=space_type,
-                        *args, **kwargs)
+        return Function(self.mixed_space(), *args, space_type=space_type,
+                        **kwargs)
 
 
 # Complex note: It is convenient to define a Hessian matrix action in terms of

--- a/tlm_adjoint/fenics/backend_code_generator_interface.py
+++ b/tlm_adjoint/fenics/backend_code_generator_interface.py
@@ -151,8 +151,8 @@ def assemble_arguments(arity, form_compiler_parameters, solver_parameters):
     return {"form_compiler_parameters": form_compiler_parameters}
 
 
-def assemble_matrix(form, bcs=None, *args,
-                    form_compiler_parameters=None, **kwargs):
+def assemble_matrix(form, bcs=None, *,
+                    form_compiler_parameters=None):
     if bcs is None:
         bcs = ()
     elif isinstance(bcs, backend_DirichletBC):
@@ -170,13 +170,12 @@ def assemble_matrix(form, bcs=None, *args,
         dummy_rhs = ufl.inner(zero, test) * ufl.dx
         A, b_bc = assemble_system(
             form, dummy_rhs, bcs=bcs,
-            form_compiler_parameters=form_compiler_parameters, *args, **kwargs)
+            form_compiler_parameters=form_compiler_parameters)
         if b_bc.norm("linf") == 0.0:
             b_bc = None
     else:
         A = assemble(
-            form, form_compiler_parameters=form_compiler_parameters,
-            *args, **kwargs)
+            form, form_compiler_parameters=form_compiler_parameters)
         b_bc = None
 
     return A, b_bc
@@ -430,35 +429,26 @@ def bind_form(form):
     return ufl.replace(form, bindings)
 
 
-# Aim for compatibility with FEniCS 2019.1.0 API
-
-
-def assemble(form, tensor=None, *args, **kwargs):
+def assemble(form, tensor=None, *,
+             form_compiler_parameters=None):
     if tensor is not None and hasattr(tensor, "_tlm_adjoint__function"):
         check_space_type(tensor._tlm_adjoint__function, "conjugate_dual")
 
     if not isinstance(form, Form):
         form = bind_form(form)
-    return backend_assemble(form, tensor=tensor, *args, **kwargs)
+    return backend_assemble(form, tensor,
+                            form_compiler_parameters=form_compiler_parameters)
 
 
-def assemble_system(A_form, b_form, bcs=None, x0=None,
-                    form_compiler_parameters=None, add_values=False,
-                    finalize_tensor=True, keep_diagonal=False, A_tensor=None,
-                    b_tensor=None, *args, **kwargs):
-    if b_tensor is not None and hasattr(b_tensor, "_tlm_adjoint__function"):
-        check_space_type(b_tensor._tlm_adjoint__function, "conjugate_dual")
-
+def assemble_system(A_form, b_form, bcs=None, *,
+                    form_compiler_parameters=None):
     if not isinstance(A_form, Form):
         A_form = bind_form(A_form)
     if not isinstance(b_form, Form):
         b_form = bind_form(b_form)
     return backend_assemble_system(
-        A_form, b_form, bcs=bcs, x0=x0,
-        form_compiler_parameters=form_compiler_parameters,
-        add_values=add_values, finalize_tensor=finalize_tensor,
-        keep_diagonal=keep_diagonal, A_tensor=A_tensor, b_tensor=b_tensor,
-        *args, **kwargs)
+        A_form, b_form, bcs=bcs,
+        form_compiler_parameters=form_compiler_parameters)
 
 
 # def solve(*args, **kwargs):

--- a/tlm_adjoint/fenics/backend_interface.py
+++ b/tlm_adjoint/fenics/backend_interface.py
@@ -421,12 +421,8 @@ add_subtract_adjoint_derivative_action(backend,
 
 def _finalize_adjoint_derivative_action(x):
     if hasattr(x, "_tlm_adjoint__fenics_adj_b"):
-        if isinstance(x, backend_Constant):
-            y = assemble(x._tlm_adjoint__fenics_adj_b)
-            subtract_adjoint_derivative_action(x, (-1.0, y))
-        else:
-            assemble(x._tlm_adjoint__fenics_adj_b, tensor=x.vector(),
-                     add_values=True)
+        y = assemble(x._tlm_adjoint__fenics_adj_b)
+        subtract_adjoint_derivative_action(x, (-1.0, y))
         delattr(x, "_tlm_adjoint__fenics_adj_b")
 
 

--- a/tlm_adjoint/fenics/backend_overrides.py
+++ b/tlm_adjoint/fenics/backend_overrides.py
@@ -68,9 +68,8 @@ def assemble(form, tensor=None, form_compiler_parameters=None,
     if tensor is not None and hasattr(tensor, "_tlm_adjoint__function"):
         check_space_type(tensor._tlm_adjoint__function, "conjugate_dual")
 
-    b = backend_assemble(form, tensor=tensor,
-                         form_compiler_parameters=form_compiler_parameters,
-                         add_values=add_values, *args, **kwargs)
+    b = backend_assemble(form, tensor, form_compiler_parameters, add_values,
+                         *args, **kwargs)
 
     if tensor is not None and hasattr(tensor, "_tlm_adjoint__function"):
         function_update_state(tensor._tlm_adjoint__function)
@@ -114,10 +113,8 @@ def assemble_system(A_form, b_form, bcs=None, x0=None,
         check_space_type(b_tensor._tlm_adjoint__function, "conjugate_dual")
 
     A, b = backend_assemble_system(
-        A_form, b_form, bcs=bcs, x0=x0,
-        form_compiler_parameters=form_compiler_parameters,
-        add_values=add_values, finalize_tensor=finalize_tensor,
-        keep_diagonal=keep_diagonal, A_tensor=A_tensor, b_tensor=b_tensor,
+        A_form, b_form, bcs, x0, form_compiler_parameters, add_values,
+        finalize_tensor, keep_diagonal, A_tensor, b_tensor,
         *args, **kwargs)
 
     if b_tensor is not None and hasattr(b_tensor, "_tlm_adjoint__function"):


### PR DESCRIPTION
Fix a few cases of

```
fn(arg0=arg0_value, *args, **kwargs)
```

which leads to an error if `args` is not empty. Also remove some unnecessary use `*args` and `**kwargs`.