### PR TITLE
Changes to state update behaviour

### DIFF
--- a/tests/firedrake/test_interface.py
+++ b/tests/firedrake/test_interface.py
@@ -81,19 +81,36 @@ def test_function_alias(setup_test, test_leaks,
     space = FunctionSpace(mesh, ufl.classes.MixedElement(
         *[space.ufl_element() for _ in range(dim)]))
 
+    def test_state(F, F_i):
+        state = function_state(F_i)
+        assert function_state(F_i) == function_state(F)
+        function_update_state(F)
+        assert function_state(F_i) == state + 1
+        assert function_state(F_i) == function_state(F)
+
+        state = function_state(F_i)
+        assert function_state(F_i) == function_state(F)
+        function_update_state(F_i)
+        assert function_state(F_i) == state + 1
+        assert function_state(F_i) == function_state(F)
+
     F = Function(space, name="F")
     for F_i in F.subfunctions:
         assert function_is_alias(F_i)
+        test_state(F, F_i)
     for i in range(dim):
         F_i = F.sub(i)
         assert dim == 1 or function_is_alias(F_i)
+        test_state(F, F_i)
 
     F = Function(space, name="F")
     for i in range(dim):
         F_i = F.sub(i)
         assert dim == 1 or function_is_alias(F_i)
+        test_state(F, F_i)
     for F_i in F.subfunctions:
         assert function_is_alias(F_i)
+        test_state(F, F_i)
 
 
 @pytest.mark.firedrake

--- a/tlm_adjoint/_code_generator/functions.py
+++ b/tlm_adjoint/_code_generator/functions.py
@@ -82,11 +82,10 @@ class ConstantInterface(_FunctionInterface):
         return self._tlm_adjoint__function_interface_attrs["name"](self)
 
     def _state(self):
-        return self._tlm_adjoint__function_interface_attrs["state"]
+        return self._tlm_adjoint__function_interface_attrs["state"][0]
 
     def _update_state(self):
-        state = self._tlm_adjoint__function_interface_attrs["state"]
-        self._tlm_adjoint__function_interface_attrs.d_setitem("state", state + 1)  # noqa: E501
+        self._tlm_adjoint__function_interface_attrs["state"][0] += 1
 
     def _is_static(self):
         return self._tlm_adjoint__function_interface_attrs["static"]
@@ -787,3 +786,5 @@ def define_function_alias(x, parent, *, key):
                 "cache", function_is_cached(parent))
             x._tlm_adjoint__function_interface_attrs.d_setitem(
                 "checkpoint", function_is_checkpointed(parent))
+            x._tlm_adjoint__function_interface_attrs.d_setitem(
+                "state", parent._tlm_adjoint__function_interface_attrs["state"])  # noqa: E501

--- a/tlm_adjoint/_code_generator/functions.py
+++ b/tlm_adjoint/_code_generator/functions.py
@@ -363,6 +363,9 @@ class Zero:
     def _tlm_adjoint__function_interface_set_values(self, values):
         raise RuntimeError("Cannot call _set_values interface of Zero")
 
+    def _tlm_adjoint__function_interface_update_state(self):
+        raise RuntimeError("Cannot call _update_state interface of Zero")
+
 
 class ZeroConstant(Constant, Zero):
     """A :class:`Constant` which is flagged as having a value of zero.

--- a/tlm_adjoint/fenics/backend_interface.py
+++ b/tlm_adjoint/fenics/backend_interface.py
@@ -53,7 +53,7 @@ def Constant__init__(self, orig, orig_args, *args, domain=None, space=None,
                        "dtype": backend_ScalarType, "id": new_space_id()})
     add_interface(self, ConstantInterface,
                   {"id": new_function_id(), "name": lambda x: x.name(),
-                   "state": 0, "space": space,
+                   "state": [0], "space": space,
                    "form_derivative_space": lambda x: r0_space(x),
                    "space_type": "primal", "dtype": self.values().dtype.type,
                    "static": False, "cache": False, "checkpoint": True})
@@ -126,11 +126,10 @@ class FunctionInterface(_FunctionInterface):
         return self.name()
 
     def _state(self):
-        return self._tlm_adjoint__function_interface_attrs["state"]
+        return self._tlm_adjoint__function_interface_attrs["state"][0]
 
     def _update_state(self):
-        state = self._tlm_adjoint__function_interface_attrs["state"]
-        self._tlm_adjoint__function_interface_attrs.d_setitem("state", state + 1)  # noqa: E501
+        self._tlm_adjoint__function_interface_attrs["state"][0] += 1
 
     def _is_static(self):
         return self._tlm_adjoint__function_interface_attrs["static"]
@@ -337,8 +336,9 @@ def Function__init__(self, orig, orig_args, *args, **kwargs):
         raise RuntimeError("PETSc backend required")
 
     add_interface(self, FunctionInterface,
-                  {"id": new_function_id(), "state": 0, "space_type": "primal",
-                   "static": False, "cache": False, "checkpoint": True})
+                  {"id": new_function_id(), "state": [0],
+                   "space_type": "primal", "static": False, "cache": False,
+                   "checkpoint": True})
 
     space = self.function_space()
     if isinstance(args[0], backend_FunctionSpace) and args[0].id() == space.id():  # noqa: E501

--- a/tlm_adjoint/firedrake/backend_interface.py
+++ b/tlm_adjoint/firedrake/backend_interface.py
@@ -85,7 +85,7 @@ def Constant__init__(self, orig, orig_args, value, domain=None, *,
                        "dtype": backend_ScalarType, "id": new_space_id()})
     add_interface(self, ConstantInterface,
                   {"id": new_function_id(), "name": lambda x: name,
-                   "state": 0, "space": space,
+                   "state": [0], "space": space,
                    "form_derivative_space": lambda x: r0_space(x),
                    "space_type": "primal", "dtype": self.dat.dtype.type,
                    "static": False, "cache": False, "checkpoint": True})
@@ -151,11 +151,10 @@ class FunctionInterfaceBase(_FunctionInterface):
         return self.name()
 
     def _state(self):
-        return self._tlm_adjoint__function_interface_attrs["state"]
+        return self._tlm_adjoint__function_interface_attrs["state"][0]
 
     def _update_state(self):
-        state = self._tlm_adjoint__function_interface_attrs["state"]
-        self._tlm_adjoint__function_interface_attrs.d_setitem("state", state + 1)  # noqa: E501
+        self._tlm_adjoint__function_interface_attrs["state"][0] += 1
 
     def _is_static(self):
         return self._tlm_adjoint__function_interface_attrs["static"]
@@ -346,7 +345,7 @@ def Function__init__(self, orig, orig_args, function_space, val=None,
         comm = self.function_space().comm
     add_interface(self, FunctionInterface,
                   {"comm": comm_dup_cached(comm), "id": new_function_id(),
-                   "state": 0, "space_type": "primal", "static": False,
+                   "state": [0], "space_type": "primal", "static": False,
                    "cache": False, "checkpoint": True})
     if isinstance(val, backend_Function):
         define_function_alias(self, val, key=("Function__init__",))
@@ -449,8 +448,8 @@ def Cofunction__init__(self, orig, orig_args, function_space, val=None,
     orig_args()
     add_interface(self, CofunctionInterface,
                   {"comm": comm_dup_cached(self.comm), "id": new_function_id(),
-                   "state": 0, "space_type": "conjugate_dual", "static": False,
-                   "cache": False, "checkpoint": True})
+                   "state": [0], "space_type": "conjugate_dual",
+                   "static": False, "cache": False, "checkpoint": True})
     if isinstance(val, backend_Cofunction):
         define_function_alias(self, val, key=("Cofunction__init__",))
 

--- a/tlm_adjoint/overloaded_float.py
+++ b/tlm_adjoint/overloaded_float.py
@@ -181,11 +181,10 @@ class FloatInterface(FunctionInterface):
         return self._tlm_adjoint__function_interface_attrs["name"]
 
     def _state(self):
-        return self._tlm_adjoint__function_interface_attrs["state"]
+        return self._tlm_adjoint__function_interface_attrs["state"][0]
 
     def _update_state(self):
-        state = self._tlm_adjoint__function_interface_attrs["state"]
-        self._tlm_adjoint__function_interface_attrs.d_setitem("state", state + 1)  # noqa: E501
+        self._tlm_adjoint__function_interface_attrs["state"][0] += 1
 
     def _is_static(self):
         return self._tlm_adjoint__function_interface_attrs["static"]
@@ -353,7 +352,7 @@ class _tlm_adjoint__SymbolicFloat(sp.Symbol):  # noqa: N801
         self._value = 0.0
         add_interface(self, FloatInterface,
                       {"cache": cache, "checkpoint": checkpoint, "id": id,
-                       "name": name, "state": 0,
+                       "name": name, "state": [0],
                        "space": FloatSpace(type(self), dtype=dtype, comm=comm),
                        "space_type": space_type, "static": static})
         self._tlm_adjoint__function_interface_attrs["caches"] = Caches(self)


### PR DESCRIPTION
- Share state values between aliases.
- Do not allow a `Zero` to have its state updated.

Resolves #374