### PR TITLE
Parallel bugfix for scalar JAX variables

### DIFF
--- a/tests/base/test_float.py
+++ b/tests/base/test_float.py
@@ -45,7 +45,7 @@ def test_float_assignment(setup_test,  # noqa: F811
 
         return (c - 1.0) ** 4
 
-    if issubclass(dtype, np.complexfloating):
+    if issubclass(dtype, (complex, np.complexfloating)):
         y = Float(2.0 + 3.0j)
     else:
         y = Float(2.0)

--- a/tlm_adjoint/_code_generator/functions.py
+++ b/tlm_adjoint/_code_generator/functions.py
@@ -166,7 +166,7 @@ class ConstantInterface(_VariableInterface):
         return self.values().sum()
 
     def _linf_norm(self):
-        return abs(self.values()).max()
+        return abs(self.values()).max(initial=0.0)
 
     def _local_size(self):
         comm = var_comm(self)

--- a/tlm_adjoint/fenics/fenics_equations.py
+++ b/tlm_adjoint/fenics/fenics_equations.py
@@ -404,6 +404,8 @@ def interpolation_matrix(x_coords, y, y_cells, y_colors):
             raise RuntimeError("Non-process-local node-node graph")
 
     comm = var_comm(y)
+    if len(y_colors) == 0 or y_colors.min() != 0:
+        raise ValueError("Invalid graph coloring")
     y_colors_N = y_colors.max() + 1
     y_colors_N = comm.allreduce(y_colors_N, op=MPI.MAX)
     assert y_colors_N >= 0

--- a/tlm_adjoint/jax.py
+++ b/tlm_adjoint/jax.py
@@ -224,7 +224,7 @@ class VectorInterface(VariableInterface):
         return s
 
     def _linf_norm(self):
-        norm = abs(self.vector).max()
+        norm = abs(self.vector).max(initial=0.0)
         if MPI is not None:
             norm = self.space.comm.allreduce(norm, op=MPI.MAX)
         return norm
@@ -866,8 +866,10 @@ def new_jax_float(space=None, *, name=None, dtype=None, comm=None):
     :returns: A scalar-valued :class:`Vector`.
     """
 
+    if comm is None:
+        comm = DEFAULT_COMM
     if space is None:
-        space = VectorSpace(1, dtype=dtype, comm=comm)
+        space = VectorSpace(1 if comm.rank == 0 else 0, dtype=dtype, comm=comm)
     x = Vector(space, name=name)
     if not var_is_scalar(x):
         raise RuntimeError("Vector is not scalar-valued")


### PR DESCRIPTION
Includes a dtype fix, and fixes a few cases found when checking for empty arrays.