### PR TITLE
Expand use of variable state locks

### DIFF
--- a/tests/firedrake/test_interface.py
+++ b/tests/firedrake/test_interface.py
@@ -2,10 +2,13 @@
 # -*- coding: utf-8 -*-
 
 from firedrake import *
+from tlm_adjoint.alias import WeakAlias
+from tlm_adjoint.interface import VariableStateChangeError
 from tlm_adjoint.firedrake import *
 
 from .test_base import *
 
+import gc
 import pytest
 import ufl
 
@@ -153,3 +156,81 @@ def test_scalar_var(setup_test, test_leaks):
     test_scalar(Constant((0.0, 0.0)), False)
     test_scalar(Function(space), False)
     test_scalar(Cofunction(space.dual()), False)
+
+
+@pytest.mark.firedrake
+@seed_test
+def test_DirichletBC_locking(setup_test, test_leaks):
+    def new_bc(space_cls):
+        mesh = UnitSquareMesh(10, 10)
+        space = space_cls(mesh, "Lagrange", 1)
+        bc_value = Function(space, name="bc_value")
+        bc = DirichletBC(space, bc_value, "on_boundary", static=True)
+        return space, bc
+
+    def new_hbc(space_cls):
+        mesh = UnitSquareMesh(10, 10)
+        space = space_cls(mesh, "Lagrange", 1)
+        bc = HomogeneousDirichletBC(space, "on_boundary")
+        return space, bc
+
+    for space_cls in (FunctionSpace,
+                      VectorFunctionSpace,
+                      TensorFunctionSpace):
+        _, bc = new_bc(space_cls)
+        try:
+            bc.homogenize()
+            assert False
+        except VariableStateChangeError:
+            pass
+        del bc
+
+        space, bc = new_bc(space_cls)
+        try:
+            bc.set_value(Function(space))
+            assert False
+        except VariableStateChangeError:
+            pass
+        del space, bc
+
+        space, bc = new_bc(space_cls)
+        try:
+            bc.function_arg = Function(space)
+            assert False
+        except VariableStateChangeError:
+            pass
+        del space, bc
+
+        _, bc = new_hbc(space_cls)
+        bc.homogenize()
+        del bc
+
+    def new_eq():
+        mesh = UnitSquareMesh(10, 10)
+        space = FunctionSpace(mesh, "Lagrange", 1)
+        bc_value = Function(space, name="bc_value")
+        bc = DirichletBC(space, bc_value, "on_boundary")
+        test, trial = TestFunction(space), TrialFunction(space)
+        u = Function(space, name="u")
+        eq = EquationSolver(inner(trial, test) * dx
+                            == inner(Constant(1.0), test) * dx, u, bc)
+        return space, bc, eq
+
+    _, bc, eq = new_eq()
+    try:
+        bc.homogenize()
+        assert False
+    except VariableStateChangeError:
+        pass
+    del bc, eq
+
+    _, bc, eq = new_eq()
+    eq = WeakAlias(eq)
+    gc.collect()
+    garbage_cleanup()
+    try:
+        bc.homogenize()
+        assert False
+    except VariableStateChangeError:
+        pass
+    del bc, eq

--- a/tlm_adjoint/fenics/equations.py
+++ b/tlm_adjoint/fenics/equations.py
@@ -10,9 +10,9 @@ from .backend import (
     TestFunction, TrialFunction, adjoint, backend_Constant,
     backend_DirichletBC, backend_Function, parameters)
 from ..interface import (
-    check_space_type, is_var, var_assign, var_id, var_is_scalar, var_new,
-    var_new_conjugate_dual, var_replacement, var_scalar_value, var_space,
-    var_zero)
+    check_space_type, is_var, var_assign, var_id, var_increment_state_lock,
+    var_is_scalar, var_new, var_new_conjugate_dual, var_replacement,
+    var_scalar_value, var_space, var_zero)
 from .backend_code_generator_interface import (
     assemble, assemble_linear_solver, copy_parameters_dict,
     form_compiler_quadrature_parameters, homogenize, interpolate_expression,
@@ -29,6 +29,7 @@ from .functions import (
     ReplacementConstant, bcs_is_cached, bcs_is_homogeneous, bcs_is_static,
     derivative, eliminate_zeros, extract_coefficients)
 
+import itertools
 import numpy as np
 try:
     import ufl_legacy as ufl
@@ -391,6 +392,15 @@ class EquationSolver(ExprEquation):
 
         hbcs = tuple(map(homogenized_bc, bcs))
 
+        class DirichletBCLock:
+            pass
+
+        bc_lock = DirichletBCLock()
+        for bc in itertools.chain(bcs, hbcs):
+            bc_value = getattr(bc, "_tlm_adjoint__bc_value", None)
+            if is_var(bc_value):
+                var_increment_state_lock(bc_value, bc_lock)
+
         if cache_jacobian is None:
             cache_jacobian = is_cached(J) and bcs_is_cached(bcs)
         if cache_adjoint_jacobian is None:
@@ -429,6 +439,7 @@ class EquationSolver(ExprEquation):
         self._rhs = rhs
         self._bcs = bcs
         self._hbcs = hbcs
+        self._bc_lock = bc_lock
         self._J = J
         self._nl_solve_J = nl_solve_J
         self._form_compiler_parameters = form_compiler_parameters

--- a/tlm_adjoint/firedrake/backend_interface.py
+++ b/tlm_adjoint/firedrake/backend_interface.py
@@ -220,10 +220,13 @@ class FunctionInterfaceBase(_VariableInterface):
         return slice(*local_range)
 
     def _get_values(self):
-        return self.dat.data_ro.flatten().copy()
+        with self.dat.vec_ro as x_v:
+            x_a = x_v.getArray(True)
+        return x_a.copy()
 
     def _set_values(self, values):
-        self.dat.data[:] = values.reshape(self.dat.data_ro.shape)[:]
+        with self.dat.vec_wo as x_v:
+            x_v.setArray(values)
 
     def _is_replacement(self):
         return False

--- a/tlm_adjoint/interface.py
+++ b/tlm_adjoint/interface.py
@@ -974,6 +974,10 @@ def var_decrement_state_lock(x, obj):
         del obj._tlm_adjoint__state_locks[x_id]
 
 
+class VariableStateChangeError(RuntimeError):
+    pass
+
+
 def var_lock_state(x):
     """Lock the state of a variable.
 
@@ -997,7 +1001,7 @@ def var_state_is_locked(x):
 def var_check_state_lock(x):
     if var_state_is_locked(x) \
             and x._tlm_adjoint__state_lock_state != var_state(x):
-        raise RuntimeError("State change while locked")
+        raise VariableStateChangeError("State change while locked")
 
 
 class StateLockDictionary(MutableMapping):
@@ -1060,7 +1064,8 @@ def var_update_state(*X):
             raise ValueError("x cannot be a replacement")
         var_check_state_lock(x)
         if var_state_is_locked(x):
-            raise RuntimeError("Cannot update state for locked variable")
+            raise VariableStateChangeError("Cannot update state for locked "
+                                           "variable")
         x._tlm_adjoint__var_interface_update_state()
     var_update_caches(*X)
 

--- a/tlm_adjoint/interface.py
+++ b/tlm_adjoint/interface.py
@@ -1252,7 +1252,12 @@ def var_get_values(x):
         freedom.
     """
 
-    return x._tlm_adjoint__var_interface_get_values()
+    values = x._tlm_adjoint__var_interface_get_values()
+    if not np.can_cast(values, var_dtype(x)):
+        raise ValueError("Invalid dtype")
+    if values.shape != (var_local_size(x),):
+        raise ValueError("Invalid shape")
+    return values
 
 
 def var_set_values(x, values):
@@ -1266,7 +1271,7 @@ def var_set_values(x, values):
 
     if not np.can_cast(values, var_dtype(x)):
         raise ValueError("Invalid dtype")
-    if not values.shape == (var_local_size(x),):
+    if values.shape != (var_local_size(x),):
         raise ValueError("Invalid shape")
     x._tlm_adjoint__var_interface_set_values(values)
     var_update_state(x)


### PR DESCRIPTION
- For the functional with `CachedHessian` objects.
- For the state with `CachedGaussNewton` objects.
- With `DirichletBC` objects.

The latter in particular leads to an exception being raised if a `DirichletBC`, used by an `EquationSolver`, is modified in a way tlm_adjoint can detect. This could perhaps be replaced by allowing `DirichletBC` objects to be variables (see #422).