### PR TITLE
Firedrake backend: Function_assign corner case bugfix

### DIFF
--- a/tlm_adjoint/firedrake/backend_overrides.py
+++ b/tlm_adjoint/firedrake/backend_overrides.py
@@ -151,7 +151,8 @@ def Function_assign(self, orig, orig_args, expr, subset=None, *,
                subset=None):
         if x is None:
             x = function_new(y)
-        if isinstance(y, ufl.classes.Zero):
+        if subset is None \
+                and isinstance(y, ufl.classes.Zero):
             ZeroAssignment(x).solve(annotate=annotate, tlm=tlm)
         elif subset is None \
                 and isinstance(y, backend_Function) \


### PR DESCRIPTION
Fixes an unused case in the local `assign` function