### PR TITLE
Simpler `WeakAlias` implementation

### DIFF
--- a/tlm_adjoint/alias.py
+++ b/tlm_adjoint/alias.py
@@ -80,12 +80,12 @@ class WeakAlias:
 
     def __init__(self, obj):
         if hasattr(obj, "__slots__"):
-            # Weak references to obj not possible, has attributes not
-            # accessible via __dict__ attribute
             raise TypeError("Cannot alias object with __slots__ attribute")
         if isinstance(obj, WeakAlias):
             raise TypeError("Cannot alias WeakAlias")
-        super().__setattr__("_tlm_adjoint__alias__dict__", obj.__dict__)
+        if len(self.__dict__) > 0:
+            raise RuntimeError("Unexpected __dict__ entries")
+        self.__dict__ = obj.__dict__
 
     def __new__(cls, obj, *args, **kwargs):
         obj_cls = type(obj)
@@ -95,19 +95,3 @@ class WeakAlias:
 
         WeakAlias.__name__ = f"{obj_cls.__name__:s}WeakAlias"
         return super().__new__(WeakAlias)
-
-    def __getattr__(self, key):
-        if key not in self._tlm_adjoint__alias__dict__:
-            raise AttributeError(f"No attribute '{key:s}'")
-        return self._tlm_adjoint__alias__dict__[key]
-
-    def __setattr__(self, key, value):
-        self._tlm_adjoint__alias__dict__[key] = value
-
-    def __delattr__(self, key):
-        if key not in self._tlm_adjoint__alias__dict__:
-            raise AttributeError(f"No attribute '{key:s}'")
-        del self._tlm_adjoint__alias__dict__[key]
-
-    def __dir__(self):
-        return list(self._tlm_adjoint__alias__dict__.keys())


### PR DESCRIPTION
tlm_adjoint, by design, allows application code to directly construct and work with tape objects (`Equation` objects). This makes caching easier, as the application code can reuse tape objects, the tape objects can cache intermediate results (e.g. finite element assembly or linear solvers), and multiple references to the same object are held on the tape. It makes analyzing the computational graph more difficult, as the tape is not an exact representation of the computational DAG, and this is instead inferred elsewhere.

It also makes managing variable references more difficult. In particular we want to be able to record two entries on the tape via
```
eq = CustomEquation(...)
eq.solve()
eq.solve()
```
i.e. without having to pass any values to the `solve` method calls. However we _also_ want
```
for n in range(N):
    CustomEquation(...).solve()
    if n < N - 1:
        new_block()
```
to not leak variable values, as that would defeat checkpointing algorithms. This is resolved by instead recording `WeakAlias` objects on the tape, which hold references only to the attributes of an object. When the original object (the original `Equation`) is destroyed the manager knows it is safe to drop references to variable values, by calling the `drop_references` method of the `WeakAlias`.

The `WeakAlias` works by holding a reference only to the `__dict__` attribute of an original aliased object. The original object can then later be destroyed while retaining attributes. This works as methods are dynamically bound (`test = [];  assert test.append is test.append  # Fails!`) and so the original object doesn't usually reference bound methods (see also `weakref_method`, used to avoid creating reference cycles via manually bound methods).

This PR simplifies the `WeakAlias` implementation by simply setting the `__dict__` attribute of the `WeakAlias`.