### PR TITLE
Firedrake backend: Call garbage_cleanup on internal PyOP2 communicators

### DIFF
--- a/docs/source/dependencies.rst
+++ b/docs/source/dependencies.rst
@@ -23,6 +23,7 @@ With the FEniCS backend tlm_adjoint requires:
 With the Firedrake backend tlm_adjoint requires:
 
   - `Firedrake <https://firedrakeproject.org>`_
+  - `PyOP2 <https://github.com/OP2/PyOP2>`_
   - `UFL <https://github.com/FEniCS/ufl>`_
   - `mpi4py <https://github.com/mpi4py/mpi4py>`_
   - `PETSc <https://petsc.org>`_

--- a/tests/fenics/test_minimize.py
+++ b/tests/fenics/test_minimize.py
@@ -274,7 +274,7 @@ def test_l_bfgs_multiple(setup_test, test_leaks):
     info(f"{Fp_calls=:d}")
 
     assert abs(F(x, y)) < 1.0e-24
-    assert x_error_norm < 1.0e-12
+    assert x_error_norm < 1.0e-11
     assert y_error_norm < 1.0e-11
     assert its <= 38
     assert F_calls <= 42

--- a/tlm_adjoint/tlm_adjoint.py
+++ b/tlm_adjoint/tlm_adjoint.py
@@ -1390,6 +1390,7 @@ class EquationManager:
                         # Finalize right-hand-sides in the control block
                         Bs[J_i][-1].finalize()
 
+                self.drop_references()
             garbage_cleanup(self._comm)
 
         for B in Bs:


### PR DESCRIPTION
Also drop references for each adjoint model, for each block, in `EquationManager.compute_gradient`.