### PR TITLE
FEniCS backend: `Function.interpolate` annotation

### DIFF
--- a/tests/fenics/test_overrides.py
+++ b/tests/fenics/test_overrides.py
@@ -158,8 +158,11 @@ def test_overrides(setup_test, test_leaks):
 
 
 @pytest.mark.fenics
+@pytest.mark.parametrize("assign_fn", [lambda x, y: x.assign(y),
+                                       lambda x, y: x.interpolate(y)])
 @seed_test
-def test_Function_assign(setup_test, test_leaks):
+def test_Function_assign(setup_test, test_leaks,
+                         assign_fn):
     mesh = UnitIntervalMesh(10)
     space = FunctionSpace(mesh, "Lagrange", 1)
 
@@ -170,22 +173,22 @@ def test_Function_assign(setup_test, test_leaks):
         u.assign(u + 2.0 * m)
 
         m_ = Function(space, name="m")
-        m_.assign(m)
+        assign_fn(m_, m)
         m = m_
         del m_
 
         u_ = Function(space, name="u")
-        u_.assign(u)
+        assign_fn(u_, u)
         u = u_
         del u_
 
         one = Function(space, name="one")
-        one.assign(Constant(1.0))
+        assign_fn(one, Constant(1.0))
 
         v = Function(space, name="v")
-        v.assign(u)
+        assign_fn(v, u)
         v.assign(u + one)
-        v.assign(Constant(0.0))
+        assign_fn(v, Constant(0.0))
         v.assign(u + v + one)
         v.assign(2.5 * u + 3.6 * v + 4.7 * m)
 

--- a/tests/firedrake/test_overrides.py
+++ b/tests/firedrake/test_overrides.py
@@ -117,8 +117,11 @@ def test_overrides(setup_test, test_leaks):
 
 
 @pytest.mark.firedrake
+@pytest.mark.parametrize("assign_fn", [lambda x, y: x.assign(y),
+                                       lambda x, y: x.interpolate(y)])
 @seed_test
-def test_Function_assign(setup_test, test_leaks):
+def test_Function_assign(setup_test, test_leaks,
+                         assign_fn):
     mesh = UnitIntervalMesh(10)
     space = FunctionSpace(mesh, "Lagrange", 1)
 
@@ -129,11 +132,11 @@ def test_Function_assign(setup_test, test_leaks):
         u.assign(u + 2.0 * m)
 
         v = Function(space, name="v")
-        v.assign(u)
-        v.assign(u + Constant(1.0))
+        assign_fn(v, u)
+        assign_fn(v, u + Constant(1.0))
         v.assign(0.0)
-        v.assign(u + v + Constant(1.0))
-        v.assign(2.5 * u + 3.6 * v + 4.7 * m)
+        assign_fn(v, u + v + Constant(1.0))
+        assign_fn(v, 2.5 * u + 3.6 * v + 4.7 * m)
 
         J = Functional(name="J")
         J.assign(((v - 1.0) ** 4) * dx)

--- a/tlm_adjoint/fenics/backend_overrides.py
+++ b/tlm_adjoint/fenics/backend_overrides.py
@@ -461,10 +461,19 @@ def Function_copy(self, orig, orig_args, deepcopy=False, *, annotate, tlm):
     return F
 
 
-@override_method(backend_Function, "interpolate")
-def Function_interpolate(self, orig, orig_args, *args, **kwargs):
+@manager_method(backend_Function, "interpolate",
+                post_call=var_update_state_post_call)
+def Function_interpolate(self, orig, orig_args, u, *, annotate, tlm):
+    if u is self:
+        eq = None
+    else:
+        eq = ExprInterpolation(self, u)
+
+    if eq is not None:
+        assert len(eq.initial_condition_dependencies()) == 0
     return_value = orig_args()
-    var_update_state(self)
+    if eq is not None:
+        eq._post_process(annotate=annotate, tlm=tlm)
     return return_value
 
 

--- a/tlm_adjoint/fenics/fenics_equations.py
+++ b/tlm_adjoint/fenics/fenics_equations.py
@@ -152,6 +152,8 @@ def greedy_coloring(space):
         cell_nodes = dofmap.cell_dofs(i)
         for j in cell_nodes:
             for k in cell_nodes:
+                if j < 0 or j >= N:
+                    raise IndexError("Node index out of range")
                 if j != k:
                     node_node_graph[j].add(k)
     node_node_graph = tuple(sorted(nodes, reverse=True)

--- a/tlm_adjoint/firedrake/backend_overrides.py
+++ b/tlm_adjoint/firedrake/backend_overrides.py
@@ -402,6 +402,7 @@ def SameMeshInterpolator_interpolate(
     if len(args) != len(function):
         raise TypeError("Unexpected number of functions")
     expr = ufl.replace(self.expr, dict(zip(args, function)))
+    expr = expr_new_x(expr, return_value, annotate=annotate, tlm=tlm)
     eq = ExprInterpolation(return_value, expr)
 
     assert len(eq.initial_condition_dependencies()) == 0


### PR DESCRIPTION
Handles only basic assignment cases, but raises exceptions in unsupported cases.