### PR TITLE
Improve operator overloading

### DIFF
--- a/tests/base/test_base.py
+++ b/tests/base/test_base.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-from tlm_adjoint import clear_caches, reset_manager
+from tlm_adjoint import (
+    clear_caches, set_default_float_dtype, set_default_jax_dtype,
+    reset_manager)
 
 from ..test_base import chdir_tmp_path, seed_test, tmp_path
 
 import logging
+import numpy as np
 import pytest
 
 __all__ = \
@@ -19,6 +22,14 @@ __all__ = \
 
 @pytest.fixture
 def setup_test():
+    try:
+        import petsc4py.PETSc as PETSc
+        default_dtype = PETSc.ScalarType
+    except ImportError:
+        default_dtype = np.double
+    set_default_float_dtype(default_dtype)
+    set_default_jax_dtype(default_dtype)
+
     logging.getLogger("tlm_adjoint").setLevel(logging.DEBUG)
 
     reset_manager("memory", {"drop_references": True})

--- a/tests/base/test_float.py
+++ b/tests/base/test_float.py
@@ -3,8 +3,8 @@
 
 from tlm_adjoint import (
     DEFAULT_COMM, DotProduct, Float, FloatEquation, Hessian, compute_gradient,
-    start_manager, stop_manager, taylor_test, taylor_test_tlm,
-    taylor_test_tlm_adjoint)
+    set_default_float_dtype, start_manager, stop_manager, taylor_test,
+    taylor_test_tlm, taylor_test_tlm_adjoint)
 
 from .test_base import seed_test, setup_test  # noqa: F401
 
@@ -22,6 +22,8 @@ pytestmark = pytest.mark.skipif(
 @seed_test
 def test_Float_new(setup_test,  # noqa: F811
                    value):
+    set_default_float_dtype(np.cdouble)
+
     x = Float(name="x")
     assert complex(x) == 0.0
 
@@ -35,6 +37,8 @@ def test_Float_new(setup_test,  # noqa: F811
 @seed_test
 def test_float_assignment(setup_test,  # noqa: F811
                           dtype):
+    set_default_float_dtype(dtype)
+
     def forward(y):
         x = Float(name="x")
         FloatEquation(x, y).solve()
@@ -85,7 +89,8 @@ def test_float_assignment(setup_test,  # noqa: F811
 
 
 @pytest.mark.base
-@pytest.mark.parametrize("op", [operator.neg,
+@pytest.mark.parametrize("op", [operator.abs,
+                                operator.neg,
                                 np.sin,
                                 np.cos,
                                 np.tan,
@@ -106,6 +111,8 @@ def test_float_assignment(setup_test,  # noqa: F811
 @seed_test
 def test_float_unary_overloading(setup_test,  # noqa: F811
                                  op):
+    set_default_float_dtype(np.double)
+
     def forward(y):
         x = op(y)
         assert abs(float(x) - op(float(y))) < 1.0e-15
@@ -164,6 +171,7 @@ def test_float_binary_overloading(setup_test,  # noqa: F811
                                   dtype, op):
     if op is np.arctan2 and issubclass(dtype, (complex, np.complexfloating)):
         pytest.skip()
+    set_default_float_dtype(dtype)
 
     def forward(y):
         x = y * y

--- a/tests/base/test_jax.py
+++ b/tests/base/test_jax.py
@@ -3,10 +3,10 @@
 
 from tlm_adjoint import (
     DEFAULT_COMM, DotProduct, Float, Hessian, Vector, VectorEquation,
-    compute_gradient, new_jax_float, set_default_jax_dtype, start_manager,
-    stop_manager, taylor_test, taylor_test_tlm, taylor_test_tlm_adjoint,
-    var_get_values, var_global_size, var_is_scalar, var_linf_norm,
-    var_local_size, var_scalar_value, var_sum)
+    compute_gradient, new_jax_float, set_default_float_dtype,
+    set_default_jax_dtype, start_manager, stop_manager, taylor_test,
+    taylor_test_tlm, taylor_test_tlm_adjoint, var_get_values, var_global_size,
+    var_is_scalar, var_linf_norm, var_local_size, var_scalar_value, var_sum)
 
 from .test_base import seed_test, setup_test  # noqa: F401
 
@@ -30,6 +30,7 @@ pytestmark = pytest.mark.skipif(
 @seed_test
 def test_jax_assignment(setup_test,  # noqa: F811
                         dtype):
+    set_default_float_dtype(dtype)
     set_default_jax_dtype(dtype)
 
     def fn(y):
@@ -81,7 +82,8 @@ def test_jax_assignment(setup_test,  # noqa: F811
 @pytest.mark.base
 @pytest.mark.skipif(jax is None, reason="JAX not available")
 @pytest.mark.skipif(DEFAULT_COMM.size > 1, reason="serial only")
-@pytest.mark.parametrize("op", [operator.neg,
+@pytest.mark.parametrize("op", [operator.abs,
+                                operator.neg,
                                 np.sin,
                                 np.cos,
                                 np.tan,
@@ -102,6 +104,7 @@ def test_jax_assignment(setup_test,  # noqa: F811
 @seed_test
 def test_jax_unary_overloading(setup_test,  # noqa: F811
                                op):
+    set_default_float_dtype(np.double)
     set_default_jax_dtype(np.double)
 
     def forward(y):
@@ -161,6 +164,7 @@ def test_jax_unary_overloading(setup_test,  # noqa: F811
 @seed_test
 def test_jax_binary_overloading(setup_test,  # noqa: F811
                                 dtype, op):
+    set_default_float_dtype(dtype)
     set_default_jax_dtype(dtype)
 
     if op is np.arctan2 and issubclass(dtype, (complex, np.complexfloating)):

--- a/tests/fenics/test_base.py
+++ b/tests/fenics/test_base.py
@@ -65,6 +65,7 @@ def setup_test():
     # parameters["tlm_adjoint"]["assembly_verification"]["rhs_tolerance"] \
     #     = 1.0e-12
 
+    set_default_float_dtype(backend_ScalarType)
     set_default_jax_dtype(backend_ScalarType)
 
     logging.getLogger("tlm_adjoint").setLevel(logging.DEBUG)

--- a/tests/firedrake/test_base.py
+++ b/tests/firedrake/test_base.py
@@ -67,6 +67,7 @@ def setup_test():
     # parameters["tlm_adjoint"]["assembly_verification"]["rhs_tolerance"] \
     #     = 1.0e-12
 
+    set_default_float_dtype(backend_ScalarType)
     set_default_jax_dtype(backend_ScalarType)
 
     logging.getLogger("firedrake").setLevel(logging.INFO)


### PR DESCRIPTION
Use `__array_ufunc__` to implement operator overloading. Leads to much more complete coverage with the JAX interface.

Also:
- Overload `Float.abs`. Use positive sub-gradient at the non-differentiable point.
- Avoid precision errors for small inputs with `Float.expm1`, by defining a custom SymPy `Function`.
- Add `set_default_float_dtype`. Closes #390.