### PR TITLE
Implement a new patch approach for automatic annotation

### DIFF
--- a/examples/fenics/diffusion/diffusion.py
+++ b/examples/fenics/diffusion/diffusion.py
@@ -3,7 +3,6 @@
 
 from fenics import *
 from tlm_adjoint.fenics import *
-from tlm_adjoint.fenics import manager as _manager
 
 # import h5py
 import mpi4py.MPI as MPI
@@ -40,7 +39,7 @@ function_set_values(zeta_2,
 # File("zeta_2.pvd", "compressed") << zeta_2
 
 
-def forward(kappa, manager=None, output_filename=None):
+def forward(kappa, output_filename=None):
     clear_caches()
 
     Psi_n = Function(space, name="Psi_n")
@@ -58,14 +57,14 @@ def forward(kappa, manager=None, output_filename=None):
     if output_filename is not None:
         f = File(output_filename, "compressed")
 
-    Assignment(Psi_n, Psi_0).solve(manager=manager)
+    Assignment(Psi_n, Psi_0).solve()
     if output_filename is not None:
         f << (Psi_n, 0.0)
     for n in range(N):
-        eq.solve(manager=manager)
+        eq.solve()
         if n < N - 1:
-            cycle.solve(manager=manager)
-            (_manager() if manager is None else manager).new_block()
+            cycle.solve()
+            new_block()
         else:
             Psi_n = Psi_np1
             Psi_n.rename("Psi_n", "a Function")
@@ -74,7 +73,7 @@ def forward(kappa, manager=None, output_filename=None):
             f << (Psi_n, (n + 1) * float(dt))
 
     J = Functional(name="J")
-    J.assign(dot(Psi_n, Psi_n) * dx, manager=manager)
+    J.assign(dot(Psi_n, Psi_n) * dx)
 
     return J
 

--- a/examples/firedrake/diffusion/diffusion.py
+++ b/examples/firedrake/diffusion/diffusion.py
@@ -3,7 +3,6 @@
 
 from firedrake import *
 from tlm_adjoint.firedrake import *
-from tlm_adjoint.firedrake import manager as _manager
 
 # import h5py
 import logging
@@ -42,7 +41,7 @@ function_set_values(zeta_2,
 # File("zeta_2.pvd").write(zeta_2)
 
 
-def forward(kappa, manager=None, output_filename=None):
+def forward(kappa, output_filename=None):
     clear_caches()
 
     Psi_n = Function(space, name="Psi_n")
@@ -60,14 +59,14 @@ def forward(kappa, manager=None, output_filename=None):
     if output_filename is not None:
         f = File(output_filename)
 
-    Assignment(Psi_n, Psi_0).solve(manager=manager)
+    Assignment(Psi_n, Psi_0).solve()
     if output_filename is not None:
         f.write(Psi_n, time=0.0)
     for n in range(N):
-        eq.solve(manager=manager)
+        eq.solve()
         if n < N - 1:
-            cycle.solve(manager=manager)
-            (_manager() if manager is None else manager).new_block()
+            cycle.solve()
+            new_block()
         else:
             Psi_n = Psi_np1
             Psi_n.rename("Psi_n", "a Function")
@@ -76,7 +75,7 @@ def forward(kappa, manager=None, output_filename=None):
             f.write(Psi_n, time=(n + 1) * float(dt))
 
     J = Functional(name="J")
-    J.assign(dot(Psi_n, Psi_n) * dx, manager=manager)
+    J.assign(dot(Psi_n, Psi_n) * dx)
 
     return J
 

--- a/tests/firedrake/test_equations.py
+++ b/tests/firedrake/test_equations.py
@@ -803,8 +803,9 @@ def test_initial_guess(setup_test, test_leaks,
 
         adj_x_0 = Function(space_1, space_type="conjugate_dual",
                            name="adj_x_0", static=True)
-        assemble(4 * dot(ufl.conj(dot(x, x) * x), ufl.conj(test_1)) * dx,
-                 tensor=function_vector(adj_x_0), annotate=False, tlm=False)
+        with paused_manager():
+            assemble(4 * dot(ufl.conj(dot(x, x) * x), ufl.conj(test_1)) * dx,
+                     tensor=function_vector(adj_x_0))
         Projection(x, zero,
                    solver_parameters=ls_parameters_cg).solve()
         if not test_adj_ic:
@@ -831,13 +832,13 @@ def test_initial_guess(setup_test, test_leaks,
                                                  function_id(adj_x_0))
     assert len(manager()._cp._cp) == 0
     if test_adj_ic:
-        assert len(manager()._cp._data) == 7
-        assert tuple(map(len, manager()._cp._data.values())) \
-            == (0, 0, 0, 1, 0, 2, 0)
-    else:
         assert len(manager()._cp._data) == 8
         assert tuple(map(len, manager()._cp._data.values())) \
-            == (0, 0, 0, 1, 0, 0, 2, 0)
+            == (0, 0, 0, 0, 1, 0, 2, 0)
+    else:
+        assert len(manager()._cp._data) == 9
+        assert tuple(map(len, manager()._cp._data.values())) \
+            == (0, 0, 0, 0, 1, 0, 0, 2, 0)
     assert len(manager()._cp._storage) == 5
 
     dJdx_0, dJdy = compute_gradient(J, [x_0, y])

--- a/tests/firedrake/test_models.py
+++ b/tests/firedrake/test_models.py
@@ -193,9 +193,10 @@ def test_diffusion_1d(setup_test, test_leaks,
 
     const_space = FunctionSpace(mesh, "R", 0)
 
+    @manager_disabled()
     def constant(value, *args, **kwargs):
         F = Function(const_space, *args, **kwargs)
-        F.assign(value, annotate=False, tlm=False)
+        F.assign(value)
         return F
 
     T_0 = Function(space, name="T_0", static=True)
@@ -294,9 +295,10 @@ def test_diffusion_2d(setup_test, test_leaks,
 
     const_space = FunctionSpace(mesh, "R", 0)
 
+    @manager_disabled()
     def constant(value, *args, **kwargs):
         F = Function(const_space, *args, **kwargs)
-        F.assign(value, annotate=False, tlm=False)
+        F.assign(value)
         return F
 
     T_0 = Function(space, name="T_0", static=True)

--- a/tests/firedrake/test_overrides.py
+++ b/tests/firedrake/test_overrides.py
@@ -186,8 +186,8 @@ def test_Nullspace(setup_test, test_leaks):
         solve(inner(grad(trial), grad(test)) * dx
               == -inner(F * F, test) * dx, psi,
               solver_parameters=ls_parameters_cg,
-              nullspace=VectorSpaceBasis(constant=True),
-              transpose_nullspace=VectorSpaceBasis(constant=True))
+              nullspace=VectorSpaceBasis(constant=True, comm=function_comm(psi)),  # noqa: E501
+              transpose_nullspace=VectorSpaceBasis(constant=True, comm=function_comm(psi)))  # noqa: E501
 
         J = Functional(name="J")
         J.assign((dot(psi, psi) ** 2) * dx

--- a/tlm_adjoint/_code_generator/functions.py
+++ b/tlm_adjoint/_code_generator/functions.py
@@ -18,6 +18,7 @@ from ..interface import (
 from ..interface import FunctionInterface as _FunctionInterface
 
 from ..caches import Caches
+from ..manager import manager_disabled
 from ..overloaded_float import SymbolicFloat
 
 import numpy as np
@@ -104,14 +105,16 @@ class ConstantInterface(_FunctionInterface):
                 = Caches(self)
         return self._tlm_adjoint__function_interface_attrs["caches"]
 
+    @manager_disabled()
     def _zero(self):
         if len(self.ufl_shape) == 0:
             value = 0.0
         else:
             value = np.zeros(self.ufl_shape, dtype=function_dtype(self))
             value = backend_Constant(value)
-        self.assign(value, annotate=False, tlm=False)
+        self.assign(value)
 
+    @manager_disabled()
     def _assign(self, y):
         if isinstance(y, SymbolicFloat):
             y = y.value()
@@ -128,8 +131,9 @@ class ConstantInterface(_FunctionInterface):
             value = y
         else:
             raise TypeError(f"Unexpected type: {type(y)}")
-        self.assign(value, annotate=False, tlm=False)
+        self.assign(value)
 
+    @manager_disabled()
     def _axpy(self, alpha, x, /):
         dtype = function_dtype(self)
         alpha = dtype(alpha)
@@ -153,7 +157,7 @@ class ConstantInterface(_FunctionInterface):
                 value = backend_Constant(value)
         else:
             raise TypeError(f"Unexpected type: {type(x)}")
-        self.assign(value, annotate=False, tlm=False)
+        self.assign(value)
 
     def _inner(self, y):
         if isinstance(y, backend_Constant):
@@ -202,6 +206,7 @@ class ConstantInterface(_FunctionInterface):
         values.setflags(write=False)
         return values
 
+    @manager_disabled()
     def _set_values(self, values):
         if not np.can_cast(values, function_dtype(self)):
             raise ValueError("Invalid dtype")
@@ -211,10 +216,10 @@ class ConstantInterface(_FunctionInterface):
         values = comm.bcast(values, root=0)
         if len(self.ufl_shape) == 0:
             values.shape = (1,)
-            self.assign(values[0], annotate=False, tlm=False)
+            self.assign(values[0])
         else:
             values.shape = self.ufl_shape
-            self.assign(backend_Constant(values), annotate=False, tlm=False)
+            self.assign(backend_Constant(values))
 
     def _replacement(self):
         if isinstance(self, ufl.classes.Coefficient):

--- a/tlm_adjoint/_code_generator/hessian_system.py
+++ b/tlm_adjoint/_code_generator/hessian_system.py
@@ -9,6 +9,7 @@ from ..interface import (
     space_comm, space_dtype)
 
 from ..eigendecomposition import eigendecompose
+from ..manager import manager_disabled
 
 from .block_system import (
     BackendMixedSpace, BlockNullspace, Matrix, NoneNullspace, Preconditioner,
@@ -162,6 +163,7 @@ class HessianSystem(System):
             arg_spaces, action_spaces, matrix,
             nullspaces=BlockNullspace(nullspace), comm=comm)
 
+    @manager_disabled()
     def solve(self, u, b, **kwargs):
         """Solve a linear system involving a Hessian matrix,
 

--- a/tlm_adjoint/fenics/backend_code_generator_interface.py
+++ b/tlm_adjoint/fenics/backend_code_generator_interface.py
@@ -13,6 +13,8 @@ from ..interface import (
     function_inner, function_new_conjugate_dual, function_set_values,
     function_space, function_space_type, space_new)
 
+from ..manager import manager_disabled
+
 from .functions import eliminate_zeros, extract_coefficients
 
 from collections.abc import Sequence
@@ -276,6 +278,7 @@ def matrix_multiply(A, x, *,
     return tensor
 
 
+@manager_disabled()
 def is_valid_r0_space(space):
     if not hasattr(space, "_tlm_adjoint__is_valid_r0_space"):
         e = space.ufl_element()
@@ -283,15 +286,14 @@ def is_valid_r0_space(space):
             valid = False
         elif len(e.value_shape()) == 0:
             r = backend_Function(space)
-            r.assign(backend_Constant(1.0), annotate=False, tlm=False)
+            r.assign(backend_Constant(1.0))
             valid = (r.vector().max() == 1.0)
         else:
             r = backend_Function(space)
             r_arr = np.arange(1, np.prod(r.ufl_shape) + 1,
                               dtype=backend_ScalarType)
             r_arr.shape = r.ufl_shape
-            r.assign(backend_Constant(r_arr),
-                     annotate=False, tlm=False)
+            r.assign(backend_Constant(r_arr))
             for i, r_c in enumerate(r.split(deepcopy=True)):
                 if r_c.vector().max() != i + 1:
                     valid = False
@@ -367,6 +369,7 @@ def verify_assembly(J, rhs, J_mat, b, bcs, form_compiler_parameters,
         assert (b - b_debug).norm("linf") <= b_tolerance * b_debug.norm("linf")
 
 
+@manager_disabled()
 def interpolate_expression(x, expr, *, adj_x=None):
     if adj_x is None:
         check_space_type(x, "primal")
@@ -398,7 +401,7 @@ def interpolate_expression(x, expr, *, adj_x=None):
             function_assign(x, value)
         elif isinstance(x, backend_Function):
             try:
-                x.assign(expr, annotate=False, tlm=False)
+                x.assign(expr)
             except RuntimeError:
                 x.interpolate(Expr())
         else:

--- a/tlm_adjoint/fenics/backend_overrides.py
+++ b/tlm_adjoint/fenics/backend_overrides.py
@@ -170,9 +170,9 @@ def extract_args_linear_solve(A, x, b,
 
 
 def solve(*args, annotate=None, tlm=None, **kwargs):
-    if annotate is None:
+    if annotate is None or annotate:
         annotate = annotation_enabled()
-    if tlm is None:
+    if tlm is None or tlm:
         tlm = tlm_enabled()
     if annotate or tlm:
         if isinstance(args[0], ufl.classes.Equation):
@@ -265,9 +265,9 @@ def solve(*args, annotate=None, tlm=None, **kwargs):
 def project(v, V=None, bcs=None, mesh=None, function=None, solver_type="lu",
             preconditioner_type="default", form_compiler_parameters=None, *,
             solver_parameters=None, annotate=None, tlm=None):
-    if annotate is None:
+    if annotate is None or annotate:
         annotate = annotation_enabled()
-    if tlm is None:
+    if tlm is None or tlm:
         tlm = tlm_enabled()
     if annotate or tlm or solver_parameters is not None:
         if function is None:
@@ -348,9 +348,9 @@ backend_DirichletBC.apply = _DirichletBC_apply
 
 
 def _Constant_assign(self, x, *, annotate=None, tlm=None):
-    if annotate is None:
+    if annotate is None or annotate:
         annotate = annotation_enabled()
-    if tlm is None:
+    if tlm is None or tlm:
         tlm = tlm_enabled()
     if annotate or tlm:
         if isinstance(x, (int, np.integer,
@@ -383,9 +383,9 @@ backend_Constant.assign = _Constant_assign
 
 
 def _Function_assign(self, rhs, *, annotate=None, tlm=None):
-    if annotate is None:
+    if annotate is None or annotate:
         annotate = annotation_enabled()
-    if tlm is None:
+    if tlm is None or tlm:
         tlm = tlm_enabled()
     if annotate or tlm:
         if isinstance(rhs, backend_Function) \
@@ -488,9 +488,9 @@ class LUSolver(backend_LUSolver):
             A = self._tlm_adjoint__A
             x, b = args
 
-        if annotate is None:
+        if annotate is None or annotate:
             annotate = annotation_enabled()
-        if tlm is None:
+        if tlm is None or tlm:
             tlm = tlm_enabled()
         if annotate or tlm:
             bcs = A._tlm_adjoint__bcs
@@ -560,9 +560,9 @@ class KrylovSolver(backend_KrylovSolver):
             A = self._tlm_adjoint__A
             x, b = args
 
-        if annotate is None:
+        if annotate is None or annotate:
             annotate = annotation_enabled()
-        if tlm is None:
+        if tlm is None or tlm:
             tlm = tlm_enabled()
         if annotate or tlm:
             bcs = A._tlm_adjoint__bcs
@@ -612,9 +612,9 @@ class LinearVariationalSolver(backend_LinearVariationalSolver):
     def solve(self, *, annotate=None, tlm=None):
         x = self._tlm_adjoint__problem.u_ufl
 
-        if annotate is None:
+        if annotate is None or annotate:
             annotate = annotation_enabled()
-        if tlm is None:
+        if tlm is None or tlm:
             tlm = tlm_enabled()
         if annotate or tlm:
             lhs = self._tlm_adjoint__problem.a_ufl
@@ -655,9 +655,9 @@ class NonlinearVariationalSolver(backend_NonlinearVariationalSolver):
     def solve(self, *, annotate=None, tlm=None):
         x = self._tlm_adjoint__problem.u_ufl
 
-        if annotate is None:
+        if annotate is None or annotate:
             annotate = annotation_enabled()
-        if tlm is None:
+        if tlm is None or tlm:
             tlm = tlm_enabled()
         if annotate or tlm:
             eq = EquationSolver(

--- a/tlm_adjoint/firedrake/backend.py
+++ b/tlm_adjoint/firedrake/backend.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 
 from firedrake import *
+from firedrake.assemble import FormAssembler  # noqa: F401
+from firedrake.projection import ProjectorBase  # noqa: F401
 from firedrake.utils import complex_mode  # noqa: F401
 import firedrake
 
@@ -10,17 +12,12 @@ backend = "Firedrake"
 backend_ScalarType = firedrake.utils.ScalarType.type
 
 extract_args = firedrake.solving._extract_args
-extract_linear_solver_args = firedrake.solving._extract_linear_solver_args
 
 backend_Constant = Constant
 backend_DirichletBC = DirichletBC
 backend_Function = Function
 backend_FunctionSpace = firedrake.functionspaceimpl.WithGeometry
-backend_LinearSolver = LinearSolver
-backend_LinearVariationalProblem = LinearVariationalProblem
-backend_LinearVariationalSolver = LinearVariationalSolver
 backend_Matrix = firedrake.matrix.Matrix
-backend_NonlinearVariationalSolver = NonlinearVariationalSolver
 backend_Vector = Vector
 backend_assemble = assemble
 backend_interpolate = interpolate

--- a/tlm_adjoint/firedrake/backend_overrides.py
+++ b/tlm_adjoint/firedrake/backend_overrides.py
@@ -2,24 +2,26 @@
 # -*- coding: utf-8 -*-
 
 from .backend import (
-    Interpolator, Parameters, Projector, backend_Constant, backend_DirichletBC,
-    backend_Function, backend_LinearSolver, backend_LinearVariationalProblem,
-    backend_LinearVariationalSolver, backend_NonlinearVariationalSolver,
-    backend_Vector, backend_assemble, backend_interpolate, backend_project,
-    backend_solve, extract_args, extract_linear_solver_args, parameters)
+    FormAssembler, Interpolator, LinearSolver, LinearVariationalProblem,
+    NonlinearVariationalSolver, Parameters, Projector, ProjectorBase,
+    backend_Constant, backend_DirichletBC, backend_Function, backend_Vector,
+    backend_assemble, backend_interpolate, backend_project, backend_solve,
+    parameters)
 from ..interface import (
-    check_space_type, function_comm, function_new, function_space,
-    function_update_state, is_function, space_id, space_new)
+    function_comm, function_new, function_space, function_update_state,
+    is_function, space_id, space_new)
 from .backend_code_generator_interface import (
     copy_parameters_dict, update_parameters_dict)
 
-from ..manager import annotation_enabled, paused_manager, tlm_enabled
-
 from ..equations import Assignment
+from ..override import (
+    add_manager_controls, manager_method, override_function, override_method,
+    override_property)
+
 from .equations import (
-    Assembly, EquationSolver, ExprEvaluation, Projection,
+    Assembly, EquationSolver, ExprEvaluation, Projection, expr_new_x,
     linear_equation_new_x)
-from .functions import Constant, extract_coefficients
+from .functions import Constant, define_function_alias
 from .firedrake_equations import LocalProjection
 
 import numpy as np
@@ -27,10 +29,6 @@ import ufl
 
 __all__ = \
     [
-        "LinearSolver",
-        "LinearVariationalProblem",
-        "LinearVariationalSolver",
-        "NonlinearVariationalSolver",
         "assemble",
         "interpolate",
         "project",
@@ -39,9 +37,9 @@ __all__ = \
 
 
 def parameters_dict_equal(parameters_a, parameters_b):
+    if set(parameters_a) != set(parameters_b):
+        return False
     for key_a, value_a in parameters_a.items():
-        if key_a not in parameters_b:
-            return False
         value_b = parameters_b[key_a]
         if isinstance(value_a, (Parameters, dict)):
             if not isinstance(value_b, (Parameters, dict)):
@@ -50,596 +48,349 @@ def parameters_dict_equal(parameters_a, parameters_b):
                 return False
         elif value_a != value_b:
             return False
-    for key_b in parameters_b:
-        if key_b not in parameters_a:
-            return False
     return True
 
 
 def packed_solver_parameters(solver_parameters, *, options_prefix=None,
                              nullspace=None, transpose_nullspace=None,
                              near_nullspace=None):
-    if options_prefix is not None or nullspace is not None \
-       or transpose_nullspace is not None or near_nullspace is not None:
-        solver_parameters = dict(solver_parameters)
-        if "tlm_adjoint" in solver_parameters:
-            tlm_adjoint_parameters = solver_parameters["tlm_adjoint"] = \
-                dict(solver_parameters["tlm_adjoint"])
-        else:
-            tlm_adjoint_parameters = solver_parameters["tlm_adjoint"] = {}
+    solver_parameters = dict(solver_parameters)
+    tlm_adjoint_parameters = solver_parameters["tlm_adjoint"] = \
+        dict(solver_parameters.get("tlm_adjoint", {}))
 
-        if options_prefix is not None:
-            if "options_prefix" in tlm_adjoint_parameters:
-                raise TypeError("Cannot pass both options_prefix argument and "
-                                "solver parameter")
-            tlm_adjoint_parameters["options_prefix"] = options_prefix
+    def set_parameter(key, value):
+        if value is not None:
+            if key in tlm_adjoint_parameters:
+                raise TypeError(f"Cannot pass both {key:s} argument and "
+                                f"solver parameter")
+            tlm_adjoint_parameters[key] = value
 
-        if nullspace is not None:
-            if "nullspace" in tlm_adjoint_parameters:
-                raise TypeError("Cannot pass both nullspace argument and "
-                                "solver parameter")
-            tlm_adjoint_parameters["nullspace"] = nullspace
-
-        if transpose_nullspace is not None:
-            if "transpose_nullspace" in tlm_adjoint_parameters:
-                raise TypeError("Cannot pass both transpose_nullspace "
-                                "argument and solver parameter")
-            tlm_adjoint_parameters["transpose_nullspace"] = transpose_nullspace
-
-        if near_nullspace is not None:
-            if "near_nullspace" in tlm_adjoint_parameters:
-                raise TypeError("Cannot pass both near_nullspace argument and "
-                                "solver parameter")
-            tlm_adjoint_parameters["near_nullspace"] = near_nullspace
+    set_parameter("options_prefix", options_prefix)
+    set_parameter("nullspace", nullspace)
+    set_parameter("transpose_nullspace", transpose_nullspace)
+    set_parameter("near_nullspace", near_nullspace)
 
     return solver_parameters
 
 
-def extract_args_assemble_form(form, tensor=None, bcs=None, *,
-                               form_compiler_parameters=None, **kwargs):
-    return form, tensor, bcs, form_compiler_parameters, kwargs
-
-
 # Aim for compatibility with Firedrake API, git master revision
-# bc79502544ca78c06d60532c2d674b7808aef0af, Mar 30 2022
-def assemble(expr, *args, annotate=None, tlm=None, **kwargs):
-    if not isinstance(expr, ufl.classes.Form):
-        return backend_assemble(expr, *args, **kwargs)
-
-    form, tensor, bcs, form_compiler_parameters, kwargs = \
-        extract_args_assemble_form(expr, *args, **kwargs)
-
-    if tensor is not None and isinstance(tensor, backend_Function):
-        check_space_type(tensor, "conjugate_dual")
-
-    b = backend_assemble(
-        form, tensor=tensor, bcs=bcs,
-        form_compiler_parameters=form_compiler_parameters,
-        **kwargs)
-
-    if tensor is not None and isinstance(tensor, backend_Function):
-        function_update_state(tensor)
-    if tensor is None and isinstance(b, backend_Function):
-        b._tlm_adjoint__function_interface_attrs.d_setitem("space_type", "conjugate_dual")  # noqa: E501
-
-    arity = len(form.arguments())
-    if arity != 0:
-        form_compiler_parameters_ = copy_parameters_dict(parameters["form_compiler"])  # noqa: E501
-        if form_compiler_parameters is not None:
-            update_parameters_dict(form_compiler_parameters_,
-                                   form_compiler_parameters)
-        form_compiler_parameters = form_compiler_parameters_
-
-        if arity == 1:
-            if annotate is None:
-                annotate = annotation_enabled()
-            if tlm is None:
-                tlm = tlm_enabled()
-            if annotate or tlm:
-                eq = Assembly(
-                    b, form,
-                    form_compiler_parameters=form_compiler_parameters)
-                eq._post_process(annotate=annotate, tlm=tlm)
-
-            b._tlm_adjoint__form = form
-        b._tlm_adjoint__form_compiler_parameters = form_compiler_parameters
-
-    return b
+# a94b01c4b3361db9c73056d92fdbd01a5bc6d1aa, Jun 16 2023
 
 
-def extract_args_linear_solve(A, x, b, *args, **kwargs):
-    (bcs,
-     solver_parameters,
-     nullspace, transpose_nullspace, near_nullspace,
-     options_prefix) = extract_linear_solver_args(A, x, b, *args, **kwargs)
+def FormAssembler_assemble_post_call(self, return_value, *args, **kwargs):
+    if is_function(return_value):
+        function_update_state(return_value)
+
+    if len(self._form.arguments()) > 0:
+        form_compiler_parameters = copy_parameters_dict(parameters["form_compiler"])  # noqa: E501
+        update_parameters_dict(form_compiler_parameters,
+                               self._form_compiler_params)
+
+        return_value._tlm_adjoint__form = self._form
+        return_value._tlm_adjoint__form_compiler_parameters = form_compiler_parameters  # noqa: E501
+
+    return return_value
+
+
+@manager_method(FormAssembler, "assemble",
+                post_call=FormAssembler_assemble_post_call)
+def FormAssembler_assemble(self, orig, orig_args, *args,
+                           annotate, tlm, **kwargs):
+    return_value = orig_args()
+
+    if len(self._form.arguments()) == 1:
+        eq = Assembly(return_value, return_value._tlm_adjoint__form,
+                      form_compiler_parameters=return_value._tlm_adjoint__form_compiler_parameters)  # noqa: E501
+        assert len(eq.initial_condition_dependencies()) == 0
+        eq._post_process(annotate=annotate, tlm=tlm)
+
+    return return_value
+
+
+def function_update_state_post_call(self, return_value, *args, **kwargs):
+    function_update_state(self)
+    return return_value
+
+
+@manager_method(backend_Constant, "assign",
+                post_call=function_update_state_post_call)
+def Constant_assign(self, orig, orig_args, value, *, annotate, tlm):
+    if isinstance(value, (int, np.integer,
+                          float, np.floating,
+                          complex, np.complexfloating)):
+        eq = Assignment(self, Constant(value, comm=function_comm(self)))
+    elif isinstance(value, backend_Constant):
+        if value is not self:
+            eq = Assignment(self, value)
+        else:
+            eq = None
+    elif isinstance(value, ufl.classes.Expr):
+        eq = ExprEvaluation(
+            self, expr_new_x(value, self, annotate=annotate, tlm=tlm))
+    else:
+        raise TypeError(f"Unexpected type: {type(value)}")
+
+    if eq is not None:
+        assert len(eq.initial_condition_dependencies()) == 0
+    return_value = orig_args()
+    if eq is not None:
+        eq._post_process(annotate=annotate, tlm=tlm)
+    return return_value
+
+
+@manager_method(backend_Function, "assign",
+                post_call=function_update_state_post_call)
+def Function_assign(self, orig, orig_args, expr, subset=None, *,
+                    annotate, tlm):
+    if subset is not None:
+        raise NotImplementedError("subset not supported")
+
+    if isinstance(expr, (int, np.integer,
+                         float, np.floating,
+                         complex, np.complexfloating)):
+        eq = Assignment(self, Constant(expr, comm=function_comm(self)))
+    elif isinstance(expr, backend_Function) \
+            and space_id(function_space(expr)) == space_id(function_space(self)):  # noqa: E501
+        if expr is not self:
+            eq = Assignment(self, expr)
+        else:
+            eq = None
+    elif isinstance(expr, ufl.classes.Expr):
+        eq = ExprEvaluation(
+            self, expr_new_x(expr, self, annotate=annotate, tlm=tlm))
+    else:
+        raise TypeError(f"Unexpected type: {type(expr)}")
+
+    if eq is not None:
+        assert len(eq.initial_condition_dependencies()) == 0
+    return_value = orig_args()
+    if eq is not None:
+        eq._post_process(annotate=annotate, tlm=tlm)
+    return return_value
+
+
+@manager_method(backend_Function, "project",
+                post_call=function_update_state_post_call)
+def Function_project(self, orig, orig_args, b, bcs=None,
+                     solver_parameters=None, form_compiler_parameters=None,
+                     use_slate_for_inverse=True, name=None, ad_block_tag=None,
+                     *, annotate, tlm):
+    if use_slate_for_inverse:
+        # Is a local solver actually used?
+        projector = Projector(
+            b, function_space(self), bcs=bcs,
+            solver_parameters=solver_parameters,
+            form_compiler_parameters=form_compiler_parameters,
+            use_slate_for_inverse=True)
+        use_slate_for_inverse = getattr(projector,
+                                        "use_slate_for_inverse", False)
+
+    if use_slate_for_inverse:
+        if bcs is not None and (isinstance(bcs, backend_DirichletBC)
+                                or len(bcs) > 0):
+            raise NotImplementedError("Boundary conditions not supported")
+        eq = LocalProjection(
+            self, expr_new_x(b, self, annotate=annotate, tlm=tlm),
+            form_compiler_parameters=form_compiler_parameters,
+            cache_jacobian=False, cache_rhs_assembly=False)
+    else:
+        eq = Projection(
+            self, expr_new_x(b, self, annotate=annotate, tlm=tlm), bcs,
+            solver_parameters=solver_parameters,
+            form_compiler_parameters=form_compiler_parameters,
+            cache_jacobian=False, cache_rhs_assembly=False)
+
+    eq._pre_process(annotate=annotate)
+    return_value = orig_args()
+    eq._post_process(annotate=annotate, tlm=tlm)
+    return return_value
+
+
+@manager_method(backend_Function, "copy", override_without_manager=True)
+def Function_copy(self, orig, orig_args, deepcopy=False, *, annotate, tlm):
+    if deepcopy:
+        F = function_new(self)
+        F.assign(self, annotate=annotate, tlm=tlm)
+    else:
+        F = orig_args()
+        define_function_alias(F, self, key="copy")
+    return F
+
+
+@manager_method(backend_Function, "interpolate")
+def Function_interpolate(self, orig, orig_args, expression, subset=None,
+                         ad_block_tag=None, *, annotate, tlm):
+    return interpolate(
+        expression, self, subset=subset, ad_block_tag=ad_block_tag,
+        annotate=annotate, tlm=tlm)
+
+
+def LinearSolver_solve_post_call(self, return_value, x, b):
+    if isinstance(x, backend_Vector):
+        x = x.function
+    if isinstance(b, backend_Vector):
+        b = b.function
+    function_update_state(x)
+    function_update_state(b)
+    return return_value
+
+
+@manager_method(LinearSolver, "solve",
+                post_call=LinearSolver_solve_post_call)
+def LinearSolver_solve(self, orig, orig_args, x, b, *, annotate, tlm):
+    if self.P is not self.A:
+        raise NotImplementedError("Preconditioners not supported")
 
     if isinstance(x, backend_Vector):
         x = x.function
     if isinstance(b, backend_Vector):
         b = b.function
-    if bcs is not None:
-        raise TypeError("Unexpected boundary conditions")
 
-    return (A, x, b,
-            solver_parameters,
-            nullspace, transpose_nullspace, near_nullspace,
-            options_prefix)
+    A = self.A
+    bcs = A.bcs
+    solver_parameters = packed_solver_parameters(
+        self.parameters, options_prefix=self.options_prefix,
+        nullspace=self.nullspace, transpose_nullspace=self.transpose_nullspace,
+        near_nullspace=self.near_nullspace)
+    form_compiler_parameters = A._tlm_adjoint__form_compiler_parameters
+    if not parameters_dict_equal(
+            b._tlm_adjoint__form_compiler_parameters,
+            form_compiler_parameters):
+        raise ValueError("Non-matching form compiler parameters")
 
+    eq = EquationSolver(
+        linear_equation_new_x(A.a == b._tlm_adjoint__form, x,
+                              annotate=annotate, tlm=tlm),
+        x, bcs, solver_parameters=solver_parameters,
+        form_compiler_parameters=form_compiler_parameters,
+        cache_jacobian=False, cache_rhs_assembly=False)
 
-# Aim for compatibility with Firedrake API, git master revision
-# bc79502544ca78c06d60532c2d674b7808aef0af, Mar 30 2022
-def solve(*args, annotate=None, tlm=None, **kwargs):
-    if annotate is None:
-        annotate = annotation_enabled()
-    if tlm is None:
-        tlm = tlm_enabled()
-    if annotate or tlm:
-        if isinstance(args[0], ufl.classes.Equation):
-            (eq_arg, x, bcs,
-             J, Jp,
-             M,
-             form_compiler_parameters, solver_parameters,
-             nullspace, transpose_nullspace, near_nullspace,
-             options_prefix) = extract_args(*args, **kwargs)
-            if bcs is None:
-                bcs = ()
-            elif isinstance(bcs, backend_DirichletBC):
-                bcs = (bcs,)
-            if form_compiler_parameters is None:
-                form_compiler_parameters = {}
-            if solver_parameters is None:
-                solver_parameters = {}
-
-            if isinstance(eq_arg.rhs, ufl.classes.Form) \
-                    and (x in extract_coefficients(eq_arg.lhs)
-                         or x in extract_coefficients(eq_arg.rhs)):
-                # See Firedrake issue #2555
-                raise ValueError("Invalid dependency")
-            if Jp is not None:
-                raise NotImplementedError("Preconditioners not supported")
-            if M is not None:
-                raise NotImplementedError("Adaptive solves not supported")
-
-            solver_parameters = packed_solver_parameters(
-                solver_parameters, options_prefix=options_prefix,
-                nullspace=nullspace, transpose_nullspace=transpose_nullspace,
-                near_nullspace=near_nullspace)
-
-            eq = EquationSolver(
-                eq_arg, x, bcs, J=J,
-                form_compiler_parameters=form_compiler_parameters,
-                solver_parameters=solver_parameters, cache_jacobian=False,
-                cache_rhs_assembly=False)
-            eq.solve(annotate=annotate, tlm=tlm)
-        else:
-            (A, x, b,
-             solver_parameters,
-             nullspace, transpose_nullspace, near_nullspace,
-             options_prefix) = extract_args_linear_solve(*args, **kwargs)
-            if solver_parameters is None:
-                solver_parameters = {}
-
-            A = A.a
-            b = b._tlm_adjoint__form
-
-            bcs = A.bcs
-
-            solver_parameters = packed_solver_parameters(
-                solver_parameters, options_prefix=options_prefix,
-                nullspace=nullspace, transpose_nullspace=transpose_nullspace,
-                near_nullspace=near_nullspace)
-
-            form_compiler_parameters = A._tlm_adjoint__form_compiler_parameters
-            if not parameters_dict_equal(
-                    b._tlm_adjoint__form_compiler_parameters,
-                    form_compiler_parameters):
-                raise ValueError("Non-matching form compiler parameters")
-
-            eq = EquationSolver(
-                linear_equation_new_x(A == b, x,
-                                      annotate=annotate, tlm=tlm),
-                x, bcs, solver_parameters=solver_parameters,
-                form_compiler_parameters=form_compiler_parameters,
-                cache_jacobian=False, cache_rhs_assembly=False)
-            eq.solve(annotate=annotate, tlm=tlm)
-    else:
-        backend_solve(*args, **kwargs)
-        if isinstance(args[0], ufl.classes.Equation):
-            x = extract_args(*args, **kwargs)[1]
-            function_update_state(x)
-        else:
-            (_, x, b,
-             _,
-             _, _, _,
-             _) = extract_args_linear_solve(*args, **kwargs)
-            function_update_state(x)
-            function_update_state(b)
-
-
-# Aim for compatibility with Firedrake API, git master revision
-# bc79502544ca78c06d60532c2d674b7808aef0af, Mar 30 2022
-def project(v, V, bcs=None, solver_parameters=None,
-            form_compiler_parameters=None, use_slate_for_inverse=True,
-            name=None, ad_block_tag=None, *, annotate=None, tlm=None):
-    if annotate is None:
-        annotate = annotation_enabled()
-    if tlm is None:
-        tlm = tlm_enabled()
-    if annotate or tlm:
-        if use_slate_for_inverse:
-            # Is a local solver actually used?
-            projector = Projector(
-                v, V, bcs=bcs, solver_parameters=solver_parameters,
-                form_compiler_parameters=form_compiler_parameters,
-                use_slate_for_inverse=True)
-            use_slate_for_inverse = getattr(projector,
-                                            "use_slate_for_inverse", False)
-        if isinstance(V, backend_Function):
-            x = V
-        else:
-            x = space_new(V, name=name)
-        if bcs is None:
-            bcs = ()
-        elif isinstance(bcs, backend_DirichletBC):
-            bcs = (bcs,)
-        if solver_parameters is None:
-            solver_parameters = {}
-        if form_compiler_parameters is None:
-            form_compiler_parameters = {}
-        if x in extract_coefficients(v):
-            x_old = function_new(x)
-            Assignment(x_old, x).solve(annotate=annotate, tlm=tlm)
-            v = ufl.replace(v, {x: x_old})
-        if use_slate_for_inverse:
-            if len(bcs) > 0:
-                raise NotImplementedError("Boundary conditions not supported")
-            eq = LocalProjection(
-                x, v, form_compiler_parameters=form_compiler_parameters,
-                cache_jacobian=False, cache_rhs_assembly=False)
-            eq.solve(annotate=annotate, tlm=tlm)
-        else:
-            eq = Projection(
-                x, v, bcs, solver_parameters=solver_parameters,
-                form_compiler_parameters=form_compiler_parameters,
-                cache_jacobian=False, cache_rhs_assembly=False)
-            eq.solve(annotate=annotate, tlm=tlm)
-    else:
-        x = backend_project(
-            v, V, bcs=bcs, solver_parameters=solver_parameters,
-            form_compiler_parameters=form_compiler_parameters,
-            use_slate_for_inverse=use_slate_for_inverse, name=name,
-            ad_block_tag=ad_block_tag)
-        function_update_state(x)
-    return x
-
-
-# Aim for compatibility with Firedrake API, git master revision
-# bc79502544ca78c06d60532c2d674b7808aef0af, Mar 30 2022
-def _Constant_assign(self, value, *, annotate=None, tlm=None):
-    if annotate is None:
-        annotate = annotation_enabled()
-    if tlm is None:
-        tlm = tlm_enabled()
-    if annotate or tlm:
-        if isinstance(value, (int, np.integer,
-                              float, np.floating,
-                              complex, np.complexfloating)):
-            Assignment(self, Constant(value, comm=function_comm(self))).solve(
-                annotate=annotate, tlm=tlm)
-            return
-        elif isinstance(value, backend_Constant):
-            if value is not self:
-                Assignment(self, value).solve(annotate=annotate, tlm=tlm)
-                return
-        elif isinstance(value, ufl.classes.Expr):
-            if self in extract_coefficients(value):
-                self_old = function_new(self)
-                Assignment(self_old, self).solve(
-                    annotate=annotate, tlm=tlm)
-                value = ufl.replace(value, {self: self_old})
-            ExprEvaluation(self, value).solve(annotate=annotate, tlm=tlm)
-            return
-
-    return_value = backend_Constant._tlm_adjoint__orig_assign(
-        self, value)
-    function_update_state(self)
+    eq._pre_process(annotate=annotate)
+    return_value = orig_args()
+    eq._post_process(annotate=annotate, tlm=tlm)
     return return_value
 
 
-assert not hasattr(backend_Constant, "_tlm_adjoint__orig_assign")
-backend_Constant._tlm_adjoint__orig_assign = backend_Constant.assign
-backend_Constant.assign = _Constant_assign
+@override_method(LinearVariationalProblem, "__init__")
+def LinearVariationalProblem__init__(self, orig, orig_args, a, L,
+                                     *args, **kwargs):
+    orig_args()
+    self._tlm_adjoint__b = L
 
 
-# Aim for compatibility with Firedrake API, git master revision
-# bc79502544ca78c06d60532c2d674b7808aef0af, Mar 30 2022
-def _Function_assign(self, expr, subset=None, *, annotate=None, tlm=None):
-    if subset is None:
-        if annotate is None:
-            annotate = annotation_enabled()
-        if tlm is None:
-            tlm = tlm_enabled()
-        if annotate or tlm:
-            if isinstance(expr, (int, np.integer,
-                                 float, np.floating,
-                                 complex, np.complexfloating)):
-                expr = Constant(expr, comm=function_comm(self))
-            if isinstance(expr, backend_Function) \
-                    and space_id(function_space(expr)) == space_id(function_space(self)):  # noqa: E501
-                if expr is not self:
-                    Assignment(self, expr).solve(
-                        annotate=annotate, tlm=tlm)
-                    return self
-            elif isinstance(expr, ufl.classes.Expr):
-                if self in extract_coefficients(expr):
-                    self_old = function_new(self)
-                    Assignment(self_old, self).solve(
-                        annotate=annotate, tlm=tlm)
-                    expr = ufl.replace(expr, {self: self_old})
-                ExprEvaluation(self, expr).solve(
-                    annotate=annotate, tlm=tlm)
-                return self
+@override_method(NonlinearVariationalSolver, "__init__")
+def NonlinearVariationalSolver__init__(
+        self, orig, orig_args, problem, *, appctx=None,
+        pre_jacobian_callback=None, post_jacobian_callback=None,
+        pre_function_callback=None, post_function_callback=None, **kwargs):
+    orig_args()
+    self._tlm_adjoint__appctx = {} if appctx is None else appctx
+    self._tlm_adjoint__pre_jacobian_callback = pre_jacobian_callback
+    self._tlm_adjoint__post_jacobian_callback = post_jacobian_callback
+    self._tlm_adjoint__pre_function_callback = pre_function_callback
+    self._tlm_adjoint__post_function_callback = post_function_callback
+    self._tlm_adjoint__transfer_manager = None
 
-    return_value = backend_Function._tlm_adjoint__orig_assign(
-        self, expr, subset=subset)
-    function_update_state(self)
+
+@override_method(NonlinearVariationalSolver, "set_transfer_manager")
+def NonlinearVariationalSolver_set_transfer_manager(
+        self, orig, orig_args, manager):
+    orig_args()
+    self._tlm_adjoint__transfer_manager = manager
+
+
+def NonlinearVariationalSolver_solve_post_call(
+        self, return_value, *args, **kwargs):
+    function_update_state(self._problem.u)
     return return_value
 
 
-assert not hasattr(backend_Function, "_tlm_adjoint__orig_assign")
-backend_Function._tlm_adjoint__orig_assign = backend_Function.assign
-backend_Function.assign = _Function_assign
-
-
-# Aim for compatibility with Firedrake API, git master revision
-# bc79502544ca78c06d60532c2d674b7808aef0af, Mar 30 2022
-def _Function_project(self, b, *args, **kwargs):
-    return project(b, self, *args, **kwargs)
-
-
-assert not hasattr(backend_Function, "_tlm_adjoint__orig_project")
-backend_Function._tlm_adjoint__orig_project = backend_Function.project
-backend_Function.project = _Function_project
-
-
-# Aim for compatibility with Firedrake API, git master revision
-# bc79502544ca78c06d60532c2d674b7808aef0af, Mar 30 2022
-class LinearSolver(backend_LinearSolver):
-    def __init__(self, A, *, P=None, **kwargs):
-        if P is not None:
-            raise NotImplementedError("Preconditioners not supported")
-
-        super().__init__(A, P=P, **kwargs)
-
-    def solve(self, x, b, *, annotate=None, tlm=None):
-        if isinstance(x, backend_Vector):
-            x = x.function
-        if isinstance(b, backend_Vector):
-            b = b.function
-
-        if annotate is None:
-            annotate = annotation_enabled()
-        if tlm is None:
-            tlm = tlm_enabled()
-        if annotate or tlm:
-            A = self.A
-            bcs = A.bcs
-            solver_parameters = packed_solver_parameters(
-                self.parameters, options_prefix=self.options_prefix,
-                nullspace=self.nullspace,
-                transpose_nullspace=self.transpose_nullspace,
-                near_nullspace=self.near_nullspace)
-            form_compiler_parameters = A._tlm_adjoint__form_compiler_parameters
-            if not parameters_dict_equal(
-                    b._tlm_adjoint__form_compiler_parameters,
-                    form_compiler_parameters):
-                raise ValueError("Non-matching form compiler parameters")
-
-            eq = EquationSolver(
-                linear_equation_new_x(A.a == b._tlm_adjoint__form, x,
-                                      annotate=annotate, tlm=tlm),
-                x, bcs, solver_parameters=solver_parameters,
-                form_compiler_parameters=form_compiler_parameters,
-                cache_jacobian=False, cache_rhs_assembly=False)
-
-            eq._pre_process(annotate=annotate)
-            super().solve(x, b)
-            function_update_state(x)
-            function_update_state(b)
-            eq._post_process(annotate=annotate, tlm=tlm)
-        else:
-            super().solve(x, b)
-            function_update_state(x)
-            function_update_state(b)
-
-
-# Aim for compatibility with Firedrake API, git master revision
-# bc79502544ca78c06d60532c2d674b7808aef0af, Mar 30 2022
-class LinearVariationalProblem(backend_LinearVariationalProblem):
-    def __init__(self, a, L, *args, **kwargs):
-        super().__init__(a, L, *args, **kwargs)
-        self._tlm_adjoint__b = L
-
-
-# Aim for compatibility with Firedrake API, git master revision
-# bc79502544ca78c06d60532c2d674b7808aef0af, Mar 30 2022
-class LinearVariationalSolver(backend_LinearVariationalSolver):
-    def __init__(self, problem, *, appctx=None, pre_jacobian_callback=None,
-                 post_jacobian_callback=None, pre_function_callback=None,
-                 post_function_callback=None, **kwargs):
-        if appctx is not None:
-            raise NotImplementedError("Preconditioners not supported")
-        if pre_jacobian_callback is not None \
-                or post_jacobian_callback is not None \
-                or pre_function_callback is not None \
-                or post_function_callback is not None:
-            raise NotImplementedError("Callbacks not supported")
-
-        super().__init__(
-            problem, appctx=appctx,
-            pre_jacobian_callback=pre_jacobian_callback,
-            post_jacobian_callback=post_jacobian_callback,
-            pre_function_callback=pre_function_callback,
-            post_function_callback=post_function_callback, **kwargs)
-
-    def set_transfer_manager(self, *args, **kwargs):
+@manager_method(NonlinearVariationalSolver, "solve",
+                post_call=NonlinearVariationalSolver_solve_post_call)
+def NonlinearVariationalSolver_solve(
+        self, orig, orig_args, bounds=None, *, annotate, tlm):
+    if len(set(self._tlm_adjoint__appctx).difference({"state", "form_compiler_parameters"})) > 0:  # noqa: E501
+        raise NotImplementedError("appctx not supported")
+    if self._tlm_adjoint__pre_jacobian_callback is not None \
+            or self._tlm_adjoint__post_jacobian_callback is not None \
+            or self._tlm_adjoint__pre_function_callback is not None \
+            or self._tlm_adjoint__post_function_callback is not None:
+        raise NotImplementedError("Callbacks not supported")
+    if self._tlm_adjoint__transfer_manager is not None:
         raise NotImplementedError("Transfer managers not supported")
+    if bounds is not None:
+        raise NotImplementedError("Bounds not supported")
+    if self._problem.Jp is not None:
+        raise NotImplementedError("Preconditioners not supported")
 
-    def solve(self, bounds=None, *, annotate=None, tlm=None):
-        x = self._problem.u
+    solver_parameters = packed_solver_parameters(
+        self.parameters, options_prefix=self.options_prefix,
+        nullspace=self._ctx._nullspace,
+        transpose_nullspace=self._ctx._nullspace_T,
+        near_nullspace=self._ctx._near_nullspace)
+    form_compiler_parameters = self._problem.form_compiler_parameters
 
-        if annotate is None:
-            annotate = annotation_enabled()
-        if tlm is None:
-            tlm = tlm_enabled()
-        if annotate or tlm:
-            if bounds is not None:
-                raise NotImplementedError("Bounds not supported")
-            if self._problem.Jp is not None:
-                raise NotImplementedError("Preconditioners not supported")
+    eq = EquationSolver(
+        self._problem.F == 0, self._problem.u, self._problem.bcs,
+        J=self._problem.J, solver_parameters=solver_parameters,
+        form_compiler_parameters=form_compiler_parameters,
+        cache_jacobian=False, cache_rhs_assembly=False)
 
-            solver_parameters = packed_solver_parameters(
-                self.parameters, options_prefix=self.options_prefix,
-                nullspace=self._ctx._nullspace,
-                transpose_nullspace=self._ctx._nullspace_T,
-                near_nullspace=self._ctx._near_nullspace)
-            form_compiler_parameters = self._problem.form_compiler_parameters
-            if form_compiler_parameters is None:
-                form_compiler_parameters = {}
-
-            A = self._problem.J
-            b = self._problem._tlm_adjoint__b
-            if x in extract_coefficients(A) or x in extract_coefficients(b):
-                # See Firedrake issue #2555
-                raise ValueError("Invalid dependency")
-
-            eq = EquationSolver(
-                A == b, x, self._problem.bcs,
-                solver_parameters=solver_parameters,
-                form_compiler_parameters=form_compiler_parameters,
-                cache_jacobian=self._problem._constant_jacobian,
-                cache_rhs_assembly=False)
-            eq.solve(annotate=annotate, tlm=tlm)
-        else:
-            super().solve(bounds=bounds)
-            function_update_state(x)
+    eq._pre_process(annotate=annotate)
+    return_value = orig_args()
+    eq._post_process(annotate=annotate, tlm=tlm)
+    return return_value
 
 
-# Aim for compatibility with Firedrake API, git master revision
-# bc79502544ca78c06d60532c2d674b7808aef0af, Mar 30 2022
-class NonlinearVariationalSolver(backend_NonlinearVariationalSolver):
-    def __init__(self, problem, *, appctx=None, pre_jacobian_callback=None,
-                 post_jacobian_callback=None, pre_function_callback=None,
-                 post_function_callback=None, **kwargs):
-        if appctx is not None:
-            raise NotImplementedError("Preconditioners not supported")
-        if pre_jacobian_callback is not None \
-                or post_jacobian_callback is not None \
-                or pre_function_callback is not None \
-                or post_function_callback is not None:
-            raise NotImplementedError("Callbacks not supported")
-
-        super().__init__(
-            problem, appctx=appctx,
-            pre_jacobian_callback=pre_jacobian_callback,
-            post_jacobian_callback=post_jacobian_callback,
-            pre_function_callback=pre_function_callback,
-            post_function_callback=post_function_callback, **kwargs)
-
-    def set_transfer_manager(self, *args, **kwargs):
-        raise NotImplementedError("Transfer managers not supported")
-
-    def solve(self, bounds=None, *, annotate=None, tlm=None):
-        if annotate is None:
-            annotate = annotation_enabled()
-        if tlm is None:
-            tlm = tlm_enabled()
-        if annotate or tlm:
-            if bounds is not None:
-                raise NotImplementedError("Bounds not supported")
-            if self._problem.Jp is not None:
-                raise NotImplementedError("Preconditioners not supported")
-
-            solver_parameters = packed_solver_parameters(
-                self.parameters, options_prefix=self.options_prefix,
-                nullspace=self._ctx._nullspace,
-                transpose_nullspace=self._ctx._nullspace_T,
-                near_nullspace=self._ctx._near_nullspace)
-            form_compiler_parameters = self._problem.form_compiler_parameters
-            if form_compiler_parameters is None:
-                form_compiler_parameters = {}
-
-            eq = EquationSolver(
-                self._problem.F == 0, self._problem.u, self._problem.bcs,
-                J=self._problem.J, solver_parameters=solver_parameters,
-                form_compiler_parameters=form_compiler_parameters,
-                cache_jacobian=False, cache_rhs_assembly=False)
-            eq.solve(annotate=annotate, tlm=tlm)
-        else:
-            super().solve(bounds=bounds)
-            function_update_state(self._problem.u)
+@override_property(ProjectorBase, "residual", cached=True)
+def ProjectorBase_residual(self, orig):
+    residual = orig()
+    residual._tlm_adjoint__function_interface_attrs.d_setitem("space_type", "conjugate_dual")  # noqa: E501
+    return residual
 
 
-# Aim for compatibility with Firedrake API, git master revision
-# b195b5c9c05dd2eaa6e920f46af730a0d715e116, Feb 24 2023
-def _Interpolator_interpolate(self, *function, output=None, transpose=False,
-                              annotate=None, tlm=None, **kwargs):
-    if annotate is None:
-        annotate = annotation_enabled()
-    if tlm is None:
-        tlm = tlm_enabled()
-    if annotate or tlm:
-        if transpose:
-            raise NotImplementedError("transpose not supported")
+def Interpolator_interpolate_post_call(self, return_value, *args, **kwargs):
+    function_update_state(return_value)
+    return return_value
 
-        args = ufl.algorithms.extract_arguments(self.expr)
-        if len(args) != len(function):
-            raise TypeError("Unexpected number of functions")
-        expr = ufl.replace(self.expr, dict(zip(args, function)))
 
-        if output is None:
-            if is_function(self.V):
-                output = self.V
-            else:
-                output = space_new(self.V)
+@manager_method(Interpolator, "interpolate",
+                post_call=Interpolator_interpolate_post_call)
+def Interpolator_interpolate(
+        self, orig, orig_args, *function, output=None, transpose=False,
+        annotate, tlm, **kwargs):
+    if transpose:
+        raise NotImplementedError("transpose not supported")
 
-        eq = ExprEvaluation(output, expr)
-        eq._pre_process(annotate=annotate)
-        Interpolator._tlm_adjoint__orig_interpolate(
-            self, *function, output=output, transpose=transpose,
-            **kwargs)
-        eq._post_process(annotate=annotate, tlm=tlm)
+    return_value = orig_args()
+
+    args = ufl.algorithms.extract_arguments(self.expr)
+    if len(args) != len(function):
+        raise TypeError("Unexpected number of functions")
+    expr = ufl.replace(self.expr, dict(zip(args, function)))
+    eq = ExprEvaluation(return_value, expr)
+
+    assert len(eq.initial_condition_dependencies()) == 0
+    eq._post_process(annotate=annotate, tlm=tlm)
+    return return_value
+
+
+@add_manager_controls
+@override_function(backend_assemble)
+def assemble(orig, orig_args, expr, *args, **kwargs):
+    if isinstance(expr, ufl.classes.Form):
+        def assemble_form(form, tensor=None, *args, **kwargs):
+            if len(form.arguments()) == 1 and tensor is None:
+                test, = form.arguments()
+                tensor = space_new(test.function_space(),
+                                   space_type="conjugate_dual")
+            return orig(form, tensor, *args, **kwargs)
+
+        return assemble_form(expr, *args, **kwargs)
     else:
-        output = Interpolator._tlm_adjoint__orig_interpolate(
-            self, *function, output=output, transpose=transpose,
-            **kwargs)
-        function_update_state(output)
-    return output
+        return orig_args()
 
 
-assert not hasattr(Interpolator, "_tlm_adjoint__orig_interpolate")
-Interpolator._tlm_adjoint__orig_interpolate = Interpolator.interpolate
-Interpolator.interpolate = _Interpolator_interpolate
-
-
-def _Function_interpolate(*args, annotate=None, tlm=None, **kwargs):
-    if annotate is None:
-        annotate = annotation_enabled()
-    if tlm is None:
-        tlm = tlm_enabled()
-    with paused_manager(annotate=not annotate, tlm=not tlm):
-        return backend_Function._tlm_adjoint__orig_interpolate(*args, **kwargs)
-
-
-assert not hasattr(backend_Function, "_tlm_adjoint__orig_interpolate")
-backend_Function._tlm_adjoint__orig_interpolate = backend_Function.interpolate
-backend_Function.interpolate = _Function_interpolate
-
-
-def interpolate(*args, annotate=None, tlm=None, **kwargs):
-    if annotate is None:
-        annotate = annotation_enabled()
-    if tlm is None:
-        tlm = tlm_enabled()
-    with paused_manager(annotate=not annotate, tlm=not tlm):
-        return backend_interpolate(*args, **kwargs)
+solve = add_manager_controls(backend_solve)
+project = add_manager_controls(backend_project)
+interpolate = add_manager_controls(backend_interpolate)

--- a/tlm_adjoint/firedrake/firedrake_equations.py
+++ b/tlm_adjoint/firedrake/firedrake_equations.py
@@ -16,7 +16,6 @@ from .backend_code_generator_interface import assemble, matrix_multiply
 
 from ..caches import Cache
 from ..equation import Equation, ZeroAssignment
-from ..manager import paused_manager
 from ..tangent_linear import get_tangent_linear
 
 from .caches import form_dependencies, form_key, parameters_key
@@ -318,8 +317,7 @@ class PointInterpolation(Equation):
         interp = _interp
         if interp is None:
             y_space = function_space(y)
-            with paused_manager():
-                vmesh = VertexOnlyMesh(y_space.mesh(), X_coords)
+            vmesh = VertexOnlyMesh(y_space.mesh(), X_coords)
             vspace = FunctionSpace(vmesh, "Discontinuous Lagrange", 0)
             interp = Interpolator(TestFunction(y_space), vspace)
             if not hasattr(interp, "_tlm_adjoint__vmesh_coords_map"):

--- a/tlm_adjoint/hessian.py
+++ b/tlm_adjoint/hessian.py
@@ -1,17 +1,19 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-from .interface import check_space_types_conjugate_dual, function_axpy, \
-    function_copy, function_get_values, function_is_cached, \
-    function_is_checkpointed, function_is_static, function_name, \
-    function_new, function_new_conjugate, function_set_values, is_function
+from .interface import (
+    check_space_types_conjugate_dual, function_axpy, function_copy,
+    function_get_values, function_is_cached, function_is_checkpointed,
+    function_is_static, function_name, function_new, function_new_conjugate,
+    function_set_values, is_function)
 
 from .caches import local_caches
 from .equations import InnerProduct
 from .functional import Functional
 from .manager import manager as _manager
-from .manager import compute_gradient, configure_tlm, function_tlm, \
-    reset_manager, restore_manager, set_manager, start_manager, stop_manager
+from .manager import (
+    compute_gradient, configure_tlm, function_tlm, paused_manager,
+    reset_manager, restore_manager, set_manager, start_manager, stop_manager)
 from .overloaded_float import Float, FloatSpace
 
 from abc import ABC, abstractmethod
@@ -296,9 +298,9 @@ class GaussNewton(ABC):
         assert len(X) == len(R_inv_tau_X)
         for x, R_inv_tau_x in zip(X, R_inv_tau_X):
             J_term = function_new(J.function())
-            InnerProduct(J_term, x, function_copy(R_inv_tau_x)).solve(
-                tlm=False)
-            J.addto(J_term, tlm=False)
+            with paused_manager(annotate=False, tlm=True):
+                InnerProduct(J_term, x, function_copy(R_inv_tau_x)).solve()
+                J.addto(J_term)
         stop_manager()
 
         # Likelihood term: J^* R^{-1} conj(J dM)

--- a/tlm_adjoint/manager.py
+++ b/tlm_adjoint/manager.py
@@ -3,8 +3,7 @@
 
 """This module provides a simple
 :class:`tlm_adjoint.tlm_adjoint.EquationManager` interface. Functions defined
-here access and interact with the default manager, or optionally a different
-manager supplied via a `manager` argument.
+here access and interact with the default manager.
 
 Documentation provided here indicates the
 :class:`tlm_adjoint.tlm_adjoint.EquationManager` methods where more complete
@@ -22,6 +21,7 @@ __all__ = \
         "configure_tlm",
         "function_tlm",
         "manager",
+        "manager_disabled",
         "manager_info",
         "paused_manager",
         "new_block",
@@ -91,193 +91,173 @@ def restore_manager(fn):
     return wrapped_fn
 
 
-def configure_checkpointing(cp_method, cp_parameters, *, manager=None):
+def configure_checkpointing(cp_method, cp_parameters):
     """See
     :meth:`tlm_adjoint.tlm_adjoint.EquationManager.configure_checkpointing`.
     """
 
     if cp_parameters is None:
         cp_parameters = {}
-    if manager is None:
-        manager = globals()["manager"]()
-    manager.configure_checkpointing(cp_method, cp_parameters=cp_parameters)
+    manager().configure_checkpointing(cp_method, cp_parameters=cp_parameters)
 
 
-def manager_info(*, info=print, manager=None):
+def manager_info(*, info=print):
     """See :meth:`tlm_adjoint.tlm_adjoint.EquationManager.info`.
     """
 
-    if manager is None:
-        manager = globals()["manager"]()
-    manager.info(info=info)
+    manager().info(info=info)
 
 
-def reset_manager(cp_method=None, cp_parameters=None, *, manager=None):
+def reset_manager(cp_method=None, cp_parameters=None):
     """See :meth:`tlm_adjoint.tlm_adjoint.EquationManager.reset`.
     """
 
-    if manager is None:
-        manager = globals()["manager"]()
-    manager.reset(cp_method=cp_method, cp_parameters=cp_parameters)
+    manager().reset(cp_method=cp_method, cp_parameters=cp_parameters)
 
 
-def reset(cp_method=None, cp_parameters=None, manager=None):
+def reset(cp_method=None, cp_parameters=None):
     warnings.warn("reset is deprecated -- use reset_manager instead",
                   DeprecationWarning, stacklevel=2)
-    if manager is None:
-        manager = globals()["manager"]()
-    manager.reset(cp_method=cp_method, cp_parameters=cp_parameters)
+    manager().reset(cp_method=cp_method, cp_parameters=cp_parameters)
 
 
-def annotation_enabled(*, manager=None):
+def annotation_enabled():
     """See :meth:`tlm_adjoint.tlm_adjoint.EquationManager.annotation_enabled`.
     """
 
-    if manager is None:
-        manager = globals()["manager"]()
-    return manager.annotation_enabled()
+    return manager().annotation_enabled()
 
 
-def start_manager(*, annotate=True, tlm=True, manager=None):
+def start_manager(*, annotate=True, tlm=True):
     """See :meth:`tlm_adjoint.tlm_adjoint.EquationManager.start`.
     """
 
-    if manager is None:
-        manager = globals()["manager"]()
-    manager.start(annotate=annotate, tlm=tlm)
+    manager().start(annotate=annotate, tlm=tlm)
 
 
-def start_annotating(manager=None):
+def start_annotating():
     warnings.warn("start_annotating is deprecated -- "
                   "use start_manager instead",
                   DeprecationWarning, stacklevel=2)
 
-    if manager is None:
-        manager = globals()["manager"]()
-    manager.start(annotate=True, tlm=False)
+    manager().start(annotate=True, tlm=False)
 
 
-def start_tlm(manager=None):
+def start_tlm():
     warnings.warn("start_tlm is deprecated -- "
                   "use start_manager instead",
                   DeprecationWarning, stacklevel=2)
 
-    if manager is None:
-        manager = globals()["manager"]()
-    manager.start(annotate=False, tlm=True)
+    manager().start(annotate=False, tlm=True)
 
 
-def stop_manager(*, annotate=True, tlm=True, manager=None):
+def stop_manager(*, annotate=True, tlm=True):
     """See :meth:`tlm_adjoint.tlm_adjoint.EquationManager.stop`.
     """
 
-    if manager is None:
-        manager = globals()["manager"]()
-    return manager.stop(annotate=annotate, tlm=tlm)
+    return manager().stop(annotate=annotate, tlm=tlm)
 
 
-def stop_annotating(manager=None):
+def stop_annotating():
     warnings.warn("stop_annotating is deprecated -- "
                   "use stop_manager instead",
                   DeprecationWarning, stacklevel=2)
 
-    if manager is None:
-        manager = globals()["manager"]()
-    return manager.stop(annotate=True, tlm=False)
+    return manager().stop(annotate=True, tlm=False)
 
 
-def stop_tlm(manager=None):
+def stop_tlm():
     warnings.warn("stop_tlm is deprecated -- "
                   "use stop_manager instead",
                   DeprecationWarning, stacklevel=2)
 
-    if manager is None:
-        manager = globals()["manager"]()
-    return manager.stop(annotate=False, tlm=True)
+    return manager().stop(annotate=False, tlm=True)
 
 
-def paused_manager(*, annotate=True, tlm=True, manager=None):
+def paused_manager(*, annotate=True, tlm=True):
     """See :meth:`tlm_adjoint.tlm_adjoint.EquationManager.paused`.
     """
 
-    if manager is None:
-        manager = globals()["manager"]()
-    return manager.paused(annotate=annotate, tlm=tlm)
+    return manager().paused(annotate=annotate, tlm=tlm)
 
 
-def configure_tlm(*args, annotate=None, tlm=True, manager=None):
+def manager_disabled(*, annotate=True, tlm=True):
+    """Decorator which can be used to disable processing of equations and
+    derivation and solution of tangent-linear equations.
+
+    :arg annotate: Whether to disable processing of equations.
+    :arg tlm: Whether to disable derivation and solution of tangent-linear
+        equations.
+    """
+
+    def wrapper(fn):
+        @functools.wraps(fn)
+        def wrapped_fn(*args, **kwargs):
+            with paused_manager(annotate=annotate, tlm=tlm):
+                return fn(*args, **kwargs)
+
+        return wrapped_fn
+
+    return wrapper
+
+
+def configure_tlm(*args, annotate=None, tlm=True):
     """See :meth:`tlm_adjoint.tlm_adjoint.EquationManager.configure_tlm`.
     """
 
-    if manager is None:
-        manager = globals()["manager"]()
-    manager.configure_tlm(*args, annotate=annotate, tlm=tlm)
+    manager().configure_tlm(*args, annotate=annotate, tlm=tlm)
 
 
-def add_tlm(M, dM, max_depth=1, manager=None):
+def add_tlm(M, dM, max_depth=1):
     warnings.warn("add_tlm is deprecated -- "
                   "use configure_tlm instead",
                   DeprecationWarning, stacklevel=2)
-    if manager is None:
-        manager = globals()["manager"]()
-    manager.add_tlm(M, dM, max_depth=max_depth, _warning=False)
+    manager().add_tlm(M, dM, max_depth=max_depth, _warning=False)
 
 
-def tlm_enabled(*, manager=None):
+def tlm_enabled():
     """See :meth:`tlm_adjoint.tlm_adjoint.EquationManager.tlm_enabled`.
     """
 
-    if manager is None:
-        manager = globals()["manager"]()
-    return manager.tlm_enabled()
+    return manager().tlm_enabled()
 
 
-def function_tlm(x, *args, manager=None):
+def function_tlm(x, *args):
     """See :meth:`tlm_adjoint.tlm_adjoint.EquationManager.function_tlm`.
     """
 
-    if manager is None:
-        manager = globals()["manager"]()
-    return manager.function_tlm(x, *args)
+    return manager().function_tlm(x, *args)
 
 
-def tlm(M, dM, x, max_depth=1, manager=None):
+def tlm(M, dM, x, max_depth=1):
     warnings.warn("tlm is deprecated -- "
                   "use function_tlm instead",
                   DeprecationWarning, stacklevel=2)
-    if manager is None:
-        manager = globals()["manager"]()
-    return manager.tlm(M, dM, x, max_depth=max_depth, _warning=False)
+    return manager().tlm(M, dM, x, max_depth=max_depth, _warning=False)
 
 
-def reset_adjoint(manager=None):
+def reset_adjoint():
     warnings.warn("reset_adjoint is deprecated",
                   DeprecationWarning, stacklevel=2)
-    if manager is None:
-        manager = globals()["manager"]()
-    manager.reset_adjoint(_warning=False)
+    manager().reset_adjoint(_warning=False)
 
 
 def compute_gradient(Js, M, *, callback=None, prune_forward=True,
                      prune_adjoint=True, prune_replay=True,
-                     cache_adjoint_degree=None, adj_ics=None, manager=None):
+                     cache_adjoint_degree=None, store_adjoint=False,
+                     adj_ics=None):
     """See :meth:`tlm_adjoint.tlm_adjoint.EquationManager.compute_gradient`.
     """
 
-    if manager is None:
-        manager = globals()["manager"]()
-    return manager.compute_gradient(Js, M, callback=callback,
-                                    prune_forward=prune_forward,
-                                    prune_adjoint=prune_adjoint,
-                                    prune_replay=prune_replay,
-                                    cache_adjoint_degree=cache_adjoint_degree,
-                                    adj_ics=adj_ics)
+    return manager().compute_gradient(
+        Js, M, callback=callback, prune_forward=prune_forward,
+        prune_adjoint=prune_adjoint, prune_replay=prune_replay,
+        cache_adjoint_degree=cache_adjoint_degree, store_adjoint=store_adjoint,
+        adj_ics=adj_ics)
 
 
-def new_block(*, manager=None):
+def new_block():
     """See :meth:`tlm_adjoint.tlm_adjoint.EquationManager.new_block`.
     """
 
-    if manager is None:
-        manager = globals()["manager"]()
-    manager.new_block()
+    manager().new_block()

--- a/tlm_adjoint/optimization.py
+++ b/tlm_adjoint/optimization.py
@@ -854,6 +854,7 @@ def minimize_l_bfgs(forward, M0, *,
     if manager is None:
         manager = _manager().new()
     set_manager(manager)
+    comm = manager.comm()
 
     M = [function_new(m0, static=function_is_static(m0),
                       cache=function_is_cached(m0),
@@ -884,7 +885,7 @@ def minimize_l_bfgs(forward, M0, *,
         last_F[2] = forward(*last_F[1])
         if is_function(last_F[2]):
             last_F[2] = Functional(_fn=last_F[2])
-        garbage_cleanup(manager.comm())
+        garbage_cleanup(comm)
         stop_manager()
 
         return last_F[2].value()
@@ -898,7 +899,7 @@ def minimize_l_bfgs(forward, M0, *,
 
     X, optimization_data = l_bfgs(
         F, Fp, M0,
-        m=m, comm=manager.comm(), **kwargs)
+        m=m, comm=comm, **kwargs)
 
     if is_function(X):
         X = (X,)

--- a/tlm_adjoint/override.py
+++ b/tlm_adjoint/override.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from .manager import (
+    annotation_enabled, manager_disabled, paused_manager, tlm_enabled)
+
+import functools
+
+__all__ = []
+
+_OVERRIDE_KEY = "_tlm_adjoint__override"
+_OVERRIDE_PROPERTY_NAME_KEY = "_tlm_adjoint__override_property_name_%i"
+_OVERRIDE_PROPERTY_COUNTER_KEY = "_tlm_adjoint__override_property_counter"
+
+
+def override_method(cls, name):
+    orig = getattr(cls, name)
+
+    def wrapper(override):
+        @functools.wraps(orig)
+        def wrapped_override(self, *args, **kwargs):
+            return override(self, orig,
+                            lambda: orig(self, *args, **kwargs),
+                            *args, **kwargs)
+
+        if hasattr(orig, _OVERRIDE_KEY):
+            raise RuntimeError("Multiple overrides")
+        setattr(orig, _OVERRIDE_KEY, wrapped_override)
+        setattr(cls, name, wrapped_override)
+        return wrapped_override
+
+    return wrapper
+
+
+def override_property(cls, name, *,
+                      cached=False):
+    orig = getattr(cls, name)
+
+    def wrapper(override):
+        @(functools.cached_property if cached else property)
+        @functools.wraps(orig)
+        def wrapped_override(self, *args, **kwargs):
+            return override(self, lambda: orig.__get__(self, type(self)),
+                            *args, **kwargs)
+
+        if hasattr(orig, _OVERRIDE_KEY):
+            raise RuntimeError("Multiple override")
+        setattr(orig, _OVERRIDE_KEY, wrapped_override)
+        setattr(cls, name, wrapped_override)
+        if cached:
+            override_counter = getattr(cls, _OVERRIDE_PROPERTY_COUNTER_KEY, -1) + 1  # noqa: E501
+            setattr(cls, _OVERRIDE_PROPERTY_COUNTER_KEY, override_counter)
+            wrapped_override.__set_name__(
+                wrapped_override,
+                _OVERRIDE_PROPERTY_NAME_KEY % override_counter)
+        return wrapped_override
+
+    return wrapper
+
+
+def override_function(orig):
+    def wrapper(override):
+        @functools.wraps(orig)
+        def wrapped_override(*args, **kwargs):
+            return override(orig,
+                            lambda: orig(*args, **kwargs),
+                            *args, **kwargs)
+
+        return wrapped_override
+
+    return wrapper
+
+
+def add_manager_controls(orig):
+    def wrapped_orig(*args, annotate=None, tlm=None, **kwargs):
+        if annotate is None or annotate:
+            annotate = annotation_enabled()
+        if tlm is None or tlm:
+            tlm = tlm_enabled()
+        with paused_manager(annotate=not annotate, tlm=not tlm):
+            return orig(*args, **kwargs)
+
+    return wrapped_orig
+
+
+def manager_method(cls, name, *,
+                   override_without_manager=False,
+                   pre_call=None, post_call=None):
+    orig = getattr(cls, name)
+
+    def wrapper(override):
+        @manager_disabled()
+        @functools.wraps(orig)
+        def wrapped_orig(self, *args, **kwargs):
+            if pre_call is not None:
+                args, kwargs = pre_call(self, *args, **kwargs)
+            return_value = orig(self, *args, **kwargs)
+            if post_call is not None:
+                return_value = post_call(self, return_value, *args, **kwargs)
+            return return_value
+
+        def wrapped_override(self, *args, annotate=None, tlm=None, **kwargs):
+            if annotate is None or annotate:
+                annotate = annotation_enabled()
+            if tlm is None or tlm:
+                tlm = tlm_enabled()
+            if annotate or tlm or override_without_manager:
+                return override(self, wrapped_orig,
+                                lambda: wrapped_orig(self, *args, **kwargs),
+                                *args, annotate=annotate, tlm=tlm, **kwargs)
+            else:
+                return wrapped_orig(self, *args, **kwargs)
+
+        if hasattr(orig, _OVERRIDE_KEY):
+            raise RuntimeError("Multiple overrides")
+        setattr(orig, _OVERRIDE_KEY, wrapped_override)
+        setattr(cls, name, wrapped_override)
+        return wrapped_override
+
+    return wrapper

--- a/tlm_adjoint/tlm_adjoint.py
+++ b/tlm_adjoint/tlm_adjoint.py
@@ -640,10 +640,9 @@ class EquationManager:
 
         :arg x: A function defining the variable and storing the value.
         :arg annotate: Whether the initial condition should be processed.
-            Defaults to `self.annotation_enabled()`.
         """
 
-        if annotate is None:
+        if annotate is None or annotate:
             annotate = self.annotation_enabled()
         if annotate:
             if self._annotation_state == AnnotationState.FINAL:
@@ -658,17 +657,14 @@ class EquationManager:
 
         :arg eq: The :class:`tlm_adjoint.equation.Equation`.
         :arg annotate: Whether solution of this equation, and any
-            tangent-linear equations, should be recorded. If `True` then
-            overridden by the `annotate` configuration of tangent-linear
-            models. If `False` then overrides the `annotate` configuration of
-            tangent-linear models. Defaults to `self.annotation_enabled()`.
+            tangent-linear equations, should be recorded.
         :arg tlm: Whether tangent-linear equations should be derived and
-            solved. Defaults to `self.tlm_enabled()`.
+            solved.
         """
 
         self.drop_references()
 
-        if annotate is None:
+        if annotate is None or annotate:
             annotate = self.annotation_enabled()
         if annotate:
             if self._annotation_state == AnnotationState.FINAL:
@@ -689,7 +685,7 @@ class EquationManager:
             self._cp.add_equation(
                 len(self._blocks), len(self._block) - 1, eq)
 
-        if tlm is None:
+        if tlm is None or tlm:
             tlm = self.tlm_enabled()
         if tlm:
             if self._tlm_state == TangentLinearState.FINAL:


### PR DESCRIPTION
Apply with the Firedrake backend.

Also remove most use of the optional `manager` argument, and prevent `annotate` and `tlm` keyword arguments overriding the `EquationManager` state.