### PR TITLE
FEnicS/Firedrake backends: `Constant` constructor annotation

### DIFF
--- a/tests/firedrake/test_overrides.py
+++ b/tests/firedrake/test_overrides.py
@@ -1,6 +1,6 @@
 from firedrake import *
 from tlm_adjoint.firedrake import *
-from tlm_adjoint.firedrake.backend import backend_assemble
+from tlm_adjoint.firedrake.backend import backend_assemble, backend_Constant
 from tlm_adjoint.firedrake.backend_code_generator_interface import (
     assemble as backend_code_generator_interface_assemble)
 
@@ -13,6 +13,51 @@ import ufl
 pytestmark = pytest.mark.skipif(
     DEFAULT_COMM.size not in {1, 4},
     reason="tests must be run in serial, or with 4 processes")
+
+
+@pytest.mark.firedrake
+@pytest.mark.parametrize("constant_cls", [backend_Constant, Constant])
+@pytest.mark.parametrize("p", [1, 2])
+@seed_test
+def test_Constant_init(setup_test,
+                       constant_cls, p):
+    def forward(m):
+        x = constant_cls(m if p == 1 else m ** p)
+        return to_float(x) ** (4 / p)
+
+    if complex_mode:
+        m = constant_cls(np.cbrt(2.0) + 1.0j * np.cbrt(3.0))
+        dm = constant_cls(np.sqrt(0.5) + 1.0j * np.sqrt(0.5))
+        dM = tuple(map(constant_cls, (complex(dm), complex(dm).conjugate())))
+    else:
+        m = constant_cls(np.cbrt(2.0))
+        dm = constant_cls(1.0)
+        dM = (dm, dm)
+
+    start_manager()
+    J = forward(m)
+    stop_manager()
+
+    J_val = J.value
+
+    dJ = compute_gradient(J, m)
+    assert abs(complex(dJ).conjugate() - 4.0 * (complex(m) ** 3)) < 1.0e-14
+
+    min_order = taylor_test(forward, m, J_val=J_val, dJ=dJ, dM=dm)
+    assert min_order > 2.00
+
+    ddJ = Hessian(forward)
+    min_order = taylor_test(forward, m, J_val=J_val, ddJ=ddJ, dM=dm)
+    assert min_order > 3.00
+
+    min_order = taylor_test_tlm(forward, m, tlm_order=1, dMs=(dm,))
+    assert min_order > 2.00
+
+    min_order = taylor_test_tlm_adjoint(forward, m, adjoint_order=1, dMs=dM)
+    assert min_order > 1.99
+
+    min_order = taylor_test_tlm_adjoint(forward, m, adjoint_order=2, dMs=dM)
+    assert min_order > 1.99
 
 
 def project_project(F, space, bc):

--- a/tlm_adjoint/fenics/__init__.py
+++ b/tlm_adjoint/fenics/__init__.py
@@ -8,8 +8,9 @@ del adjoint, alias, cached_hessian, caches, checkpointing, \
 from .backend import backend, backend_RealType, backend_ScalarType  # noqa: E402,E501,F401
 from .backend_code_generator_interface import linear_solver  # noqa: E402,F401
 from .backend_interface import *   # noqa: E402,F401
-from .backend_overrides import *   # noqa: E402,F401
 from .caches import *              # noqa: E402,F401
 from .equations import *           # noqa: E402,F401
 from .fenics_equations import *    # noqa: E402,F401
 from .functions import *           # noqa: E402,F401
+
+from .backend_overrides import *   # noqa: E402,F401

--- a/tlm_adjoint/fenics/backend_overrides.py
+++ b/tlm_adjoint/fenics/backend_overrides.py
@@ -382,6 +382,36 @@ def DirichletBC_apply(self, orig, orig_args, *args):
             b._tlm_adjoint__bcs.append(self)
 
 
+def Constant_init_assign(self, value, annotate, tlm):
+    if is_var(value):
+        eq = Assignment(self, value)
+    elif isinstance(value, ufl.classes.Expr):
+        eq = ExprInterpolation(self, value)
+    else:
+        eq = None
+
+    if eq is not None:
+        assert len(eq.initial_condition_dependencies()) == 0
+        eq._post_process(annotate=annotate, tlm=tlm)
+
+
+@manager_method(backend_Constant, "__init__")
+def backend_Constant__init__(self, orig, orig_args, value, *args,
+                             annotate, tlm, **kwargs):
+    orig_args()
+    Constant_init_assign(self, value, annotate, tlm)
+
+
+# Patch the subclass constructor separately so that all variable attributes are
+# set before annotation
+@manager_method(Constant, "__init__")
+def Constant__init__(self, orig, orig_args, value=None, *args,
+                     annotate, tlm, **kwargs):
+    orig_args()
+    if value is not None:
+        Constant_init_assign(self, value, annotate, tlm)
+
+
 def var_update_state_post_call(self, return_value, *args, **kwargs):
     var_update_state(self)
     return return_value

--- a/tlm_adjoint/fenics/functions.py
+++ b/tlm_adjoint/fenics/functions.py
@@ -14,6 +14,7 @@ from ..interface import (
     var_replacement, var_scalar_value, var_space, var_space_type)
 
 from ..caches import Caches
+from ..manager import paused_manager
 
 import numbers
 import numpy as np
@@ -467,7 +468,8 @@ class DirichletBC(backend_DirichletBC):
     # Based on FEniCS 2019.1.0 DirichletBC API
     def __init__(self, V, g, sub_domain, *args,
                  static=None, _homogeneous=False, **kwargs):
-        super().__init__(V, g, sub_domain, *args, **kwargs)
+        with paused_manager():
+            super().__init__(V, g, sub_domain, *args, **kwargs)
 
         if static is None:
             for dep in extract_coefficients(

--- a/tlm_adjoint/firedrake/__init__.py
+++ b/tlm_adjoint/firedrake/__init__.py
@@ -8,7 +8,6 @@ del adjoint, alias, cached_hessian, caches, checkpointing, \
 from .backend import backend, backend_RealType, backend_ScalarType  # noqa: E402,E501,F401
 from .backend_code_generator_interface import linear_solver  # noqa: E402,F401
 from .backend_interface import *    # noqa: E402,F401
-from .backend_overrides import *    # noqa: E402,F401
 from .block_system import \
     (ConstantNullspace, DirichletBCNullspace, NoneNullspace, UnityNullspace)  # noqa: E402,E501,F401
 from .caches import *               # noqa: E402,F401
@@ -16,3 +15,5 @@ from .equations import *            # noqa: E402,F401
 from .firedrake_equations import *  # noqa: E402,F401
 from .functions import *            # noqa: E402,F401
 from .hessian_system import *       # noqa: E402,F401
+
+from .backend_overrides import *    # noqa: E402,F401

--- a/tlm_adjoint/firedrake/backend_interface.py
+++ b/tlm_adjoint/firedrake/backend_interface.py
@@ -11,6 +11,7 @@ from ..interface import (
 
 from ..equations import Conversion
 from ..override import override_method, override_property
+from ..manager import paused_manager
 
 from .equations import Assembly
 from .functions import (
@@ -43,7 +44,8 @@ __all__ = \
 def Constant__init__(self, orig, orig_args, value, domain=None, *,
                      name=None, space=None, comm=None,
                      **kwargs):
-    orig(self, value, domain=domain, name=name, **kwargs)
+    with paused_manager():
+        orig(self, value, domain=domain, name=name, **kwargs)
 
     if name is None:
         name = self.name

--- a/tlm_adjoint/firedrake/functions.py
+++ b/tlm_adjoint/firedrake/functions.py
@@ -13,6 +13,7 @@ from ..interface import (
     var_scalar_value, var_space, var_space_type)
 
 from ..caches import Caches
+from ..manager import paused_manager
 
 import numbers
 import numpy as np
@@ -283,9 +284,10 @@ class Constant(backend_Constant):
         if cache is None:
             cache = static
 
-        super().__init__(
-            value, *args, name=name, domain=domain, space=space,
-            comm=comm, **kwargs)
+        with paused_manager():
+            super().__init__(
+                value, *args, name=name, domain=domain, space=space,
+                comm=comm, **kwargs)
         self._tlm_adjoint__var_interface_attrs.d_setitem("space_type", space_type)  # noqa: E501
         self._tlm_adjoint__var_interface_attrs.d_setitem("static", static)
         self._tlm_adjoint__var_interface_attrs.d_setitem("cache", cache)


### PR DESCRIPTION
Handles the case where a `Constant` is initialized using other `Constant`s.