### PR TITLE
Update checkpoint schedules tests

### DIFF
--- a/tests/checkpoint_schedules/test_binomial.py
+++ b/tests/checkpoint_schedules/test_binomial.py
@@ -180,6 +180,7 @@ def test_MultistageCheckpointSchedule(trajectory,
             # adjoint
             assert model_n == cp_schedule.n
             assert model_r == cp_schedule.r
+            assert cp_schedule.max_n == n
 
             # Either no data is being stored, or exactly one of forward restart
             # or non-linear dependency data is being stored

--- a/tests/checkpoint_schedules/test_binomial.py
+++ b/tests/checkpoint_schedules/test_binomial.py
@@ -121,6 +121,9 @@ def test_MultistageCheckpointSchedule(trajectory,
         ics.update(cp[0])
         model_n = cp_action.n
 
+        # Can advance the forward to the current location of the adjoint
+        assert ics.issuperset(range(model_n, n - model_r))
+
         if cp_action.delete:
             del snapshots[cp_action.n]
 

--- a/tests/checkpoint_schedules/test_mixed.py
+++ b/tests/checkpoint_schedules/test_mixed.py
@@ -203,6 +203,7 @@ def test_MixedCheckpointSchedule(n, S):
             # adjoint
             assert model_n is None or model_n == cp_schedule.n
             assert model_r == cp_schedule.r
+            assert cp_schedule.max_n == n
 
             # Either no data is being stored, or exactly one of forward restart
             # or non-linear dependency data is being stored

--- a/tests/checkpoint_schedules/test_mixed.py
+++ b/tests/checkpoint_schedules/test_mixed.py
@@ -124,6 +124,9 @@ def test_MixedCheckpointSchedule(n, S):
             ics.update(cp[0])
             model_n = cp_action.n
 
+            # Can advance the forward to the current location of the adjoint
+            assert ics.issuperset(range(model_n, n - model_r))
+
         if len(cp[1]) > 0:
             # Loading a non-linear dependency data checkpoint:
 

--- a/tests/checkpoint_schedules/test_validity.py
+++ b/tests/checkpoint_schedules/test_validity.py
@@ -242,6 +242,7 @@ def test_validity(schedule, schedule_kwargs,
             # adjoint
             assert model_n is None or model_n == cp_schedule.n
             assert model_r == cp_schedule.r
+            assert cp_schedule.max_n is None or cp_schedule.max_n == n
 
             # Checkpoint storage limits are not exceeded
             for storage_type, storage_limit in storage_limits.items():

--- a/tests/checkpoint_schedules/test_validity.py
+++ b/tests/checkpoint_schedules/test_validity.py
@@ -175,6 +175,9 @@ def test_validity(schedule, schedule_kwargs,
             ics.update(cp[0])
             model_n = cp_action.n
 
+            # Can advance the forward to the current location of the adjoint
+            assert ics.issuperset(range(model_n, n - model_r))
+
         if len(cp[1]) > 0:
             data.clear()
             data.update(cp[1])


### PR DESCRIPTION
- Check checkpoint schedule max steps while the schedule is running.
- Check that forward restart storage allows the forward to advance sufficiently far when loading checkpoint data.