### PR TITLE
distinct_combinations_indices bugfix

### DIFF
--- a/tlm_adjoint/tangent_linear.py
+++ b/tlm_adjoint/tangent_linear.py
@@ -47,10 +47,7 @@ def distinct_combinations_indices(iterable, r):
             self._value = value
 
         def __eq__(self, other):
-            if isinstance(other, Comparison):
-                return self._key == other._key
-            else:
-                return NotImplemented
+            return self._key == other._key
 
         def __hash__(self):
             return hash(self._key)


### PR DESCRIPTION
`__eq__` should not return `NotImplemented`