### PR TITLE
Firedrake backend: Handle some cases of non-scalar-valued functions in ExprAssignment

### DIFF
--- a/tlm_adjoint/_code_generator/equations.py
+++ b/tlm_adjoint/_code_generator/equations.py
@@ -1081,12 +1081,16 @@ class ExprInterpolation(ExprEquation):
             return adj_x
 
         dep = eq_deps[dep_index]
+        if len(dep.ufl_shape) > 0:
+            raise NotImplementedError("Case not implemented")
+
+        F = function_new_conjugate_dual(dep)
+
         dF = diff(self._rhs, dep)
         dF = ufl.algorithms.expand_derivatives(dF)
         dF = eliminate_zeros(dF)
         dF = self._nonlinear_replace(dF, nl_deps)
 
-        F = function_new_conjugate_dual(dep)
         interpolate_expression(F, dF, adj_x=adj_x)
         return (-1.0, F)
 


### PR DESCRIPTION
This is less simple that is appears. Really we want to implement.

```
test = TestFunction(adj_x.function_space())
trial = TrialFunction(dep)
residual = dot(test, x - rhs)
dF = derivative(residual, dep, trial)
result = action(adjoint(dF), adj_x)
# Zero elimination, dependency replacement
result = assemble(result)
```

Assuming `dep` is in the primal space, in the above:
- `dot` is used in indicate evaluation of a general antilinear functional in the antidual space represented by `TestFunction(adj_x.function_space())`.
- `assemble` computes degrees of freedom for an antilinear functional by evaluating its input with argument equal, in turn, to each basis function used for the primal space.

The implementation in this PR works, but uses
```
derivative(self._rhs, dep, adj_x)
```
which mixes primal and antidual spaces and so is subtly wrong (but is the same approach as used in Firedrake). This trick does not easily generalize to the complex case, and so currently this is implemented only for the real case.

Also raise an exception for non-implemented cases in `ExprInterpolation`.

See #329