### PR TITLE
Add variable state locking

### DIFF
--- a/tests/base/test_equations.py
+++ b/tests/base/test_equations.py
@@ -11,7 +11,8 @@ from .test_base import seed_test, setup_test  # noqa: F401
 import pytest
 
 pytestmark = pytest.mark.skipif(
-    DEFAULT_COMM.size > 1, reason="serial only")
+    DEFAULT_COMM.size not in {1, 4},
+    reason="tests must be run in serial, or with 4 processes")
 
 
 @pytest.mark.base

--- a/tests/base/test_interface.py
+++ b/tests/base/test_interface.py
@@ -1,14 +1,19 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-from tlm_adjoint import DEFAULT_COMM, Float, Vector, var_name
+from tlm_adjoint import (
+    DEFAULT_COMM, Float, StateLockDictionary, Vector, var_lock_state, var_name)
+from tlm_adjoint.interface import (
+    var_decrement_state_lock, var_increment_state_lock, var_state_is_locked)
 
 from .test_base import seed_test, setup_test  # noqa: F401
 
+import itertools
 import pytest
 
 pytestmark = pytest.mark.skipif(
-    DEFAULT_COMM.size > 1, reason="serial only")
+    DEFAULT_COMM.size not in {1, 4},
+    reason="tests must be run in serial, or with 4 processes")
 
 
 @pytest.mark.base
@@ -22,3 +27,169 @@ def test_name(setup_test,  # noqa: F811
     name = "_tlm_adjoint__test_name"
     F = cls(name=name)
     assert var_name(F) == name
+
+
+@pytest.mark.base
+@seed_test
+def test_state_lock(setup_test):  # noqa: F811
+    class Test:
+        pass
+
+    f = Float(1.0)
+    assert not var_state_is_locked(f)
+
+    # Increment 10 times with the same object ...
+    t = Test()
+    assert not var_state_is_locked(f)
+    for _ in range(10):
+        var_increment_state_lock(f, t)
+        assert var_state_is_locked(f)
+    # ... then decrement 10 times with the same object
+    for _ in range(9):
+        var_decrement_state_lock(f, t)
+        assert var_state_is_locked(f)
+    var_decrement_state_lock(f, t)
+    assert not var_state_is_locked(f)
+
+    # Increment 10 times with the same object ...
+    t = Test()
+    assert not var_state_is_locked(f)
+    for _ in range(10):
+        var_increment_state_lock(f, t)
+        assert var_state_is_locked(f)
+    # ... then destroy the object
+    del t
+    assert not var_state_is_locked(f)
+
+    # Increment 10 times each with 10 different objects ...
+    assert not var_state_is_locked(f)
+    T = [Test() for _ in range(10)]
+    for t, _ in itertools.product(T, range(10)):
+        var_increment_state_lock(f, t)
+        assert var_state_is_locked(f)
+    # ... then destroy the objects
+    t = None
+    assert var_state_is_locked(f)
+    while len(T) > 1:
+        T.pop()
+        assert var_state_is_locked(f)
+    T.pop()
+    assert not var_state_is_locked(f)
+
+    # Increment 10 times using itself ...
+    assert not var_state_is_locked(f)
+    for _ in range(10):
+        var_increment_state_lock(f, f)
+        assert var_state_is_locked(f)
+    # ... then decrement 10 times using itself
+    for _ in range(9):
+        var_decrement_state_lock(f, f)
+        assert var_state_is_locked(f)
+    var_decrement_state_lock(f, f)
+    assert not var_state_is_locked(f)
+
+    # Lock
+    assert not var_state_is_locked(f)
+    var_lock_state(f)
+    assert var_state_is_locked(f)
+
+
+@pytest.mark.base
+@seed_test
+def test_StateLockDictionary(setup_test):  # noqa: F811
+    f = Float(1.0)
+    assert not var_state_is_locked(f)
+
+    def test_setitem(d, key, value, s):
+        assert len(d) == s
+        assert key not in d
+        try:
+            d[key]
+            assert False
+        except KeyError:
+            pass
+
+        d[key] = value
+
+        assert len(d) == s + 1
+        assert key in d
+        assert d[key] is value
+
+    def test_delitem(d, key, value, delfn, s):
+        assert len(d) == s
+        assert key in d
+        assert d[key] is value
+
+        delfn(d, key)
+
+        assert len(d) == s - 1
+        assert key not in d
+        try:
+            d[key]
+            assert False
+        except KeyError:
+            pass
+
+    def delfn_del(d, key):
+        del d[key]
+
+    def delfn_pop(d, key):
+        d.pop(key)
+
+    def test_replaceitem(d, key, oldvalue, newvalue, s):
+        assert len(d) == s
+        assert key in d
+        assert d[key] is oldvalue
+
+        d[key] = newvalue
+
+        assert len(d) == s
+        assert key in d
+        assert d[key] is newvalue
+
+    keys = list(itertools.chain.from_iterable(
+        ([i, (i,), str(i)]) for i in range(10)))
+
+    # Add items, delete items with del and pop
+    for delfn in (delfn_del, delfn_pop):
+        d = StateLockDictionary()
+        assert not var_state_is_locked(f)
+        for i, key in enumerate(keys):
+            test_setitem(d, key, f, i)
+            assert var_state_is_locked(f)
+        for i, key in enumerate(keys[1:]):
+            test_delitem(d, key, f, delfn, len(keys) - i)
+            assert var_state_is_locked(f)
+        test_delitem(d, keys[0], f, delfn, 1)
+        assert not var_state_is_locked(f)
+
+    # Add items, replace items with None
+    d = StateLockDictionary()
+    assert not var_state_is_locked(f)
+    for i, key in enumerate(keys):
+        test_setitem(d, key, f, i)
+        assert var_state_is_locked(f)
+    for key in keys[1:]:
+        test_replaceitem(d, key, f, None, len(keys))
+        assert var_state_is_locked(f)
+    test_replaceitem(d, keys[0], f, None, len(keys))
+    assert not var_state_is_locked(f)
+
+    # Add items, clear
+    d = StateLockDictionary()
+    assert not var_state_is_locked(f)
+    for i, key in enumerate(keys):
+        test_setitem(d, key, f, i)
+        assert var_state_is_locked(f)
+    d.clear()
+    assert len(d) == 0
+    assert not var_state_is_locked(f)
+
+    # Add items, destroy the StateLockDictionary
+    d = StateLockDictionary()
+    assert not var_state_is_locked(f)
+    for i, key in enumerate(keys):
+        test_setitem(d, key, f, i)
+        assert var_state_is_locked(f)
+    del d
+    assert not var_state_is_locked(f)

--- a/tests/base/test_manager.py
+++ b/tests/base/test_manager.py
@@ -16,7 +16,8 @@ import numpy as np
 import pytest
 
 pytestmark = pytest.mark.skipif(
-    DEFAULT_COMM.size > 1, reason="serial only")
+    DEFAULT_COMM.size not in {1, 4},
+    reason="tests must be run in serial, or with 4 processes")
 
 
 @pytest.mark.base
@@ -207,6 +208,7 @@ def test_tlm_annotation(setup_test):  # noqa: F811
 
 @pytest.mark.base
 @pytest.mark.parametrize("cp_method", ["memory", "multistage"])
+@pytest.mark.skipif(DEFAULT_COMM.size > 1, reason="serial only")
 @seed_test
 def test_random_computational_graph(setup_test,  # noqa: F811
                                     tmp_path, cp_method):

--- a/tests/firedrake/test_interface.py
+++ b/tests/firedrake/test_interface.py
@@ -85,13 +85,13 @@ def test_Function_alias(setup_test, test_leaks,
         state = var_state(F_i)
         assert var_state(F_i) == var_state(F)
         var_update_state(F)
-        assert var_state(F_i) == state + 1
+        assert var_state(F_i) > state
         assert var_state(F_i) == var_state(F)
 
         state = var_state(F_i)
         assert var_state(F_i) == var_state(F)
         var_update_state(F_i)
-        assert var_state(F_i) == state + 1
+        assert var_state(F_i) > state
         assert var_state(F_i) == var_state(F)
 
     F = Function(space, name="F")

--- a/tlm_adjoint/adjoint.py
+++ b/tlm_adjoint/adjoint.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from .interface import (
-    finalize_adjoint_derivative_action, space_new,
+    StateLockDictionary, finalize_adjoint_derivative_action, space_new,
     subtract_adjoint_derivative_action, var_copy, var_id, var_space,
     var_space_type)
 
@@ -502,7 +502,7 @@ class TransposeComputationalGraph:
 
 class AdjointCache:
     def __init__(self):
-        self._cache = {}
+        self._cache = StateLockDictionary()
         self._keys = {}
         self._cache_key = None
 

--- a/tlm_adjoint/cached_hessian.py
+++ b/tlm_adjoint/cached_hessian.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-from .interface import var_id, var_new, var_scalar_value, var_state
+from .interface import (
+    StateLockDictionary, var_id, var_new, var_scalar_value, var_state)
 
 from .caches import clear_caches
 from .hessian import GaussNewton, Hessian
@@ -29,10 +30,10 @@ class HessianOptimization:
 
         blocks = list(manager._blocks) + [list(manager._block)]
 
-        ics = dict(manager._cp.initial_conditions(cp=True, refs=True,
-                                                  copy=False))
+        ics = StateLockDictionary(
+            manager._cp.initial_conditions(cp=True, refs=True, copy=False))
 
-        nl_deps = {}
+        nl_deps = StateLockDictionary()
         for n, block in enumerate(blocks):
             for i, eq in enumerate(block):
                 nl_deps[(n, i)] = manager._cp[(n, i)]

--- a/tlm_adjoint/eigendecomposition.py
+++ b/tlm_adjoint/eigendecomposition.py
@@ -25,8 +25,8 @@ class PythonMatrix:
     def mult(self, A, x, y):
         import petsc4py.PETSc as PETSc
 
-        with x as x_a:
-            y_a = self._action(x_a)
+        x_a = x.getArray(True).copy()
+        y_a = self._action(x_a)
 
         if not np.can_cast(y_a, PETSc.ScalarType):
             raise ValueError("Invalid dtype")
@@ -239,20 +239,18 @@ def eigendecompose(space, A_action, *, B_action=None, arg_space_type="primal",
             assert lam_i.imag == 0.0
             lam[i] = lam_i.real
             if v_i is not None:
-                with v_i as v_i_a:
-                    assert len(v_i_a) == 0 or abs(v_i_a).max() == 0.0
+                v_i_a = v_i.getArray()
+                assert len(v_i_a) == 0 or abs(v_i_a).max() == 0.0
+                del v_i_a
             # else:
             #     # Complex note: If v_i is None then v_r may be non-real
             #     pass
-            with v_r as v_r_a:
-                var_set_values(V_r[i], v_r_a)
+            var_set_values(V_r[i], v_r.getArray(True))
         else:
             lam[i] = lam_i
-            with v_r as v_r_a:
-                var_set_values(V_r[i], v_r_a)
+            var_set_values(V_r[i], v_r.getArray(True))
             if v_i is not None:
-                with v_i as v_i_a:
-                    var_set_values(V_i[i], v_i_a)
+                var_set_values(V_i[i], v_i.getArray(True))
 
     esolver.destroy()
     A_matrix.destroy()

--- a/tlm_adjoint/equation.py
+++ b/tlm_adjoint/equation.py
@@ -431,6 +431,7 @@ class Equation(Referrer):
 
             if is_var(adj_X):
                 adj_X = (adj_X,)
+            var_update_state(*adj_X)
 
             for m, adj_x in enumerate(adj_X):
                 check_space_types(adj_x, self.X(m),

--- a/tlm_adjoint/fenics/backend_interface.py
+++ b/tlm_adjoint/fenics/backend_interface.py
@@ -11,7 +11,7 @@ from ..interface import (
     register_subtract_adjoint_derivative_action, space_id,
     subtract_adjoint_derivative_action,
     subtract_adjoint_derivative_action_base, var_copy, var_linf_norm,
-    var_scalar_value, var_space, var_space_type)
+    var_lock_state, var_scalar_value, var_space, var_space_type)
 from ..interface import VariableInterface as _VariableInterface
 from .backend_code_generator_interface import assemble, r0_space
 
@@ -298,17 +298,9 @@ class ZeroFunction(Function, Zero):
         Function.__init__(
             self, *args, **kwargs,
             static=True, cache=True)
+        var_lock_state(self)
         if var_linf_norm(self) != 0.0:
             raise RuntimeError("ZeroFunction is not zero-valued")
-
-    def assign(self, *args, **kwargs):
-        raise RuntimeError("Cannot call assign method of ZeroFunction")
-
-    def interpolate(self, *args, **kwargs):
-        raise RuntimeError("Cannot call interpolate method of ZeroFunction")
-
-    def project(self, *args, **kwargs):
-        raise RuntimeError("Cannot call project method of ZeroFunction")
 
 
 # Aim for compatibility with FEniCS 2019.1.0 API

--- a/tlm_adjoint/fenics/functions.py
+++ b/tlm_adjoint/fenics/functions.py
@@ -11,8 +11,9 @@ from .backend import (
 from ..interface import (
     DEFAULT_COMM, SpaceInterface, add_interface, comm_parent, is_var,
     space_comm, var_caches, var_comm, var_dtype, var_derivative_space, var_id,
-    var_is_cached, var_is_replacement, var_is_static, var_linf_norm, var_name,
-    var_replacement, var_scalar_value, var_space, var_space_type)
+    var_is_cached, var_is_replacement, var_is_static, var_linf_norm,
+    var_lock_state, var_name, var_replacement, var_scalar_value, var_space,
+    var_space_type)
 from ..interface import VariableInterface as _VariableInterface
 
 from ..caches import Caches
@@ -318,15 +319,6 @@ class Zero:
     variables for which UFL zero elimination should not be applied.
     """
 
-    def _tlm_adjoint__var_interface_assign(self, y):
-        raise RuntimeError("Cannot call _assign interface of Zero")
-
-    def _tlm_adjoint__var_interface_axpy(self, alpha, x, /):
-        raise RuntimeError("Cannot call _axpy interface of Zero")
-
-    def _tlm_adjoint__var_interface_set_values(self, values):
-        raise RuntimeError("Cannot call _set_values interface of Zero")
-
     def _tlm_adjoint__var_interface_update_state(self):
         raise RuntimeError("Cannot call _update_state interface of Zero")
 
@@ -343,11 +335,9 @@ class ZeroConstant(Constant, Zero):
         Constant.__init__(
             self, name=name, domain=domain, space=space, space_type=space_type,
             shape=shape, comm=comm, static=True, cache=True)
+        var_lock_state(self)
         if var_linf_norm(self) != 0.0:
             raise RuntimeError("ZeroConstant is not zero-valued")
-
-    def assign(self, *args, **kwargs):
-        raise RuntimeError("Cannot call assign method of ZeroConstant")
 
 
 def extract_coefficients(expr):

--- a/tlm_adjoint/firedrake/backend_interface.py
+++ b/tlm_adjoint/firedrake/backend_interface.py
@@ -11,8 +11,8 @@ from ..interface import (
     register_subtract_adjoint_derivative_action, relative_space_type,
     space_type_warning, subtract_adjoint_derivative_action,
     subtract_adjoint_derivative_action_base, var_caches, var_id, var_is_alias,
-    var_is_cached, var_is_static, var_linf_norm, var_name, var_space,
-    var_space_type)
+    var_is_cached, var_is_static, var_linf_norm, var_lock_state, var_name,
+    var_space, var_space_type)
 from ..interface import VariableInterface as _VariableInterface
 from .backend_code_generator_interface import assemble, r0_space
 
@@ -303,17 +303,9 @@ class ZeroFunction(Function, Zero):
         Function.__init__(
             self, *args, **kwargs,
             static=True, cache=True)
+        var_lock_state(self)
         if var_linf_norm(self) != 0.0:
             raise RuntimeError("ZeroFunction is not zero-valued")
-
-    def assign(self, *args, **kwargs):
-        raise RuntimeError("Cannot call assign method of ZeroFunction")
-
-    def interpolate(self, *args, **kwargs):
-        raise RuntimeError("Cannot call interpolate method of ZeroFunction")
-
-    def project(self, *args, **kwargs):
-        raise RuntimeError("Cannot call project method of ZeroFunction")
 
 
 @override_method(backend_Function, "__init__")

--- a/tlm_adjoint/firedrake/functions.py
+++ b/tlm_adjoint/firedrake/functions.py
@@ -11,8 +11,9 @@ from .backend import (
 from ..interface import (
     DEFAULT_COMM, SpaceInterface, add_interface, comm_parent, is_var,
     space_comm, var_caches, var_comm, var_dtype, var_derivative_space, var_id,
-    var_is_cached, var_is_replacement, var_is_static, var_linf_norm, var_name,
-    var_replacement, var_scalar_value, var_space, var_space_type)
+    var_is_cached, var_is_replacement, var_is_static, var_linf_norm,
+    var_lock_state, var_name, var_replacement, var_scalar_value, var_space,
+    var_space_type)
 from ..interface import VariableInterface as _VariableInterface
 
 from ..caches import Caches
@@ -361,6 +362,7 @@ class ZeroConstant(Constant, Zero):
         Constant.__init__(
             self, name=name, domain=domain, space=space, space_type=space_type,
             shape=shape, comm=comm, static=True, cache=True)
+        var_lock_state(self)
         if var_linf_norm(self) != 0.0:
             raise RuntimeError("ZeroConstant is not zero-valued")
 
@@ -368,9 +370,6 @@ class ZeroConstant(Constant, Zero):
         return Constant.__new__(
             cls, constant_value(shape=shape), *args,
             shape=shape, static=True, cache=True, **kwargs)
-
-    def assign(self, *args, **kwargs):
-        raise RuntimeError("Cannot call assign method of ZeroConstant")
 
 
 def as_coefficient(x):

--- a/tlm_adjoint/interface.py
+++ b/tlm_adjoint/interface.py
@@ -1045,10 +1045,14 @@ class StateLockDictionary(MutableMapping):
 
 
 def var_update_state(*X):
-    """Update the state counter for zero of more variables. Invalidates cache
-    entries.
+    """Ensure that variable state is updated, and check for cache invalidation.
 
-    :arg X: A :class:`tuple` of variables whose state value should be updated.
+    May delegate updating of the state to a backend library, in which case this
+    function checks that the state has been updated since the last
+    :func:`.var_update_state` call (or since instantiation on the first call),
+    and updates the backend state again only if needed.
+
+    :arg X: A :class:`tuple` of variables.
     """
 
     for x in X:

--- a/tlm_adjoint/optimization.py
+++ b/tlm_adjoint/optimization.py
@@ -980,25 +980,26 @@ def minimize_tao(forward, M0, *,
         M_inv_action = wrapped_action(M_inv_action, copy=False)
 
     def from_petsc(y, X):
-        with y as y_a:
-            if not issubclass(y_a.dtype.type, (float, np.floating)):
-                raise ValueError("Invalid dtype")
-            if len(y_a.shape) != 1:
-                raise ValueError("Invalid shape")
+        y_a = y.getArray(True)
 
-            i0 = 0
-            if len(X) != len(indices):
-                raise ValueError("Invalid length")
-            for j, x in enumerate(X):
-                i1 = i0 + var_local_size(x)
-                if i1 > y_a.shape[0]:
-                    raise ValueError("Invalid shape")
-                if (i0, i1) != indices[j]:
-                    raise ValueError("Invalid shape")
-                var_set_values(x, y_a[i0:i1])
-                i0 = i1
-            if i0 != y_a.shape[0]:
+        if not issubclass(y_a.dtype.type, (float, np.floating)):
+            raise ValueError("Invalid dtype")
+        if len(y_a.shape) != 1:
+            raise ValueError("Invalid shape")
+
+        i0 = 0
+        if len(X) != len(indices):
+            raise ValueError("Invalid length")
+        for j, x in enumerate(X):
+            i1 = i0 + var_local_size(x)
+            if i1 > y_a.shape[0]:
                 raise ValueError("Invalid shape")
+            if (i0, i1) != indices[j]:
+                raise ValueError("Invalid shape")
+            var_set_values(x, y_a[i0:i1])
+            i0 = i1
+        if i0 != y_a.shape[0]:
+            raise ValueError("Invalid shape")
 
     def to_petsc(x, Y):
         x_a = np.zeros(n, dtype=PETSc.ScalarType)


### PR DESCRIPTION
tlm_adjoint maintains an internal variable 'state'. This state is updated whenever a change to a variable is recorded, which occurs when
- The variable is updated by `Equation.forward` or (as of this PR) `Equation.adjoint`.
- The variable is updated using `var_`-prefixed interface functions.
- Variable updates are recorded in FEniCS/Firedrake overrides.
- With the Firedrake backend (as of this PR): When a `dat_version` changes.

Previously state changes have been used to invalidate cache entries. This PR adds variable state locking, so that attempting to update the state of a locked variable will raise an exception. The primary approach is to use either
- `var_lock_state`: Lock the state of a variable until it is destroyed.
- `StateLockDictionary`: Lock the state of a variable for as long as it is a value in the dictionary.

Internally these use  `var_increment_state_lock` and `var_decrement_state_lock` to increment and decrement state locks.

Locks are held by objects -- in the `StateLockDictionary` case by the `StateLockDictionary` itself -- and are automatically released if those objects are destroyed. Consequently a `StateLockDictionary` must be used *very* carefully, as destruction via the garbage collector may lead to non-deterministic release of the lock.

In this PR state locking is used for:
- `Zero` objects, locked on instantiation and until they are destroyed.
- Checkpoint storage.
- Forward data in a `CachedHessian`.
- Adjoint caches.

The primary pattern this approach addresses is the following:
```
m = Function(space, name="m", static=True)
m.assign(1.0)
start_manager()
J = forward(m)
stop_manager()
m.assign(0.0)
```
The issue here is that, since `m` is static, it can be stored by reference for use by the adjoint or for checkpointing. (Such storage by reference is itself required for assembly/solver caching, to avoid unnecessarily invalidating cache entries). Subsequently changing the value of `m` changes the stored data, and can lead to adjoint inconsistency. With this PR, if this occurs, an exception will be raised on the second `m.assign` call.

Possible future extensions:
- Check non-modification assumptions in `Equation` methods -- e.g. check that `nl_deps`  is not modified by a call to `Equation.adjoint`.
- Make use of the PETSc `VecLockReadPush` and `VecLockReadPop` functions (not currently exposed via the Python bindings).

Closes #364