### PR TITLE
Add VectorEquation.tangent_linear

### DIFF
--- a/tests/base/test_base.py
+++ b/tests/base/test_base.py
@@ -5,7 +5,7 @@ from tlm_adjoint import (
     clear_caches, set_default_float_dtype, set_default_jax_dtype,
     reset_manager)
 
-from ..test_base import chdir_tmp_path, seed_test, tmp_path
+from ..test_base import chdir_tmp_path, jax_tlm_config, seed_test, tmp_path
 
 import logging
 import numpy as np
@@ -14,6 +14,7 @@ import pytest
 __all__ = \
     [
         "chdir_tmp_path",
+        "jax_tlm_config",
         "seed_test",
         "setup_test",
         "tmp_path"

--- a/tests/base/test_jax.py
+++ b/tests/base/test_jax.py
@@ -8,7 +8,7 @@ from tlm_adjoint import (
     taylor_test_tlm, taylor_test_tlm_adjoint, var_get_values, var_global_size,
     var_is_scalar, var_linf_norm, var_local_size, var_scalar_value, var_sum)
 
-from .test_base import seed_test, setup_test  # noqa: F401
+from .test_base import jax_tlm_config, seed_test, setup_test  # noqa: F401
 
 try:
     import jax
@@ -21,14 +21,16 @@ import pytest
 pytestmark = pytest.mark.skipif(
     DEFAULT_COMM.size not in {1, 4},
     reason="tests must be run in serial, or with 4 processes")
+pytestmark = pytest.mark.skipif(
+    jax is None,
+    reason="JAX not available")
 
 
 @pytest.mark.base
-@pytest.mark.skipif(jax is None, reason="JAX not available")
 @pytest.mark.skipif(DEFAULT_COMM.size > 1, reason="serial only")
 @pytest.mark.parametrize("dtype", [np.double, np.cdouble])
 @seed_test
-def test_jax_assignment(setup_test,  # noqa: F811
+def test_jax_assignment(setup_test, jax_tlm_config,  # noqa: F811
                         dtype):
     set_default_float_dtype(dtype)
     set_default_jax_dtype(dtype)
@@ -80,7 +82,6 @@ def test_jax_assignment(setup_test,  # noqa: F811
 
 
 @pytest.mark.base
-@pytest.mark.skipif(jax is None, reason="JAX not available")
 @pytest.mark.skipif(DEFAULT_COMM.size > 1, reason="serial only")
 @pytest.mark.parametrize("op", [operator.abs,
                                 operator.neg,
@@ -102,7 +103,7 @@ def test_jax_assignment(setup_test,  # noqa: F811
                                 np.log10,
                                 np.sqrt])
 @seed_test
-def test_jax_unary_overloading(setup_test,  # noqa: F811
+def test_jax_unary_overloading(setup_test, jax_tlm_config,  # noqa: F811
                                op):
     set_default_float_dtype(np.double)
     set_default_jax_dtype(np.double)
@@ -137,7 +138,7 @@ def test_jax_unary_overloading(setup_test,  # noqa: F811
 
     ddJ = Hessian(forward)
     min_order = taylor_test(forward, y, J_val=J_val, ddJ=ddJ, seed=1.0e-3)
-    assert min_order > 2.97
+    assert min_order > 2.93
 
     min_order = taylor_test_tlm(forward, y, tlm_order=1, seed=1.0e-3)
     assert min_order > 1.99
@@ -152,7 +153,6 @@ def test_jax_unary_overloading(setup_test,  # noqa: F811
 
 
 @pytest.mark.base
-@pytest.mark.skipif(jax is None, reason="JAX not available")
 @pytest.mark.skipif(DEFAULT_COMM.size > 1, reason="serial only")
 @pytest.mark.parametrize("dtype", [np.double, np.cdouble])
 @pytest.mark.parametrize("op", [operator.add,
@@ -162,7 +162,7 @@ def test_jax_unary_overloading(setup_test,  # noqa: F811
                                 operator.pow,
                                 np.arctan2])
 @seed_test
-def test_jax_binary_overloading(setup_test,  # noqa: F811
+def test_jax_binary_overloading(setup_test, jax_tlm_config,  # noqa: F811
                                 dtype, op):
     set_default_float_dtype(dtype)
     set_default_jax_dtype(dtype)
@@ -218,13 +218,12 @@ def test_jax_binary_overloading(setup_test,  # noqa: F811
 
 
 @pytest.mark.base
-@pytest.mark.skipif(jax is None, reason="JAX not available")
 @pytest.mark.parametrize("dtype", [np.double, np.cdouble])
 @pytest.mark.parametrize("x_val", [-np.sqrt(2.0),
                                    np.sqrt(3.0),
                                    np.sqrt(5.0) + 1.0j * np.sqrt(7.0)])
 @seed_test
-def test_jax_float(setup_test,  # noqa: F811
+def test_jax_float(setup_test, jax_tlm_config,  # noqa: F811
                    dtype, x_val):
     if isinstance(x_val, (complex, np.complexfloating)) \
             and not issubclass(dtype, (complex, np.complexfloating)):

--- a/tests/fenics/test_base.py
+++ b/tests/fenics/test_base.py
@@ -10,7 +10,7 @@ from tlm_adjoint.fenics.backend_code_generator_interface import (
 from tlm_adjoint.alias import gc_disabled
 from tlm_adjoint.override import override_method
 
-from ..test_base import chdir_tmp_path, seed_test, tmp_path
+from ..test_base import chdir_tmp_path, jax_tlm_config, seed_test, tmp_path
 from ..test_base import run_example as _run_example
 
 import gc
@@ -32,6 +32,7 @@ __all__ = \
         "interpolate_expression",
 
         "chdir_tmp_path",
+        "jax_tlm_config",
         "run_example",
         "seed_test",
         "setup_test",

--- a/tests/firedrake/test_base.py
+++ b/tests/firedrake/test_base.py
@@ -11,7 +11,7 @@ from tlm_adjoint.firedrake.backend_code_generator_interface import (
 from tlm_adjoint.alias import gc_disabled
 from tlm_adjoint.override import override_method
 
-from ..test_base import chdir_tmp_path, seed_test, tmp_path
+from ..test_base import chdir_tmp_path, jax_tlm_config, seed_test, tmp_path
 from ..test_base import (
     run_example as _run_example, run_example_notebook as _run_example_notebook)
 
@@ -34,6 +34,7 @@ __all__ = \
         "interpolate_expression",
 
         "chdir_tmp_path",
+        "jax_tlm_config",
         "run_example",
         "run_example_notebook",
         "seed_test",

--- a/tests/firedrake/test_jax.py
+++ b/tests/firedrake/test_jax.py
@@ -16,12 +16,14 @@ import pytest
 pytestmark = pytest.mark.skipif(
     DEFAULT_COMM.size not in {1, 4},
     reason="tests must be run in serial, or with 4 processes")
+pytestmark = pytest.mark.skipif(
+    jax is None,
+    reason="JAX not available")
 
 
 @pytest.mark.firedrake
-@pytest.mark.skipif(jax is None, reason="JAX not available")
 @seed_test
-def test_jax_conversion(setup_test):
+def test_jax_conversion(setup_test, jax_tlm_config):
     mesh = UnitIntervalMesh(20)
     X = SpatialCoordinate(mesh)
     space = FunctionSpace(mesh, "Lagrange", 1)
@@ -64,9 +66,8 @@ def test_jax_conversion(setup_test):
 
 
 @pytest.mark.firedrake
-@pytest.mark.skipif(jax is None, reason="JAX not available")
 @seed_test
-def test_jax_integration(setup_test):
+def test_jax_integration(setup_test, jax_tlm_config):
     mesh = UnitIntervalMesh(20)
     X = SpatialCoordinate(mesh)
     space = FunctionSpace(mesh, "Lagrange", 1)


### PR DESCRIPTION
In JAX a forward+tangent-linear operation

```
x, jvp = jax.linearize(fun, y)
tau_x = jvp(tau_y)
```

defines a map

$$y, \tau_y \mapsto x(y), \tau_x(y, x(y), \tau_y).$$

That is, a dependency $y$ and its associated tangent-linear $\tau_y$ are mapped to both a forward value $x(y)$ and tangent-linear value $\tau_x(y, x(y), \tau_y)$.

The usual tlm_adjoint approach instead splits this into two operations, recorded as two `Equation` objects,

$$y \mapsto x(y),$$

$$y, x, \tau_y \mapsto \tau_x(y, x, \tau_y).$$

However with JAX the values $x(y)$ are intermediates in the evaluation of $\tau_x(y, x(y), \tau_y)$. This means that to perform a reverse mode calculation over the calculations for both $x(y)$ and $\tau_x(y, x(y), \tau_y)$ we must have both as outputs -- we cannot e.g. store $x(y)$ as a side-effect in the evaluation of $\tau_x(y, x(y), \tau_y)$ and then later differentiate it.

This PR implements _two_ different approaches to resolve this. For `VectorEquation(.., with_tlm=True)` (the default) we record a single operation corresponding to

$$y, \tau_y \mapsto x(y), \tau_x(y, x(y), \tau_y).$$

With `VectorEquation(..., with_tlm=False)`, and via the `VectorEquation.tangent_linear` method, we record two operations corresponding to

$$y \mapsto x(y),$$

$$y, \tau_y \mapsto \tau_x(y, x(y), \tau_y).$$

With a single first order tangent-linear the latter performs two forward evaluations, but may be the best that is possible if we want to split the operations.

Closes #393