### PR TITLE
Avoid comparing bools using 'is' in checkpoint schedules tests

### DIFF
--- a/tests/checkpoint_schedules/test_binomial.py
+++ b/tests/checkpoint_schedules/test_binomial.py
@@ -115,7 +115,7 @@ def test_MultistageCheckpointSchedule(trajectory,
         assert cp_action.n < n - model_r
         # The loaded data is deleted iff it is exactly one step away from the
         # current location of the adjoint
-        assert cp_action.delete is (cp_action.n == n - model_r - 1)
+        assert cp_action.delete == (cp_action.n == n - model_r - 1)
 
         ics.clear()
         ics.update(cp[0])

--- a/tests/checkpoint_schedules/test_mixed.py
+++ b/tests/checkpoint_schedules/test_mixed.py
@@ -117,7 +117,7 @@ def test_MixedCheckpointSchedule(n, S):
             assert cp_action.n < n - model_r - 1
             # The loaded data is deleted iff non-linear dependency data for all
             # remaining steps can be checkpoint and stored
-            assert cp_action.delete is (cp_action.n >= n - model_r - 1
+            assert cp_action.delete == (cp_action.n >= n - model_r - 1
                                         - (s - len(snapshots) + 1))
 
             ics.clear()


### PR DESCRIPTION
Works around the following behaviour
```
import numpy as np
assert (np.int64(1) == 1) is True  # Fails
```
Here `np.int64(1) == 1` has type `np.bool_`, not `bool`.