### PR TITLE
Always copy values in function_get_values

### DIFF
--- a/tlm_adjoint/_code_generator/functions.py
+++ b/tlm_adjoint/_code_generator/functions.py
@@ -202,10 +202,9 @@ class ConstantInterface(_FunctionInterface):
     def _get_values(self):
         comm = function_comm(self)
         if comm.rank == 0:
-            values = self.values().view()
+            values = self.values().copy()
         else:
             values = np.array([], dtype=function_dtype(self))
-        values.setflags(write=False)
         return values
 
     @manager_disabled()

--- a/tlm_adjoint/fenics/backend_interface.py
+++ b/tlm_adjoint/fenics/backend_interface.py
@@ -252,9 +252,7 @@ class FunctionInterface(_FunctionInterface):
 
     @check_vector_size
     def _get_values(self):
-        values = self.vector().get_local().view()
-        values.setflags(write=False)
-        return values
+        return self.vector().get_local().copy()  # copy likely not required
 
     @check_vector_size
     def _set_values(self, values):

--- a/tlm_adjoint/firedrake/backend_interface.py
+++ b/tlm_adjoint/firedrake/backend_interface.py
@@ -268,7 +268,6 @@ class FunctionInterface(_FunctionInterface):
         with self.dat.vec_ro as x_v:
             with x_v as x_v_a:
                 values = x_v_a.copy()
-        values.setflags(write=False)
         return values
 
     def _set_values(self, values):

--- a/tlm_adjoint/interface.py
+++ b/tlm_adjoint/interface.py
@@ -1081,12 +1081,11 @@ def function_local_indices(x):
 
 
 def function_get_values(x):
-    """Return the process local degrees of freedom vector associated with a
-    function.
+    """Return a copy of the process local degrees of freedom vector associated
+    with a function.
 
     :arg x: The function.
     :returns: A :class:`numpy.ndarray` containing the degrees of freedom.
-        Should not be modified.
     """
 
     return x._tlm_adjoint__function_interface_get_values()

--- a/tlm_adjoint/numpy/backend_interface.py
+++ b/tlm_adjoint/numpy/backend_interface.py
@@ -177,9 +177,7 @@ class FunctionInterface(_FunctionInterface):
         return slice(0, self.vector().shape[0])
 
     def _get_values(self):
-        values = self.vector().view()
-        values.setflags(write=False)
-        return values
+        return self.vector().copy()
 
     def _set_values(self, values):
         if not np.can_cast(values, self.dtype()):

--- a/tlm_adjoint/overloaded_float.py
+++ b/tlm_adjoint/overloaded_float.py
@@ -244,10 +244,9 @@ class FloatInterface(FunctionInterface):
 
     def _get_values(self):
         comm = function_comm(self)
-        value = self.value()
-        values = np.array([value] if comm.rank == 0 else [],
-                          dtype=type(value))
-        values.setflags(write=False)
+        dtype = function_dtype(self)
+        value = dtype(self.value())
+        values = np.array([value] if comm.rank == 0 else [], dtype=dtype)
         return values
 
     def _set_values(self, values):


### PR DESCRIPTION
Also make the return value writeable.

Leads to more consistent behaviour across backends, and fixes a corner case bug in `MemoryStorage`.