### PR TITLE
Avoid casting using dtypes

### DIFF
--- a/tests/fenics/test_caches.py
+++ b/tests/fenics/test_caches.py
@@ -227,7 +227,7 @@ def test_mat_terms(setup_test, test_leaks,
     x = Function(space, name="x")
     x_expr = exp(X[0]) * X[1]
     if issubclass(function_dtype(x), (complex, np.complexfloating)):
-        x_expr += X[0] * sin(X[1]) * 1.j
+        x_expr = x_expr + X[0] * sin(X[1]) * 1.0j
     interpolate_expression(x, x_expr)
 
     form = inner(ufl.conj(x) if x_conjugate else x, test) * dx

--- a/tests/fenics/test_eigendecomposition.py
+++ b/tests/fenics/test_eigendecomposition.py
@@ -163,6 +163,8 @@ def test_CachedHessian(setup_test):
     assert abs(error).max() == 0.0
 
     if issubclass(space_dtype(space), (complex, np.complexfloating)):
+        # Minor gap in test, as could use a different order from the real
+        # components
         error = (np.array(sorted(lam.imag), dtype=np.float64)
                  - np.array(sorted(lam_opt.imag), dtype=np.float64))
         assert abs(error).max() == 0.0

--- a/tests/fenics/test_equations.py
+++ b/tests/fenics/test_equations.py
@@ -356,7 +356,7 @@ def test_PointInterpolation(setup_test, test_leaks, test_ghost_modes,
     X_coords = np.array([[0.1, 0.1, 0.1],
                          [0.2, 0.3, 0.4],
                          [0.9, 0.8, 0.7],
-                         [0.4, 0.2, 0.3]], dtype=np.float64)
+                         [0.4, 0.2, 0.3]], dtype=backend_ScalarType)
 
     # Test optimization: Use to cache the interpolation matrix
     P = [None]

--- a/tests/firedrake/test_caches.py
+++ b/tests/firedrake/test_caches.py
@@ -227,7 +227,7 @@ def test_mat_terms(setup_test, test_leaks,
     x = Function(space, name="x")
     x_expr = exp(X[0]) * X[1]
     if issubclass(function_dtype(x), (complex, np.complexfloating)):
-        x_expr += X[0] * sin(X[1]) * 1.j
+        x_expr = x_expr + X[0] * sin(X[1]) * 1.0j
     interpolate_expression(x, x_expr)
 
     form = inner(ufl.conj(x) if x_conjugate else x, test) * dx

--- a/tests/firedrake/test_eigendecomposition.py
+++ b/tests/firedrake/test_eigendecomposition.py
@@ -163,6 +163,8 @@ def test_CachedHessian(setup_test):
     assert abs(error).max() == 0.0
 
     if issubclass(space_dtype(space), (complex, np.complexfloating)):
+        # Minor gap in test, as could use a different order from the real
+        # components
         error = (np.array(sorted(lam.imag), dtype=np.float64)
                  - np.array(sorted(lam_opt.imag), dtype=np.float64))
         assert abs(error).max() == 0.0

--- a/tests/firedrake/test_equations.py
+++ b/tests/firedrake/test_equations.py
@@ -292,7 +292,7 @@ def test_PointInterpolation(setup_test, test_leaks,
     X_coords = np.array([[0.1, 0.1, 0.1],
                          [0.2, 0.3, 0.4],
                          [0.9, 0.8, 0.7],
-                         [0.4, 0.2, 0.3]], dtype=np.float64)
+                         [0.4, 0.2, 0.3]], dtype=backend_ScalarType)
 
     def forward(y):
         X_vals = [Constant(name=f"x_{i:d}")
@@ -380,13 +380,13 @@ def test_ExprAssignment(setup_test, test_leaks,
     y = Function(space, name="y")
     z = Function(space, name="z")
     if complex_mode:
-        c = Constant(np.sqrt(2.0 + 1.j * np.sqrt(3.0)))
+        c = Constant(np.sqrt(2.0 + 1.0j * np.sqrt(3.0)))
         interpolate_expression(y,
                                cos(3.0 * pi * X[0])
-                               + 1.j * sin(5.0 * pi * X[0]))
+                               + 1.0j * sin(5.0 * pi * X[0]))
         interpolate_expression(z,
                                cos(7.0 * pi * X[0])
-                               + 1.j * sin(11.0 * pi * X[0]))
+                               + 1.0j * sin(11.0 * pi * X[0]))
     else:
         c = Constant(np.sqrt(2.0))
         interpolate_expression(y,
@@ -507,7 +507,7 @@ def test_ExprInterpolation_transpose(setup_test, test_leaks,
     if complex_mode:
         interpolate_expression(y_2,
                                cos(3.0 * pi * X[0])
-                               + 1.j * sin(5.0 * pi * X[0]))
+                               + 1.0j * sin(5.0 * pi * X[0]))
     else:
         interpolate_expression(y_2,
                                cos(3.0 * pi * X[0]))

--- a/tests/firedrake/test_overrides.py
+++ b/tests/firedrake/test_overrides.py
@@ -241,7 +241,7 @@ def test_interpolate(setup_test, test_leaks,
     if complex_mode:
         interpolate_expression(y_2,
                                cos(3.0 * pi * X[0])
-                               + 1.j * sin(5.0 * pi * X[0]))
+                               + 1.0j * sin(5.0 * pi * X[0]))
     else:
         interpolate_expression(y_2,
                                cos(3.0 * pi * X[0]))
@@ -434,7 +434,7 @@ def test_DirichletBC_apply(setup_test, test_leaks, tmp_path):
         interpolate_expression(
             y,
             cos(pi * X[0]) * cos(2.0 * pi * X[1])
-            + 1.j * cos(3.0 * pi * X[0]) * cos(4.0 * pi * X[1]))
+            + 1.0j * cos(3.0 * pi * X[0]) * cos(4.0 * pi * X[1]))
     else:
         interpolate_expression(
             y,

--- a/tests/numpy/test_base.py
+++ b/tests/numpy/test_base.py
@@ -128,7 +128,7 @@ def info(message):
 class Constant(Function):
     def __init__(self, value=0.0, *, name=None, space_type="primal",
                  static=False, cache=None, checkpoint=None):
-        space = FunctionSpace(1)  # , dtype=default_dtype())
+        space = FunctionSpace(1)
         super().__init__(space, name=name, space_type=space_type,
                          static=static, cache=cache, checkpoint=checkpoint)
         self.assign(value)

--- a/tlm_adjoint/_code_generator/functions.py
+++ b/tlm_adjoint/_code_generator/functions.py
@@ -122,11 +122,10 @@ class ConstantInterface(_FunctionInterface):
         if isinstance(y, (int, np.integer,
                           float, np.floating,
                           complex, np.complexfloating)):
-            dtype = function_dtype(self)
             if len(self.ufl_shape) == 0:
-                value = dtype(y)
+                value = y
             else:
-                value = np.full(self.ufl_shape, dtype(y), dtype=dtype)
+                value = np.full(self.ufl_shape, y)
                 value = backend_Constant(value)
         elif isinstance(y, backend_Constant):
             value = y
@@ -136,28 +135,28 @@ class ConstantInterface(_FunctionInterface):
 
     @manager_disabled()
     def _axpy(self, alpha, x, /):
-        dtype = function_dtype(self)
-        alpha = dtype(alpha)
         if isinstance(x, SymbolicFloat):
             x = x.value()
         if isinstance(x, (int, np.integer,
                           float, np.floating,
                           complex, np.complexfloating)):
             if len(self.ufl_shape) == 0:
-                value = (dtype(self) + alpha * dtype(x))
+                value = (function_scalar_value(self) + alpha * x)
             else:
-                value = self.values() + alpha * dtype(x)
+                value = self.values() + alpha * x
                 value.shape = self.ufl_shape
                 value = backend_Constant(value)
         elif isinstance(x, backend_Constant):
             if len(self.ufl_shape) == 0:
-                value = (dtype(self) + alpha * dtype(x))
+                value = (function_scalar_value(self)
+                         + alpha * function_scalar_value(x))
             else:
                 value = self.values() + alpha * x.values()
                 value.shape = self.ufl_shape
                 value = backend_Constant(value)
         elif is_function(x):
-            value = dtype(self) + alpha * function_scalar_value(x)
+            value = (function_scalar_value(self)
+                     + alpha * function_scalar_value(x))
         else:
             raise TypeError(f"Unexpected type: {type(x)}")
         self.assign(value)

--- a/tlm_adjoint/equations.py
+++ b/tlm_adjoint/equations.py
@@ -134,7 +134,6 @@ class LinearCombination(Equation):
         alpha = []
         Y = []
         for a, y in args:
-            a = function_dtype(x)(a)
             if a.imag == 0.0:
                 a = a.real
             check_space_types(x, y)
@@ -466,11 +465,7 @@ class DotProductRHS(RHS):
         comm = function_comm(b)
         if comm.size > 1:
             import mpi4py.MPI as MPI
-            d_local = np.array([d], dtype=function_dtype(b))
-            d_global = np.full((1,), np.NAN, dtype=function_dtype(b))
-            comm.Allreduce(d_local, d_global, op=MPI.SUM)
-            d, = d_global
-            del d_local, d_global
+            d = comm.allreduce(d, op=MPI.SUM)
 
         function_set_values(b, function_get_values(b) + self._alpha * d)
 

--- a/tlm_adjoint/firedrake/backend_code_generator_interface.py
+++ b/tlm_adjoint/firedrake/backend_code_generator_interface.py
@@ -7,8 +7,8 @@ from .backend import (
     backend_solve, complex_mode, extract_args, homogenize, parameters)
 from ..interface import (
     check_space_type, check_space_types, function_assign, function_axpy,
-    function_copy, function_inner, function_new_conjugate_dual, function_space,
-    function_space_type, space_new)
+    function_comm, function_copy, function_inner, function_new_conjugate_dual,
+    function_space, function_space_type, space_new)
 
 from ..manager import manager_disabled
 from ..override import override_method
@@ -16,6 +16,7 @@ from ..override import override_method
 from .functions import eliminate_zeros, extract_coefficients
 
 from collections.abc import Sequence
+import mpi4py.MPI as MPI
 import numpy as np
 import petsc4py.PETSc as PETSc
 import ufl
@@ -342,9 +343,9 @@ def is_valid_r0_space(space):
         elif len(e.value_shape()) == 0:
             r = backend_Function(space)
             r.assign(backend_Constant(1.0))
-            with r.dat.vec_ro as r_v:
-                r_max = r_v.max()[1]
-            valid = (r_max == 1.0)
+            valid = 1 if (r.dat.data_ro == 1.0).all() else 0
+            valid = function_comm(r).allreduce(valid, op=MPI.MIN)
+            valid = valid == 1
         else:
             # See Firedrake issue #1456
             valid = False

--- a/tlm_adjoint/firedrake/backend_interface.py
+++ b/tlm_adjoint/firedrake/backend_interface.py
@@ -168,11 +168,10 @@ class FunctionInterface(_FunctionInterface):
         elif isinstance(y, (int, np.integer,
                             float, np.floating,
                             complex, np.complexfloating)):
-            dtype = function_dtype(self)
             if len(self.ufl_shape) == 0:
-                self.assign(backend_Constant(dtype(y)))
+                self.assign(backend_Constant(y))
             else:
-                y_arr = np.full(self.ufl_shape, dtype(y), dtype=dtype)
+                y_arr = np.full(self.ufl_shape, y)
                 self.assign(backend_Constant(y_arr))
         elif isinstance(y, Zero):
             with self.dat.vec_wo as x_v:
@@ -194,8 +193,6 @@ class FunctionInterface(_FunctionInterface):
 
     @manager_disabled()
     def _axpy(self, alpha, x, /):
-        dtype = function_dtype(self)
-        alpha = dtype(alpha)
         if isinstance(x, SymbolicFloat):
             x = x.value()
         if isinstance(x, backend_Function):
@@ -206,7 +203,7 @@ class FunctionInterface(_FunctionInterface):
         elif isinstance(x, (int, np.integer,
                             float, np.floating,
                             complex, np.complexfloating)):
-            self.assign(self + alpha * dtype(x))
+            self.assign(self + alpha * x)
         elif isinstance(x, Zero):
             pass
         elif isinstance(x, backend_Constant):

--- a/tlm_adjoint/interface.py
+++ b/tlm_adjoint/interface.py
@@ -1303,7 +1303,6 @@ def subtract_adjoint_derivative_action_base(x, alpha, y):
         pass
     elif is_function(y):
         check_space_types(x, y)
-        alpha = function_dtype(x)(alpha)
         function_axpy(x, -alpha, y)
     else:
         raise NotImplementedError("Unexpected case encountered")

--- a/tlm_adjoint/numpy/backend_interface.py
+++ b/tlm_adjoint/numpy/backend_interface.py
@@ -126,16 +126,15 @@ class FunctionInterface(_FunctionInterface):
         self.vector()[:] = 0.0
 
     def _assign(self, y):
-        dtype = self.dtype()
         if isinstance(y, SymbolicFloat):
             y = y.value()
         if isinstance(y, (int, np.integer,
                           float, np.floating,
                           complex, np.complexfloating)) \
-                and np.can_cast(y, dtype):
-            self.vector()[:] = dtype(y)
+                and np.can_cast(y, self.dtype()):
+            self.vector()[:] = y
         elif isinstance(y, Function):
-            if np.can_cast(y.dtype(), dtype):
+            if np.can_cast(y.dtype(), self.dtype()):
                 self.vector()[:] = y.vector()
             else:
                 raise ValueError("Invalid dtype")
@@ -143,17 +142,15 @@ class FunctionInterface(_FunctionInterface):
             raise TypeError("Invalid type")
 
     def _axpy(self, alpha, x, /):
-        dtype = self.dtype()
-        alpha = dtype(alpha)
         if isinstance(x, SymbolicFloat):
             x = x.value()
         if isinstance(x, (int, np.integer,
                           float, np.floating,
                           complex, np.complexfloating)) \
-                and np.can_cast(x, dtype):
-            self.vector()[:] += alpha * dtype(x)
+                and np.can_cast(x, self.dtype()):
+            self.vector()[:] += alpha * x
         elif isinstance(x, Function):
-            if np.can_cast(x.dtype(), dtype):
+            if np.can_cast(x.dtype(), self.dtype()):
                 self.vector()[:] += alpha * x.vector()
             else:
                 raise ValueError("Invalid dtype")
@@ -185,8 +182,7 @@ class FunctionInterface(_FunctionInterface):
         return values
 
     def _set_values(self, values):
-        dtype = self.dtype()
-        if not np.can_cast(values, dtype):
+        if not np.can_cast(values, self.dtype()):
             raise ValueError("Invalid dtype")
         if values.shape != self.vector().shape:
             raise ValueError("Invalid shape")

--- a/tlm_adjoint/numpy/equations.py
+++ b/tlm_adjoint/numpy/equations.py
@@ -106,7 +106,7 @@ class ContractionArray:
         self._A = A.copy()
         self._A_conjugate = A.conjugate()
         self._I = tuple(I)
-        self._alpha = A.dtype.type(alpha)
+        self._alpha = alpha
 
     def A(self):
         A = self._A

--- a/tlm_adjoint/overloaded_float.py
+++ b/tlm_adjoint/overloaded_float.py
@@ -214,7 +214,6 @@ class FloatInterface(FunctionInterface):
             function_assign(self, function_scalar_value(y))
 
     def _axpy(self, alpha, x, /):
-        alpha = function_dtype(self)(alpha)
         function_assign(self, self.value() + alpha * function_scalar_value(x))
 
     def _inner(self, y):


### PR DESCRIPTION
Avoid casting using dtypes. This, for example, avoids a calculation of the type

```
x = dtype(a) * dtype(b)
```

which in the complex case can be very different from

```
x = dtype(a * b)
```

if `a` and `b` are complex but `dtype` is a real type.

#308 identified while updating the above, fixed separately in #309. Also a few minor complex and parallel updates encountered while updating the above.