### PR TITLE
Remove legacy FEniCS references from the documentation

### DIFF
--- a/docs/source/examples/0_getting_started.ipynb
+++ b/docs/source/examples/0_getting_started.ipynb
@@ -80,7 +80,7 @@
    "source": [
     "The key changes here are:\n",
     "\n",
-    "- To import tlm_adjoint. Here no backend library (e.g. FEniCS or Firedrake) is needed.\n",
+    "- To import tlm_adjoint.\n",
     "- Controlling the 'manager' &ndash; an object tlm_adjoint uses to process equations. The manager is first reset using `reset_manager`. This clears any previous processing, and disables the manager. `start_manager` and `stop_manager` are then used to enable the manager just when it is needed.\n",
     "- Defining `x` and `y` to be of type `Float`. Calculations involving `x` and `y` are recorded by the manager. The result of the calculations &ndash; here `z` &ndash; will have the same type, and we can access its value with `float(z)`.\n",
     "\n",

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -2,8 +2,7 @@ tlm_adjoint
 ===========
 
 tlm_adjoint is a high-level algorithmic differentiation tool, principally for
-use with `FEniCS <https://fenicsproject.org>`_ or `Firedrake
-<https://firedrakeproject.org>`_.
+use with `Firedrake <https://firedrakeproject.org>`_.
 
 The primary aim of tlm_adjoint is to enable higher order adjoint calculations
 -- and in particular to compute Hessian information -- while also using adjoint
@@ -13,9 +12,9 @@ data, and caching of linear solver data.
 Features
 --------
 
-    - Integrates with the FEniCS or Firedrake automated code generation
-      libraries, and applies a high-level algorithmic differentiation approach
-      to enable tangent-linear and adjoint calculations.
+    - Integrates with the Firedrake automated code generation library, and
+      applies a high-level algorithmic differentiation approach to enable
+      tangent-linear and adjoint calculations.
     - Applies a *reverse-over-multiple-forward* approach for higher order
       adjoint calculations. For example a Hessian action on some given
       direction is computed by deriving an adjoint associated with a combined

--- a/readme.rst
+++ b/readme.rst
@@ -2,8 +2,7 @@ tlm_adjoint
 ===========
 
 `tlm_adjoint <https://tlm-adjoint.github.io>`_ is a high-level algorithmic
-differentiation tool, principally for use with
-`FEniCS <https://fenicsproject.org>`_ or `Firedrake
+differentiation tool, principally for use with `Firedrake
 <https://firedrakeproject.org>`_.
 
 The primary aim of tlm_adjoint is to enable higher order adjoint calculations


### PR DESCRIPTION
The legacy FEniCS backend is already lacking a few newer features. With the FEniCS backend:

- Block system solvers and Hessian solvers have been removed.
- Only special cases of adjoint interpolation are available.
- Variable state locking is much less robust.
- Integration with JAX is untested.

Newer features are very likely to be Firedrake-only.

The FEniCS backend can be retained at least so long as there is a working version in Ubuntu LTS, but this PR removes it as a principal target.