### PR TITLE
Do not overload `+` operator

### DIFF
--- a/tests/base/test_float.py
+++ b/tests/base/test_float.py
@@ -91,7 +91,6 @@ def test_float_assignment(setup_test,  # noqa: F811
 @pytest.mark.base
 @pytest.mark.parametrize("op", [operator.abs,
                                 operator.neg,
-                                operator.pos,
                                 np.sin,
                                 np.cos,
                                 np.tan,

--- a/tests/base/test_jax.py
+++ b/tests/base/test_jax.py
@@ -85,7 +85,6 @@ def test_jax_assignment(setup_test, jax_tlm_config,  # noqa: F811
 @pytest.mark.skipif(DEFAULT_COMM.size > 1, reason="serial only")
 @pytest.mark.parametrize("op", [operator.abs,
                                 operator.neg,
-                                operator.pos,
                                 np.sin,
                                 np.cos,
                                 np.tan,

--- a/tlm_adjoint/jax.py
+++ b/tlm_adjoint/jax.py
@@ -387,7 +387,8 @@ class Vector(np.lib.mixins.NDArrayOperatorsMixin):
             return NotImplemented
         if len(kwargs) > 0:
             return NotImplemented
-        if ufunc in {np.equal, np.not_equal,
+        if ufunc in {np.positive,
+                     np.equal, np.not_equal,
                      np.less, np.less_equal,
                      np.greater, np.greater_equal}:
             return NotImplemented

--- a/tlm_adjoint/overloaded_float.py
+++ b/tlm_adjoint/overloaded_float.py
@@ -615,11 +615,6 @@ class _tlm_adjoint__OverloadedFloat(np.lib.mixins.NDArrayOperatorsMixin,  # noqa
             return -x
 
     @staticmethod
-    @register_operation(np.positive)
-    def positive(x):
-        return SymbolicFloat.__pos__(x)
-
-    @staticmethod
     @register_operation(np.negative)
     def negative(x):
         return SymbolicFloat.__neg__(x)


### PR DESCRIPTION
Copying in the `+` operator might be problematic when annotation is disabled, e.g.

```
start_manager()
J = forward(m)
stop_manager()
dJ = compute_gradient(+J, m)  # always zero
```

However aliasing could be problematic when the annotation is enabled.

To avoid the ambiguity this PR removes `+` overloading.