### PR TITLE
FEniCS/Firedrake backends: Do not have ReplacementConstant and ReplacementFunction inherit from backend Constant and Function

### DIFF
--- a/tests/fenics/test_base.py
+++ b/tests/fenics/test_base.py
@@ -8,6 +8,7 @@ from tlm_adjoint.fenics.backend import backend_Constant, backend_Function
 from tlm_adjoint.fenics.backend_code_generator_interface import \
     complex_mode, interpolate_expression
 from tlm_adjoint.alias import gc_disabled
+from tlm_adjoint.override import override_method
 
 import copy
 import functools
@@ -146,22 +147,16 @@ def referenced_functions():
                  if F_ref is not None)
 
 
-def _Constant__init__(self, *args, **kwargs):
-    _Constant__init__orig(self, *args, **kwargs)
+@override_method(backend_Constant, "__init__")
+def Constant__init__(self, orig, orig_args, *args, **kwargs):
+    orig_args()
     _function_ids[function_id(self)] = self
 
 
-_Constant__init__orig = backend_Constant.__init__
-backend_Constant.__init__ = _Constant__init__
-
-
-def _Function__init__(self, *args, **kwargs):
-    _Function__init__orig(self, *args, **kwargs)
+@override_method(backend_Function, "__init__")
+def Function__init__(self, orig, orig_args, *args, **kwargs):
+    orig_args()
     _function_ids[function_id(self)] = self
-
-
-_Function__init__orig = backend_Function.__init__
-backend_Function.__init__ = _Function__init__
 
 
 @pytest.fixture

--- a/tests/firedrake/test_base.py
+++ b/tests/firedrake/test_base.py
@@ -8,6 +8,7 @@ from tlm_adjoint.firedrake.backend import backend_Constant, backend_Function
 from tlm_adjoint.firedrake.backend_code_generator_interface import (
     complex_mode, interpolate_expression)
 from tlm_adjoint.alias import gc_disabled
+from tlm_adjoint.override import override_method
 
 import copy
 import functools
@@ -139,22 +140,16 @@ def referenced_functions():
                  if F_ref is not None)
 
 
-def _Constant__init__(self, *args, **kwargs):
-    _Constant__init__orig(self, *args, **kwargs)
+@override_method(backend_Constant, "__init__")
+def Constant__init__(self, orig, orig_args, *args, **kwargs):
+    orig_args()
     _function_ids[function_id(self)] = self
 
 
-_Constant__init__orig = backend_Constant.__init__
-backend_Constant.__init__ = _Constant__init__
-
-
-def _Function__init__(self, *args, **kwargs):
-    _Function__init__orig(self, *args, **kwargs)
+@override_method(backend_Function, "__init__")
+def Function__init__(self, orig, orig_args, *args, **kwargs):
+    orig_args()
     _function_ids[function_id(self)] = self
-
-
-_Function__init__orig = backend_Function.__init__
-backend_Function.__init__ = _Function__init__
 
 
 @pytest.fixture

--- a/tests/firedrake/test_base.py
+++ b/tests/firedrake/test_base.py
@@ -4,7 +4,7 @@
 from firedrake import *
 from tlm_adjoint.firedrake import *
 from tlm_adjoint.firedrake import manager as _manager
-from tlm_adjoint.firedrake.backend import backend_Function
+from tlm_adjoint.firedrake.backend import backend_Constant, backend_Function
 from tlm_adjoint.firedrake.backend_code_generator_interface import (
     complex_mode, interpolate_expression)
 from tlm_adjoint.alias import gc_disabled
@@ -139,6 +139,15 @@ def referenced_functions():
                  if F_ref is not None)
 
 
+def _Constant__init__(self, *args, **kwargs):
+    _Constant__init__orig(self, *args, **kwargs)
+    _function_ids[function_id(self)] = self
+
+
+_Constant__init__orig = backend_Constant.__init__
+backend_Constant.__init__ = _Constant__init__
+
+
 def _Function__init__(self, *args, **kwargs):
     _Function__init__orig(self, *args, **kwargs)
     _function_ids[function_id(self)] = self
@@ -175,7 +184,8 @@ def test_leaks():
 
     refs = 0
     for F in referenced_functions():
-        if function_name(F) != f"{DEFAULT_MESH_NAME:s}_coordinates":
+        if not isinstance(F, ZeroConstant) \
+                and function_name(F) != f"{DEFAULT_MESH_NAME:s}_coordinates":
             info(f"{function_name(F):s} referenced")
             refs += 1
     if refs == 0:

--- a/tests/firedrake/test_manager.py
+++ b/tests/firedrake/test_manager.py
@@ -304,7 +304,7 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
             assert not b._references_dropped
             assert not M._references_dropped
             for dep in linear_eq.dependencies():
-                assert function_is_replacement(dep) or isinstance(dep, Constant)  # noqa: E501
+                assert function_is_replacement(dep)
             for dep in b.dependencies():
                 assert not function_is_replacement(dep)
 
@@ -338,7 +338,7 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
             assert b._references_dropped
             assert M._references_dropped
             for dep in b.dependencies():
-                assert function_is_replacement(dep) or isinstance(dep, Constant)  # noqa: E501
+                assert function_is_replacement(dep)
 
         M = IdentityMatrix()
 
@@ -462,7 +462,7 @@ def test_Referrers_FixedPointEquation(setup_test, test_leaks):
             assert len(manager._to_drop_references) == 0
             assert fp_eq._references_dropped
             for dep in fp_eq.dependencies():
-                assert function_is_replacement(dep) or isinstance(dep, Constant)  # noqa: E501
+                assert function_is_replacement(dep)
             for eq in [eq0, eq1]:
                 assert not eq._references_dropped
                 for dep in eq.dependencies():
@@ -496,7 +496,7 @@ def test_Referrers_FixedPointEquation(setup_test, test_leaks):
             for eq in [eq0, eq1]:
                 assert eq._references_dropped
                 for dep in eq.dependencies():
-                    assert function_is_replacement(dep) or isinstance(dep, Constant)  # noqa: E501
+                    assert function_is_replacement(dep)
             del eq
 
         J = Functional(name="J")

--- a/tests/numpy/test_base.py
+++ b/tests/numpy/test_base.py
@@ -4,6 +4,7 @@
 from tlm_adjoint.numpy import *
 from tlm_adjoint.numpy import manager as _manager
 from tlm_adjoint.alias import gc_disabled
+from tlm_adjoint.override import override_method
 
 import functools
 import gc
@@ -92,13 +93,10 @@ def referenced_functions():
                  if F_ref is not None)
 
 
-def _Function__init__(self, *args, **kwargs):
-    _Function__init__orig(self, *args, **kwargs)
+@override_method(Function, "__init__")
+def Function__init__(self, orig, orig_args, *args, **kwargs):
+    orig_args()
     _function_ids[function_id(self)] = self
-
-
-_Function__init__orig = Function.__init__
-Function.__init__ = _Function__init__
 
 
 @pytest.fixture

--- a/tlm_adjoint/_code_generator/caches.py
+++ b/tlm_adjoint/_code_generator/caches.py
@@ -15,7 +15,8 @@ from .backend_code_generator_interface import (
 from ..caches import Cache
 
 from .functions import (
-    derivative, eliminate_zeros, extract_coefficients, replaced_form)
+    ReplacementFunction, derivative, eliminate_zeros, extract_coefficients,
+    replaced_form)
 
 from collections import defaultdict
 import ufl
@@ -220,7 +221,7 @@ def split_terms(terms, base_integral,
             mat_dep = None
             for dep in extract_coefficients(term):
                 if not is_cached(dep):
-                    if isinstance(dep, backend_Function) and mat_dep is None:
+                    if isinstance(dep, (backend_Function, ReplacementFunction)) and mat_dep is None:  # noqa: E501
                         mat_dep = dep
                     else:
                         mat_dep = None

--- a/tlm_adjoint/_code_generator/functions.py
+++ b/tlm_adjoint/_code_generator/functions.py
@@ -225,13 +225,9 @@ class ConstantInterface(_FunctionInterface):
             self.assign(backend_Constant(values))
 
     def _replacement(self):
-        if isinstance(self, ufl.classes.Coefficient):
-            if not hasattr(self, "_tlm_adjoint__replacement"):
-                self._tlm_adjoint__replacement = ReplacementConstant(self)
-            return self._tlm_adjoint__replacement
-        else:
-            # For Firedrake
-            return self
+        if not hasattr(self, "_tlm_adjoint__replacement"):
+            self._tlm_adjoint__replacement = ReplacementConstant(self)
+        return self._tlm_adjoint__replacement
 
     def _is_replacement(self):
         return False
@@ -805,24 +801,21 @@ class Replacement(ufl.classes.Coefficient):
             return (self._tlm_adjoint__domain,)
 
 
-class ReplacementConstant(backend_Constant, Replacement):
-    """A backend `Constant` representing a symbolic variable but with no
-    value.
+class ReplacementConstant(Replacement):
+    """Represents a symbolic constant, but has no value.
     """
 
     def __init__(self, x):
-        Replacement.__init__(self, x)
+        super().__init__(x)
         self._tlm_adjoint__function_interface_attrs["form_derivative_space"] \
             = x._tlm_adjoint__function_interface_attrs["form_derivative_space"]
 
 
-class ReplacementFunction(backend_Function, Replacement):
-    """A backend `Function` representing a symbolic variable but with no
-    value.
+class ReplacementFunction(Replacement):
+    """Represents a symbolic function, but has no value.
     """
 
-    def __init__(self, x):
-        Replacement.__init__(self, x)
+    pass
 
 
 def replaced_form(form):


### PR DESCRIPTION
`ReplacementConstant` and `ReplacementFunction` have previously inherited from `Constant` and `Function` respectively. The only benefit is that is makes it easy to detect if a `Coefficient` originates e.g. from a `Function` using `isinstance`. However the `Constant` and `Function` constructors were never called when instantiating these objects, and could not be called without defeating the purpose of these `Replacement` subclasses (to define symbolic variables without space allocated for values).

I could only find one case where an `isinstance` check used the previous behaviour, in the matrix action caching optimization. This PR fixes this one case, and updates `ReplacementConstant` and `ReplacementFunction` to no longer inherit from `Constant` and `Function`.

References to `Constant` objects are now once again dropped when using the Firedrake backend. The memory benefit is trivial, but this means that `Constant` and `Function` objects are handled in similar ways.