### PR TITLE
Cache improvements

### DIFF
--- a/tests/fenics/test_caches.py
+++ b/tests/fenics/test_caches.py
@@ -27,20 +27,25 @@ def test_clear_caches(setup_test, test_leaks):
     space = FunctionSpace(mesh, "Lagrange", 1)
     F = Function(space, name="F", cache=True)
 
-    def cache_item(F):
+    def cache_item(F, F_value=None):
         form = inner(F, TestFunction(F.function_space())) * dx
-        cached_form, _ = assembly_cache().assemble(form)
+        cached_form, _ = assembly_cache().assemble(
+            form, replace_map=None if F_value is None else {F: F_value})
         return cached_form
 
-    def test_not_cleared(F, cached_form):
+    def test_not_cleared(F, cached_form, F_value=None):
         assert len(assembly_cache()) == 1
         assert cached_form() is not None
         assert len(var_caches(F)) == 1
+        if F_value is not None:
+            assert len(var_caches(F_value)) == 1
 
-    def test_cleared(F, cached_form):
+    def test_cleared(F, cached_form, F_value=None):
         assert len(assembly_cache()) == 0
         assert cached_form() is None
         assert len(var_caches(F)) == 0
+        if F_value is not None:
+            assert len(var_caches(F_value)) == 0
 
     assert len(assembly_cache()) == 0
 
@@ -73,6 +78,20 @@ def test_clear_caches(setup_test, test_leaks):
     test_not_cleared(F, cached_form)
     var_update_caches(var_replacement(F), value=Function(space))
     test_cleared(F, cached_form)
+
+    F_value = Function(space, name="F_value")
+
+    # Clear on state update of value
+    cached_form = cache_item(F, F_value)
+    test_not_cleared(F, cached_form, F_value)
+    var_update_state(F_value)
+    test_cleared(F, cached_form, F_value)
+
+    # Clear on state update of value, replacement
+    cached_form = cache_item(var_replacement(F), F_value)
+    test_not_cleared(F, cached_form, F_value)
+    var_update_state(F_value)
+    test_cleared(F, cached_form, F_value)
 
 
 @pytest.mark.fenics

--- a/tests/firedrake/test_interface.py
+++ b/tests/firedrake/test_interface.py
@@ -17,20 +17,41 @@ pytestmark = pytest.mark.skipif(
     reason="tests must be run in serial, or with 4 processes")
 
 
+@pytest.fixture(params=[{"cls": lambda **kwargs: Constant(**kwargs)},
+                        {"cls": lambda **kwargs: Constant(domain=UnitIntervalMesh(20), **kwargs)},  # noqa: E501
+                        {"cls": lambda **kwargs: Function(FunctionSpace(UnitIntervalMesh(20), "Lagrange", 1), **kwargs)}])  # noqa: E501
+def var_cls(request):
+    return request.param["cls"]
+
+
 @pytest.mark.firedrake
-@pytest.mark.parametrize(
-    "cls",
-    [lambda name: Float(name=name),
-     lambda name: Constant(name=name),
-     lambda name: Constant(domain=UnitIntervalMesh(20), name=name),
-     lambda name: Function(FunctionSpace(UnitIntervalMesh(20), "Lagrange", 1),
-                           name=name)])
 @seed_test
 def test_name(setup_test,
-              cls):
+              var_cls):
     name = "_tlm_adjoint__test_name"
-    F = cls(name=name)
+    F = var_cls(name=name)
     assert var_name(F) == name
+
+
+@pytest.mark.firedrake
+@pytest.mark.parametrize("static", [False, True])
+@pytest.mark.parametrize("cache", [False, True, None])
+@seed_test
+def test_replacement(setup_test,  # noqa: F811
+                     var_cls, cache, static):
+    name = "_tlm_adjoint__test_name"
+    F = var_cls(name=name, static=static, cache=cache)
+    F_id = var_id(F)
+    F_caches = var_caches(F)
+
+    for var in (F, var_replacement(F)):
+        assert var_id(var) == F_id
+        assert var_name(var) == name
+        assert var_is_static(var) is not None
+        assert var_is_static(var) == static
+        assert var_is_cached(var) is not None
+        assert var_is_cached(var) == (static if cache is None else cache)
+        assert var_caches(var) is F_caches
 
 
 @pytest.mark.firedrake

--- a/tlm_adjoint/caches.py
+++ b/tlm_adjoint/caches.py
@@ -6,6 +6,7 @@ from .interface import var_caches, var_id, var_is_replacement, var_state
 from .alias import gc_disabled
 
 import functools
+from operator import itemgetter
 import weakref
 
 __all__ = \
@@ -217,7 +218,7 @@ class Cache:
         self._cache[key] = value_ref
 
         assert len(deps) == len(dep_ids)
-        for dep, dep_id in zip(deps, dep_ids):
+        for dep_id, dep in sorted(zip(dep_ids, deps), key=itemgetter(0)):
             dep_caches = var_caches(dep)
             dep_caches.add(self)
 

--- a/tlm_adjoint/caches.py
+++ b/tlm_adjoint/caches.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-from .interface import var_caches, var_id, var_state
+from .interface import var_caches, var_id, var_is_replacement, var_state
 
 from .alias import gc_disabled
 
@@ -211,6 +211,8 @@ class Cache:
         value = value()
         value_ref = CacheRef(value)
         dep_ids = tuple(map(var_id, deps))
+        if len(set(dep_ids)) != len(dep_ids):
+            raise ValueError("Duplicate dependency")
 
         self._cache[key] = value_ref
 
@@ -267,6 +269,9 @@ class Caches:
     """
 
     def __init__(self, x):
+        if var_is_replacement(x):
+            raise ValueError("x cannot be a replacement")
+
         self._caches = weakref.WeakValueDictionary()
         self._id = var_id(x)
         self._state = (self._id, var_state(x))
@@ -307,6 +312,9 @@ class Caches:
 
         :arg x: A variable which defines a potentially new value.
         """
+
+        if var_is_replacement(x):
+            raise ValueError("x cannot be a replacement")
 
         state = (var_id(x), var_state(x))
         if state != self._state:

--- a/tlm_adjoint/equation.py
+++ b/tlm_adjoint/equation.py
@@ -419,9 +419,6 @@ class Equation(Referrer):
             or `None` to indicate that the solution is zero.
         """
 
-        if adj_X is not None:
-            var_update_caches(*adj_X)
-        var_update_caches(*B)
         var_update_caches(*self.nonlinear_dependencies(), value=nl_deps)
 
         if adj_X is not None and len(adj_X) == 1:
@@ -457,7 +454,6 @@ class Equation(Referrer):
             differentiating with respect to `self.dependencies()[dep_index]`.
         """
 
-        var_update_caches(*adj_X)
         var_update_caches(*self.nonlinear_dependencies(), value=nl_deps)
 
         if len(adj_X) == 1:

--- a/tlm_adjoint/fenics/backend_code_generator_interface.py
+++ b/tlm_adjoint/fenics/backend_code_generator_interface.py
@@ -9,9 +9,9 @@ from .backend import (
     backend_assemble_system, backend_solve as solve, complex_mode,
     has_lu_solver_method, parameters)
 from ..interface import (
-    check_space_type, check_space_types, space_new, var_assign, var_get_values,
-    var_inner, var_new_conjugate_dual, var_set_values, var_space,
-    var_space_type)
+    check_space_type, check_space_types, is_var, space_new, var_assign,
+    var_get_values, var_inner, var_new_conjugate_dual, var_set_values,
+    var_space, var_space_type)
 
 from ..manager import manager_disabled
 
@@ -364,7 +364,8 @@ def interpolate_expression(x, expr, *, adj_x=None):
         check_space_type(x, "conjugate_dual")
         check_space_type(adj_x, "conjugate_dual")
     for dep in extract_coefficients(expr):
-        check_space_type(dep, "primal")
+        if is_var(dep):
+            check_space_type(dep, "primal")
 
     expr = eliminate_zeros(expr)
 

--- a/tlm_adjoint/fenics/caches.py
+++ b/tlm_adjoint/fenics/caches.py
@@ -222,12 +222,12 @@ def split_terms(terms, base_integral,
             mat_dep = None
             for dep in extract_coefficients(term):
                 if not is_cached(dep):
-                    if isinstance(dep, (backend_Function, ReplacementFunction)) and mat_dep is None:  # noqa: E501
-                        mat_dep = dep
-                    else:
+                    if mat_dep is not None:
                         mat_dep = None
                         break
-            if mat_dep is None:
+                    mat_dep = dep
+            if not isinstance(mat_dep, (backend_Function,
+                                        ReplacementFunction)):
                 non_cached_terms.append(term)
             else:
                 term_form = ufl.classes.Form(

--- a/tlm_adjoint/fenics/caches.py
+++ b/tlm_adjoint/fenics/caches.py
@@ -6,7 +6,9 @@ caching.
 """
 
 from .backend import TrialFunction, backend_DirichletBC, backend_Function
-from ..interface import is_var, var_id, var_is_cached, var_space
+from ..interface import (
+    is_var, var_caches, var_id, var_is_cached, var_is_replacement,
+    var_replacement, var_space, var_state)
 from .backend_code_generator_interface import (
     assemble, assemble_arguments, assemble_matrix, complex_mode, linear_solver,
     matrix_copy, parameters_key)
@@ -18,6 +20,7 @@ from .functions import (
     replaced_form)
 
 from collections import defaultdict
+import itertools
 try:
     import ufl_legacy as ufl
 except ImportError:
@@ -278,26 +281,44 @@ def split_form(form):
     return cached_form, mat_forms, non_cached_forms
 
 
-def form_dependencies(form):
+def form_key(*forms):
+    key = []
+
+    for form in forms:
+        deps = [dep for dep in extract_coefficients(form) if is_var(dep)]
+        deps = sorted(deps, key=var_id)
+        deps_key = tuple((var_id(dep), var_state(dep)) for dep in deps)
+
+        form = replaced_form(form)
+        form = ufl.algorithms.expand_derivatives(form)
+        form = ufl.algorithms.apply_algebra_lowering.apply_algebra_lowering(form)  # noqa: E501
+        form = ufl.algorithms.expand_indices(form)
+        form = form_simplify_conj(form)
+        form = form_simplify_sign(form)
+
+        key.extend((form, deps_key))
+
+    return tuple(key)
+
+
+def form_dependencies(*forms):
     deps = {}
-    for dep in extract_coefficients(form):
+
+    for dep in itertools.chain.from_iterable(map(extract_coefficients, forms)):
         if is_var(dep):
-            deps.setdefault(var_id(dep), dep)
-    return deps
+            dep_id = var_id(dep)
+            if dep_id in deps:
+                dep_old = deps[dep_id]
+                assert (dep is dep_old
+                        or dep is var_replacement(dep_old)
+                        or var_replacement(dep) is dep_old)
+                assert var_caches(dep) is var_caches(dep_old)
+                if var_is_replacement(dep_old):
+                    deps[dep_id] = dep
+            else:
+                deps[dep_id] = dep
 
-
-def form_key(form):
-    form = replaced_form(form)
-    form = ufl.algorithms.expand_derivatives(form)
-    form = ufl.algorithms.apply_algebra_lowering.apply_algebra_lowering(form)
-    form = ufl.algorithms.expand_indices(form)
-    form = form_simplify_conj(form)
-    form = form_simplify_sign(form)
-    return form
-
-
-def assemble_key(form, bcs, assemble_kwargs):
-    return (form_key(form), tuple(bcs), parameters_key(assemble_kwargs))
+    return tuple(sorted(deps.values(), key=var_id))
 
 
 class AssemblyCache(Cache):
@@ -340,16 +361,19 @@ class AssemblyCache(Cache):
             linear_solver_parameters = {}
 
         form = eliminate_zeros(form, force_non_empty_form=True)
+        if replace_map is None:
+            assemble_form = form
+        else:
+            assemble_form = ufl.replace(form, replace_map)
         arity = len(form.arguments())
         assemble_kwargs = assemble_arguments(arity, form_compiler_parameters,
                                              linear_solver_parameters)
-        key = assemble_key(form, bcs, assemble_kwargs)
+
+        key = (form_key(form, assemble_form),
+               tuple(bcs),
+               parameters_key(assemble_kwargs))
 
         def value():
-            if replace_map is None:
-                assemble_form = form
-            else:
-                assemble_form = ufl.replace(form, replace_map)
             if arity == 0:
                 if len(bcs) > 0:
                     raise TypeError("Unexpected boundary conditions for arity "
@@ -366,14 +390,7 @@ class AssemblyCache(Cache):
             return b
 
         return self.add(key, value,
-                        deps=tuple(form_dependencies(form).values()))
-
-
-def linear_solver_key(form, bcs, linear_solver_parameters,
-                      form_compiler_parameters):
-    return (form_key(form), tuple(bcs),
-            parameters_key(linear_solver_parameters),
-            parameters_key(form_compiler_parameters))
+                        deps=form_dependencies(form, assemble_form))
 
 
 class LinearSolverCache(Cache):
@@ -414,8 +431,15 @@ class LinearSolverCache(Cache):
             linear_solver_parameters = {}
 
         form = eliminate_zeros(form, force_non_empty_form=True)
-        key = linear_solver_key(form, bcs, linear_solver_parameters,
-                                form_compiler_parameters)
+        if replace_map is None:
+            assemble_form = form
+        else:
+            assemble_form = ufl.replace(form, replace_map)
+
+        key = (form_key(form, assemble_form),
+               tuple(bcs),
+               parameters_key(form_compiler_parameters),
+               parameters_key(linear_solver_parameters))
 
         if assembly_cache is None:
             assembly_cache = globals()["assembly_cache"]()
@@ -431,7 +455,7 @@ class LinearSolverCache(Cache):
             return solver, A, b_bc
 
         return self.add(key, value,
-                        deps=tuple(form_dependencies(form).values()))
+                        deps=form_dependencies(form, assemble_form))
 
 
 _assembly_cache = AssemblyCache()

--- a/tlm_adjoint/fenics/equations.py
+++ b/tlm_adjoint/fenics/equations.py
@@ -12,7 +12,7 @@ from .backend import (
 from ..interface import (
     check_space_type, is_var, var_assign, var_id, var_increment_state_lock,
     var_is_scalar, var_new, var_new_conjugate_dual, var_replacement,
-    var_scalar_value, var_space, var_zero)
+    var_scalar_value, var_space, var_update_caches, var_zero)
 from .backend_code_generator_interface import (
     assemble, assemble_linear_solver, copy_parameters_dict,
     form_compiler_quadrature_parameters, homogenize, interpolate_expression,

--- a/tlm_adjoint/fenics/equations.py
+++ b/tlm_adjoint/fenics/equations.py
@@ -48,7 +48,7 @@ __all__ = \
     ]
 
 
-def derivative_dependencies(expr, dep):
+def extract_derivative_coefficients(expr, dep):
     dexpr = derivative(expr, dep, enable_automatic_argument=False)
     dexpr = ufl.algorithms.expand_derivatives(dexpr)
     return extract_coefficients(dexpr)
@@ -61,7 +61,7 @@ def extract_dependencies(expr, *,
     for dep in extract_coefficients(expr):
         if is_var(dep):
             deps.setdefault(var_id(dep), dep)
-            for nl_dep in derivative_dependencies(expr, dep):
+            for nl_dep in extract_derivative_coefficients(expr, dep):
                 if is_var(nl_dep):
                     nl_deps.setdefault(var_id(dep), dep)
                     nl_deps.setdefault(var_id(nl_dep), nl_dep)

--- a/tlm_adjoint/fenics/equations.py
+++ b/tlm_adjoint/fenics/equations.py
@@ -94,7 +94,7 @@ class ExprEquation(Equation):
             assert len(eq_deps) == len(deps)
             return {eq_dep: dep
                     for eq_dep, dep in zip(eq_deps, deps)
-                    if isinstance(eq_dep, (ufl.classes.ConstantValue, ufl.classes.Coefficient))}  # noqa: E501
+                    if isinstance(eq_dep, ufl.classes.Expr)}
 
     def _replace(self, expr, deps):
         if deps is None:
@@ -108,7 +108,7 @@ class ExprEquation(Equation):
         assert len(eq_nl_deps) == len(nl_deps)
         return {eq_nl_dep: nl_dep
                 for eq_nl_dep, nl_dep in zip(eq_nl_deps, nl_deps)
-                if isinstance(eq_nl_dep, (ufl.classes.ConstantValue, ufl.classes.Coefficient))}  # noqa: E501
+                if isinstance(eq_nl_dep, ufl.classes.Expr)}
 
     def _nonlinear_replace(self, expr, nl_deps):
         replace_map = self._nonlinear_replace_map(nl_deps)
@@ -179,7 +179,7 @@ class Assembly(ExprEquation):
     def drop_references(self):
         replace_map = {dep: var_replacement(dep)
                        for dep in self.dependencies()
-                       if isinstance(dep, (ufl.classes.ConstantValue, ufl.classes.Coefficient))}  # noqa: E501
+                       if isinstance(dep, ufl.classes.Expr)}
 
         super().drop_references()
         self._rhs = ufl.replace(self._rhs, replace_map)

--- a/tlm_adjoint/fenics/equations.py
+++ b/tlm_adjoint/fenics/equations.py
@@ -87,11 +87,14 @@ def apply_rhs_bcs(b, hbcs, *, b_bc=None):
 
 class ExprEquation(Equation):
     def _replace_map(self, deps):
-        eq_deps = self.dependencies()
-        assert len(eq_deps) == len(deps)
-        return {eq_dep: dep
-                for eq_dep, dep in zip(eq_deps, deps)
-                if isinstance(eq_dep, (ufl.classes.ConstantValue, ufl.classes.Coefficient))}  # noqa: E501
+        if deps is None:
+            return None
+        else:
+            eq_deps = self.dependencies()
+            assert len(eq_deps) == len(deps)
+            return {eq_dep: dep
+                    for eq_dep, dep in zip(eq_deps, deps)
+                    if isinstance(eq_dep, (ufl.classes.ConstantValue, ufl.classes.Coefficient))}  # noqa: E501
 
     def _replace(self, expr, deps):
         if deps is None:
@@ -520,7 +523,7 @@ class EquationSolver(ExprEquation):
                     mat_form,
                     form_compiler_parameters=self._form_compiler_parameters,
                     linear_solver_parameters=self._linear_solver_parameters,
-                    replace_map=None if deps is None else self._replace_map(deps))  # noqa: E501
+                    replace_map=self._replace_map(deps))
             mat, _ = mat_bc
             dep = (eq_deps if deps is None else deps)[dep_index]
             if b is None:
@@ -534,7 +537,7 @@ class EquationSolver(ExprEquation):
                 cached_form[1], cached_b = assembly_cache().assemble(
                     cached_form[0],
                     form_compiler_parameters=self._form_compiler_parameters,
-                    replace_map=None if deps is None else self._replace_map(deps))  # noqa: E501
+                    replace_map=self._replace_map(deps))
             if b is None:
                 b = rhs_copy(cached_b)
             else:
@@ -561,7 +564,7 @@ class EquationSolver(ExprEquation):
                             self._J, bcs=self._bcs,
                             form_compiler_parameters=self._form_compiler_parameters,  # noqa: E501
                             linear_solver_parameters=self._linear_solver_parameters,  # noqa: E501
-                            replace_map=None if deps is None else self._replace_map(deps))  # noqa: E501
+                            replace_map=self._replace_map(deps))
                 J_solver, J_mat, b_bc = J_solver_mat_bc
 
                 if self._cache_rhs_assembly:

--- a/tlm_adjoint/fenics/equations.py
+++ b/tlm_adjoint/fenics/equations.py
@@ -517,6 +517,7 @@ class EquationSolver(ExprEquation):
                 form_compiler_parameters=self._form_compiler_parameters)
 
         for dep_index, (mat_form, mat_cache) in mat_forms.items():
+            var_update_caches(*eq_deps, value=deps)
             mat_bc = mat_cache()
             if mat_bc is None:
                 mat_forms[dep_index][1], mat_bc = assembly_cache().assemble(
@@ -532,6 +533,7 @@ class EquationSolver(ExprEquation):
                 matrix_multiply(mat, dep, tensor=b, addto=True)
 
         if cached_form is not None:
+            var_update_caches(*eq_deps, value=deps)
             cached_b = cached_form[1]()
             if cached_b is None:
                 cached_form[1], cached_b = assembly_cache().assemble(
@@ -550,11 +552,14 @@ class EquationSolver(ExprEquation):
         return b
 
     def forward_solve(self, x, deps=None):
+        eq_deps = self.dependencies()
+
         if self._linear:
             if self._cache_jacobian:
                 # Cases 1 and 2: Linear, Jacobian cached, with or without RHS
                 # assembly caching
 
+                var_update_caches(*eq_deps, value=deps)
                 J_solver_mat_bc = self._forward_J_solver()
                 if J_solver_mat_bc is None:
                     # Assemble and cache the Jacobian, construct and cache the
@@ -627,6 +632,8 @@ class EquationSolver(ExprEquation):
                   solver_parameters=self._solver_parameters)
 
     def subtract_adjoint_derivative_actions(self, adj_x, nl_deps, dep_Bs):
+        eq_nl_deps = self.nonlinear_dependencies()
+
         for dep_index, dep_B in dep_Bs.items():
             if dep_index not in self._adjoint_dF_cache:
                 dep = self.dependencies()[dep_index]
@@ -651,6 +658,7 @@ class EquationSolver(ExprEquation):
 
                 if self._adjoint_action_cache[dep_index] is not None:
                     # Cached matrix action
+                    var_update_caches(*eq_nl_deps, value=nl_deps)
                     mat_bc = self._adjoint_action_cache[dep_index]()
                     if mat_bc is None:
                         self._adjoint_action_cache[dep_index], mat_bc = \
@@ -678,8 +686,10 @@ class EquationSolver(ExprEquation):
     def adjoint_jacobian_solve(self, adj_x, nl_deps, b):
         if adj_x is None:
             adj_x = self.new_adj_x()
+        eq_nl_deps = self.nonlinear_dependencies()
 
         if self._cache_adjoint_jacobian:
+            var_update_caches(*eq_nl_deps, value=nl_deps)
             J_solver_mat_bc = self._adjoint_J_solver()
             if J_solver_mat_bc is None:
                 self._adjoint_J_solver, J_solver_mat_bc = \

--- a/tlm_adjoint/fenics/fenics_equations.py
+++ b/tlm_adjoint/fenics/fenics_equations.py
@@ -10,7 +10,7 @@ from .backend import (
 from ..interface import (
     check_space_type, is_var, space_comm, var_assign, var_comm, var_get_values,
     var_is_scalar, var_local_size, var_new, var_new_conjugate_dual,
-    var_scalar_value, var_set_values)
+    var_scalar_value, var_set_values, var_update_caches)
 from .backend_code_generator_interface import assemble
 
 from ..caches import Cache

--- a/tlm_adjoint/fenics/fenics_equations.py
+++ b/tlm_adjoint/fenics/fenics_equations.py
@@ -307,8 +307,9 @@ class LocalProjection(EquationSolver):
             local_solver = self._forward_J_solver()
             if local_solver is None:
                 self._forward_J_solver, local_solver = \
-                    local_solver_cache().local_solver(self._lhs,
-                                                      self._local_solver_type)
+                    local_solver_cache().local_solver(
+                        self._lhs, self._local_solver_type,
+                        replace_map=self._replace_map(deps))
         else:
             local_solver = LocalSolver(self._lhs,
                                        solver_type=self._local_solver_type)
@@ -320,8 +321,9 @@ class LocalProjection(EquationSolver):
             local_solver = self._forward_J_solver()
             if local_solver is None:
                 self._forward_J_solver, local_solver = \
-                    local_solver_cache().local_solver(self._lhs,
-                                                      self._local_solver_type)
+                    local_solver_cache().local_solver(
+                        self._lhs, self._local_solver_type,
+                        replace_map=self._nonlinear_replace_map(nl_deps))
         else:
             local_solver = LocalSolver(self._lhs,
                                        solver_type=self._local_solver_type)

--- a/tlm_adjoint/fenics/fenics_equations.py
+++ b/tlm_adjoint/fenics/fenics_equations.py
@@ -296,6 +296,8 @@ class LocalProjection(EquationSolver):
         self._local_solver_type = local_solver_type
 
     def forward_solve(self, x, deps=None):
+        eq_deps = self.dependencies()
+
         if self._cache_rhs_assembly:
             b = self._cached_rhs(deps)
         else:
@@ -304,6 +306,7 @@ class LocalProjection(EquationSolver):
                 form_compiler_parameters=self._form_compiler_parameters)
 
         if self._cache_jacobian:
+            var_update_caches(*eq_deps, value=deps)
             local_solver = self._forward_J_solver()
             if local_solver is None:
                 self._forward_J_solver, local_solver = \
@@ -317,7 +320,10 @@ class LocalProjection(EquationSolver):
         local_solver.solve_local(x.vector(), b, x.function_space().dofmap())
 
     def adjoint_jacobian_solve(self, adj_x, nl_deps, b):
+        eq_nl_deps = self.nonlinear_dependencies()
+
         if self._cache_jacobian:
+            var_update_caches(*eq_nl_deps, value=nl_deps)
             local_solver = self._forward_J_solver()
             if local_solver is None:
                 self._forward_J_solver, local_solver = \

--- a/tlm_adjoint/firedrake/backend_code_generator_interface.py
+++ b/tlm_adjoint/firedrake/backend_code_generator_interface.py
@@ -7,8 +7,9 @@ from .backend import (
     backend_assemble, backend_solve, complex_mode, extract_args, homogenize,
     parameters)
 from ..interface import (
-    check_space_type, check_space_types, space_new, var_assign, var_axpy,
-    var_copy, var_inner, var_new_conjugate_dual, var_space, var_space_type)
+    check_space_type, check_space_types, is_var, space_new, var_assign,
+    var_axpy, var_copy, var_inner, var_new_conjugate_dual, var_space,
+    var_space_type)
 
 from ..manager import manager_disabled
 from ..override import override_method
@@ -372,7 +373,8 @@ def interpolate_expression(x, expr, *, adj_x=None):
         check_space_type(x, "conjugate_dual")
         check_space_type(adj_x, "conjugate_dual")
     for dep in extract_coefficients(expr):
-        check_space_type(dep, "primal")
+        if is_var(dep):
+            check_space_type(dep, "primal")
 
     expr = eliminate_zeros(expr)
 

--- a/tlm_adjoint/firedrake/caches.py
+++ b/tlm_adjoint/firedrake/caches.py
@@ -6,7 +6,9 @@ caching.
 """
 
 from .backend import TrialFunction, backend_DirichletBC, backend_Function
-from ..interface import is_var, var_id, var_is_cached, var_space
+from ..interface import (
+    is_var, var_caches, var_id, var_is_cached, var_is_replacement,
+    var_replacement, var_space, var_state)
 from .backend_code_generator_interface import (
     assemble, assemble_arguments, assemble_matrix, complex_mode, linear_solver,
     matrix_copy, parameters_key)
@@ -18,6 +20,7 @@ from .functions import (
     replaced_form)
 
 from collections import defaultdict
+import itertools
 import ufl
 
 __all__ = \
@@ -275,26 +278,44 @@ def split_form(form):
     return cached_form, mat_forms, non_cached_forms
 
 
-def form_dependencies(form):
+def form_key(*forms):
+    key = []
+
+    for form in forms:
+        deps = [dep for dep in extract_coefficients(form) if is_var(dep)]
+        deps = sorted(deps, key=var_id)
+        deps_key = tuple((var_id(dep), var_state(dep)) for dep in deps)
+
+        form = replaced_form(form)
+        form = ufl.algorithms.expand_derivatives(form)
+        form = ufl.algorithms.apply_algebra_lowering.apply_algebra_lowering(form)  # noqa: E501
+        form = ufl.algorithms.expand_indices(form)
+        form = form_simplify_conj(form)
+        form = form_simplify_sign(form)
+
+        key.extend((form, deps_key))
+
+    return tuple(key)
+
+
+def form_dependencies(*forms):
     deps = {}
-    for dep in extract_coefficients(form):
+
+    for dep in itertools.chain.from_iterable(map(extract_coefficients, forms)):
         if is_var(dep):
-            deps.setdefault(var_id(dep), dep)
-    return deps
+            dep_id = var_id(dep)
+            if dep_id in deps:
+                dep_old = deps[dep_id]
+                assert (dep is dep_old
+                        or dep is var_replacement(dep_old)
+                        or var_replacement(dep) is dep_old)
+                assert var_caches(dep) is var_caches(dep_old)
+                if var_is_replacement(dep_old):
+                    deps[dep_id] = dep
+            else:
+                deps[dep_id] = dep
 
-
-def form_key(form):
-    form = replaced_form(form)
-    form = ufl.algorithms.expand_derivatives(form)
-    form = ufl.algorithms.apply_algebra_lowering.apply_algebra_lowering(form)
-    form = ufl.algorithms.expand_indices(form)
-    form = form_simplify_conj(form)
-    form = form_simplify_sign(form)
-    return form
-
-
-def assemble_key(form, bcs, assemble_kwargs):
-    return (form_key(form), tuple(bcs), parameters_key(assemble_kwargs))
+    return tuple(sorted(deps.values(), key=var_id))
 
 
 class AssemblyCache(Cache):
@@ -337,16 +358,19 @@ class AssemblyCache(Cache):
             linear_solver_parameters = {}
 
         form = eliminate_zeros(form, force_non_empty_form=True)
+        if replace_map is None:
+            assemble_form = form
+        else:
+            assemble_form = ufl.replace(form, replace_map)
         arity = len(form.arguments())
         assemble_kwargs = assemble_arguments(arity, form_compiler_parameters,
                                              linear_solver_parameters)
-        key = assemble_key(form, bcs, assemble_kwargs)
+
+        key = (form_key(form, assemble_form),
+               tuple(bcs),
+               parameters_key(assemble_kwargs))
 
         def value():
-            if replace_map is None:
-                assemble_form = form
-            else:
-                assemble_form = ufl.replace(form, replace_map)
             if arity == 0:
                 if len(bcs) > 0:
                     raise TypeError("Unexpected boundary conditions for arity "
@@ -363,14 +387,7 @@ class AssemblyCache(Cache):
             return b
 
         return self.add(key, value,
-                        deps=tuple(form_dependencies(form).values()))
-
-
-def linear_solver_key(form, bcs, linear_solver_parameters,
-                      form_compiler_parameters):
-    return (form_key(form), tuple(bcs),
-            parameters_key(linear_solver_parameters),
-            parameters_key(form_compiler_parameters))
+                        deps=form_dependencies(form, assemble_form))
 
 
 class LinearSolverCache(Cache):
@@ -411,8 +428,15 @@ class LinearSolverCache(Cache):
             linear_solver_parameters = {}
 
         form = eliminate_zeros(form, force_non_empty_form=True)
-        key = linear_solver_key(form, bcs, linear_solver_parameters,
-                                form_compiler_parameters)
+        if replace_map is None:
+            assemble_form = form
+        else:
+            assemble_form = ufl.replace(form, replace_map)
+
+        key = (form_key(form, assemble_form),
+               tuple(bcs),
+               parameters_key(form_compiler_parameters),
+               parameters_key(linear_solver_parameters))
 
         if assembly_cache is None:
             assembly_cache = globals()["assembly_cache"]()
@@ -428,7 +452,7 @@ class LinearSolverCache(Cache):
             return solver, A, b_bc
 
         return self.add(key, value,
-                        deps=tuple(form_dependencies(form).values()))
+                        deps=form_dependencies(form, assemble_form))
 
 
 _assembly_cache = AssemblyCache()

--- a/tlm_adjoint/firedrake/caches.py
+++ b/tlm_adjoint/firedrake/caches.py
@@ -219,12 +219,12 @@ def split_terms(terms, base_integral,
             mat_dep = None
             for dep in extract_coefficients(term):
                 if not is_cached(dep):
-                    if isinstance(dep, (backend_Function, ReplacementFunction)) and mat_dep is None:  # noqa: E501
-                        mat_dep = dep
-                    else:
+                    if mat_dep is not None:
                         mat_dep = None
                         break
-            if mat_dep is None:
+                    mat_dep = dep
+            if not isinstance(mat_dep, (backend_Function,
+                                        ReplacementFunction)):
                 non_cached_terms.append(term)
             else:
                 term_form = ufl.classes.Form(

--- a/tlm_adjoint/firedrake/equations.py
+++ b/tlm_adjoint/firedrake/equations.py
@@ -91,7 +91,7 @@ class ExprEquation(Equation):
             assert len(eq_deps) == len(deps)
             return {eq_dep: dep
                     for eq_dep, dep in zip(eq_deps, deps)
-                    if isinstance(eq_dep, (ufl.classes.ConstantValue, ufl.classes.Coefficient))}  # noqa: E501
+                    if isinstance(eq_dep, ufl.classes.Expr)}
 
     def _replace(self, expr, deps):
         if deps is None:
@@ -105,7 +105,7 @@ class ExprEquation(Equation):
         assert len(eq_nl_deps) == len(nl_deps)
         return {eq_nl_dep: nl_dep
                 for eq_nl_dep, nl_dep in zip(eq_nl_deps, nl_deps)
-                if isinstance(eq_nl_dep, (ufl.classes.ConstantValue, ufl.classes.Coefficient))}  # noqa: E501
+                if isinstance(eq_nl_dep, ufl.classes.Expr)}
 
     def _nonlinear_replace(self, expr, nl_deps):
         replace_map = self._nonlinear_replace_map(nl_deps)
@@ -176,7 +176,7 @@ class Assembly(ExprEquation):
     def drop_references(self):
         replace_map = {dep: var_replacement(dep)
                        for dep in self.dependencies()
-                       if isinstance(dep, (ufl.classes.ConstantValue, ufl.classes.Coefficient))}  # noqa: E501
+                       if isinstance(dep, ufl.classes.Expr)}
 
         super().drop_references()
         self._rhs = ufl.replace(self._rhs, replace_map)

--- a/tlm_adjoint/firedrake/equations.py
+++ b/tlm_adjoint/firedrake/equations.py
@@ -12,7 +12,7 @@ from .backend import (
 from ..interface import (
     check_space_type, is_var, var_assign, var_id, var_increment_state_lock,
     var_is_scalar, var_new, var_new_conjugate_dual, var_replacement,
-    var_scalar_value, var_space, var_zero)
+    var_scalar_value, var_space, var_update_caches, var_zero)
 from .backend_code_generator_interface import (
     assemble, assemble_linear_solver, copy_parameters_dict,
     form_compiler_quadrature_parameters, homogenize, interpolate_expression,

--- a/tlm_adjoint/firedrake/equations.py
+++ b/tlm_adjoint/firedrake/equations.py
@@ -84,11 +84,14 @@ def apply_rhs_bcs(b, hbcs, *, b_bc=None):
 
 class ExprEquation(Equation):
     def _replace_map(self, deps):
-        eq_deps = self.dependencies()
-        assert len(eq_deps) == len(deps)
-        return {eq_dep: dep
-                for eq_dep, dep in zip(eq_deps, deps)
-                if isinstance(eq_dep, (ufl.classes.ConstantValue, ufl.classes.Coefficient))}  # noqa: E501
+        if deps is None:
+            return None
+        else:
+            eq_deps = self.dependencies()
+            assert len(eq_deps) == len(deps)
+            return {eq_dep: dep
+                    for eq_dep, dep in zip(eq_deps, deps)
+                    if isinstance(eq_dep, (ufl.classes.ConstantValue, ufl.classes.Coefficient))}  # noqa: E501
 
     def _replace(self, expr, deps):
         if deps is None:
@@ -518,7 +521,7 @@ class EquationSolver(ExprEquation):
                     mat_form,
                     form_compiler_parameters=self._form_compiler_parameters,
                     linear_solver_parameters=self._linear_solver_parameters,
-                    replace_map=None if deps is None else self._replace_map(deps))  # noqa: E501
+                    replace_map=self._replace_map(deps))
             mat, _ = mat_bc
             dep = (eq_deps if deps is None else deps)[dep_index]
             if b is None:
@@ -532,7 +535,7 @@ class EquationSolver(ExprEquation):
                 cached_form[1], cached_b = assembly_cache().assemble(
                     cached_form[0],
                     form_compiler_parameters=self._form_compiler_parameters,
-                    replace_map=None if deps is None else self._replace_map(deps))  # noqa: E501
+                    replace_map=self._replace_map(deps))
             if b is None:
                 b = rhs_copy(cached_b)
             else:
@@ -559,7 +562,7 @@ class EquationSolver(ExprEquation):
                             self._J, bcs=self._bcs,
                             form_compiler_parameters=self._form_compiler_parameters,  # noqa: E501
                             linear_solver_parameters=self._linear_solver_parameters,  # noqa: E501
-                            replace_map=None if deps is None else self._replace_map(deps))  # noqa: E501
+                            replace_map=self._replace_map(deps))
                 J_solver, J_mat, b_bc = J_solver_mat_bc
 
                 if self._cache_rhs_assembly:

--- a/tlm_adjoint/firedrake/equations.py
+++ b/tlm_adjoint/firedrake/equations.py
@@ -45,7 +45,7 @@ __all__ = \
     ]
 
 
-def derivative_dependencies(expr, dep):
+def extract_derivative_coefficients(expr, dep):
     dexpr = derivative(expr, dep, enable_automatic_argument=False)
     dexpr = ufl.algorithms.expand_derivatives(dexpr)
     return extract_coefficients(dexpr)
@@ -58,7 +58,7 @@ def extract_dependencies(expr, *,
     for dep in extract_coefficients(expr):
         if is_var(dep):
             deps.setdefault(var_id(dep), dep)
-            for nl_dep in derivative_dependencies(expr, dep):
+            for nl_dep in extract_derivative_coefficients(expr, dep):
                 if is_var(nl_dep):
                     nl_deps.setdefault(var_id(dep), dep)
                     nl_deps.setdefault(var_id(nl_dep), nl_dep)

--- a/tlm_adjoint/firedrake/firedrake_equations.py
+++ b/tlm_adjoint/firedrake/firedrake_equations.py
@@ -11,7 +11,8 @@ from .backend import (
 from ..interface import (
     check_space_type, comm_dup_cached, is_var, space_new, var_comm, var_id,
     var_inner, var_is_scalar, var_new, var_new_conjugate_dual, var_replacement,
-    var_scalar_value, var_space_type, var_zero, weakref_method)
+    var_scalar_value, var_space_type, var_update_caches, var_zero,
+    weakref_method)
 from .backend_code_generator_interface import assemble, matrix_multiply
 from .backend_interface import ReplacementCofunction, ReplacementFunction
 

--- a/tlm_adjoint/firedrake/firedrake_equations.py
+++ b/tlm_adjoint/firedrake/firedrake_equations.py
@@ -177,7 +177,8 @@ class LocalProjection(EquationSolver):
                 self._forward_J_solver, local_solver = \
                     local_solver_cache().local_solver(
                         self._lhs,
-                        form_compiler_parameters=self._form_compiler_parameters)  # noqa: E501
+                        form_compiler_parameters=self._form_compiler_parameters,  # noqa: E501
+                        replace_map=self._replace_map(deps))
         else:
             local_solver = LocalSolver(
                 self._lhs,
@@ -192,7 +193,8 @@ class LocalProjection(EquationSolver):
                 self._forward_J_solver, local_solver = \
                     local_solver_cache().local_solver(
                         self._lhs,
-                        form_compiler_parameters=self._form_compiler_parameters)  # noqa: E501
+                        form_compiler_parameters=self._form_compiler_parameters,  # noqa: E501
+                        replace_map=self._nonlinear_replace_map(nl_deps))
         else:
             local_solver = LocalSolver(
                 self._lhs,

--- a/tlm_adjoint/firedrake/firedrake_equations.py
+++ b/tlm_adjoint/firedrake/firedrake_equations.py
@@ -160,6 +160,8 @@ class LocalProjection(EquationSolver):
             match_quadrature=match_quadrature)
 
     def forward_solve(self, x, deps=None):
+        eq_deps = self.dependencies()
+
         if self._cache_rhs_assembly:
             b = self._cached_rhs(deps)
         elif deps is None:
@@ -172,6 +174,7 @@ class LocalProjection(EquationSolver):
                 form_compiler_parameters=self._form_compiler_parameters)
 
         if self._cache_jacobian:
+            var_update_caches(*eq_deps, value=deps)
             local_solver = self._forward_J_solver()
             if local_solver is None:
                 self._forward_J_solver, local_solver = \
@@ -187,7 +190,10 @@ class LocalProjection(EquationSolver):
         local_solver._tlm_adjoint__solve_local(x, b)
 
     def adjoint_jacobian_solve(self, adj_x, nl_deps, b):
+        eq_nl_deps = self.nonlinear_dependencies()
+
         if self._cache_jacobian:
+            var_update_caches(*eq_nl_deps, value=nl_deps)
             local_solver = self._forward_J_solver()
             if local_solver is None:
                 self._forward_J_solver, local_solver = \

--- a/tlm_adjoint/fixed_point.py
+++ b/tlm_adjoint/fixed_point.py
@@ -3,7 +3,7 @@
 
 from .interface import (
     is_var, no_space_type_checking, var_assign, var_axpy, var_copy, var_id,
-    var_inner, var_update_caches, var_zero)
+    var_inner, var_zero)
 
 from .adjoint import AdjointModelRHS
 from .alias import WeakAlias
@@ -327,7 +327,6 @@ class FixedPointSolver(Equation, CustomNormSq):
         if not nonzero_initial_guess:
             for x in X:
                 var_zero(x)
-            var_update_caches(*self.X(), value=X)
 
         it = 0
         X_0 = tuple(tuple(map(var_copy, eq_X[i]))

--- a/tlm_adjoint/interface.py
+++ b/tlm_adjoint/interface.py
@@ -966,7 +966,7 @@ def var_decrement_state_lock(x, obj):
     var_check_state_lock(x)
     x_id = var_id(x)
 
-    if x._tlm_adjoint__state_lock < 1:
+    if x._tlm_adjoint__state_lock < obj._tlm_adjoint__state_locks[x_id][1]:
         raise RuntimeError("Invalid state lock")
     if obj._tlm_adjoint__state_locks[x_id][1] < 1:
         raise RuntimeError("Invalid state lock")

--- a/tlm_adjoint/interface.py
+++ b/tlm_adjoint/interface.py
@@ -1132,6 +1132,7 @@ def var_update_caches(*X, value=None):
     else:
         if is_var(value):
             value = (value,)
+        var_update_caches(*value)
         assert len(X) == len(value)
         for x, x_value in zip(X, value):
             var_check_state_lock(x_value)


### PR DESCRIPTION
1. Values, provided by the `replace_map` when generating cache entries, are now included in the key.
2. Updating the state of a value via `var_update_state` now clears associated cache entries.
3. Validity of cache entries is checked every time before use with extra `var_update_caches` calls. This catches all cache invalidation visible to tlm_adjoint -- which with the Firedrake backend includes any updates to dat versions, even those that do not have associated `var_update_state` calls.

A better alternative to 3 is to make hashing cheap and then simply check the caches every time -- but this needs #183 in order to avoid leaking memory when applying checkpointing.