### PR TITLE
Add `FormSum` support to `EquationSolver`

### DIFF
--- a/tests/fenics/test_base.py
+++ b/tests/fenics/test_base.py
@@ -1,9 +1,10 @@
 from fenics import *
 from tlm_adjoint.fenics import *
 from tlm_adjoint.fenics import manager as _manager
-from tlm_adjoint.fenics.backend import backend_Constant, backend_Function
+from tlm_adjoint.fenics.backend import (
+    backend_Constant, backend_Function, complex_mode)
 from tlm_adjoint.fenics.backend_code_generator_interface import (
-    complex_mode, interpolate_expression)
+    interpolate_expression)
 from tlm_adjoint.alias import gc_disabled
 from tlm_adjoint.override import override_method
 

--- a/tests/fenics/test_base.py
+++ b/tests/fenics/test_base.py
@@ -155,9 +155,8 @@ def test_leaks():
 
     refs = 0
     for F in referenced_vars():
-        if not isinstance(F, ZeroConstant):
-            info(f"{var_name(F):s} referenced")
-            refs += 1
+        info(f"{var_name(F):s} referenced")
+        refs += 1
     if refs == 0:
         info("No references")
 

--- a/tests/fenics/test_equations.py
+++ b/tests/fenics/test_equations.py
@@ -2,6 +2,7 @@ from fenics import *
 from tlm_adjoint.fenics import *
 from tlm_adjoint.fenics.backend_code_generator_interface import (
     assemble_linear_solver)
+from tlm_adjoint.fenics.functions import extract_coefficients
 
 from .test_base import *
 

--- a/tests/fenics/test_equations.py
+++ b/tests/fenics/test_equations.py
@@ -958,14 +958,8 @@ def test_eliminate_zeros(setup_test, test_leaks):
     L = inner(F, test) * dx
 
     for i in range(3):
-        L_z = eliminate_zeros(L, force_non_empty_form=False)
+        L_z = eliminate_zeros(L)
         assert L_z.empty()
-
-        L_z = eliminate_zeros(L, force_non_empty_form=True)
-        assert not L_z.empty()
-        b = Function(space, space_type="conjugate_dual")
-        assemble(L_z, tensor=b)
-        assert var_linf_norm(b) == 0.0
 
 
 @pytest.mark.fenics
@@ -996,13 +990,7 @@ def test_eliminate_zeros_arity_1(setup_test, test_leaks,
             + Constant(1.0) * inner(grad(F), grad(test)) * dx)
 
     zero_form = eliminate_zeros(form)
-    assert len(zero_form.integrals()) == 0
-
-    zero_form = eliminate_zeros(form, force_non_empty_form=True)
-    assert F not in extract_coefficients(zero_form)
-    b = Function(space, space_type="conjugate_dual")
-    assemble(zero_form, tensor=b)
-    assert var_linf_norm(b) == 0.0
+    assert zero_form.empty()
 
 
 @pytest.mark.fenics

--- a/tests/firedrake/test_base.py
+++ b/tests/firedrake/test_base.py
@@ -2,9 +2,9 @@ from firedrake import *
 from tlm_adjoint.firedrake import *
 from tlm_adjoint.firedrake import manager as _manager
 from tlm_adjoint.firedrake.backend import (
-    backend_Cofunction, backend_Constant, backend_Function)
+    backend_Cofunction, backend_Constant, backend_Function, complex_mode)
 from tlm_adjoint.firedrake.backend_code_generator_interface import (
-    complex_mode, interpolate_expression)
+    interpolate_expression)
 from tlm_adjoint.alias import gc_disabled
 from tlm_adjoint.override import override_method
 

--- a/tests/firedrake/test_base.py
+++ b/tests/firedrake/test_base.py
@@ -151,8 +151,7 @@ def test_leaks():
 
     refs = 0
     for F in referenced_vars():
-        if not isinstance(F, ZeroConstant) \
-                and var_name(F) != f"{DEFAULT_MESH_NAME:s}_coordinates":
+        if var_name(F) != f"{DEFAULT_MESH_NAME:s}_coordinates":
             info(f"{var_name(F):s} referenced")
             refs += 1
     if refs == 0:

--- a/tests/firedrake/test_caches.py
+++ b/tests/firedrake/test_caches.py
@@ -263,12 +263,13 @@ def test_mat_terms(setup_test, test_leaks,
     b_ref = Cofunction(space.dual(), name="b_ref")
     assemble(form, tensor=b_ref)
 
-    cached_terms, mat_terms, non_cached_terms = split_form(form)
+    cached_terms, mat_terms, non_cached_terms, non_cached_expr = split_form(form)  # noqa: E501
 
     assert cached_terms.empty()
     if not complex_mode or not x_conjugate:
         assert len(mat_terms) == 1
         assert non_cached_terms.empty()
+        assert isinstance(non_cached_expr, ufl.classes.ZeroBaseForm)
 
         assert tuple(mat_terms.keys()) == (var_id(x),)
         A, = tuple(mat_terms.values())
@@ -279,6 +280,7 @@ def test_mat_terms(setup_test, test_leaks,
     else:
         assert len(mat_terms) == 0
         assert not non_cached_terms.empty()
+        assert isinstance(non_cached_expr, ufl.classes.ZeroBaseForm)
 
         b = Cofunction(space.dual(), name="b")
         assemble(non_cached_terms, tensor=b)

--- a/tests/firedrake/test_caches.py
+++ b/tests/firedrake/test_caches.py
@@ -263,13 +263,12 @@ def test_mat_terms(setup_test, test_leaks,
     b_ref = Cofunction(space.dual(), name="b_ref")
     assemble(form, tensor=b_ref)
 
-    cached_terms, mat_terms, non_cached_terms, non_cached_expr = split_form(form)  # noqa: E501
+    cached_terms, mat_terms, non_cached_terms = split_form(form)
 
     assert cached_terms.empty()
     if not complex_mode or not x_conjugate:
         assert len(mat_terms) == 1
-        assert non_cached_terms.empty()
-        assert isinstance(non_cached_expr, ufl.classes.ZeroBaseForm)
+        assert isinstance(non_cached_terms, ufl.classes.ZeroBaseForm)
 
         assert tuple(mat_terms.keys()) == (var_id(x),)
         A, = tuple(mat_terms.values())
@@ -279,8 +278,7 @@ def test_mat_terms(setup_test, test_leaks,
         assert b_bc is None
     else:
         assert len(mat_terms) == 0
-        assert not non_cached_terms.empty()
-        assert isinstance(non_cached_expr, ufl.classes.ZeroBaseForm)
+        assert not isinstance(non_cached_terms, ufl.classes.ZeroBaseForm)
 
         b = Cofunction(space.dual(), name="b")
         assemble(non_cached_terms, tensor=b)

--- a/tests/firedrake/test_equations.py
+++ b/tests/firedrake/test_equations.py
@@ -1237,14 +1237,8 @@ def test_eliminate_zeros(setup_test, test_leaks):
     L = inner(F, test) * dx
 
     for i in range(3):
-        L_z = eliminate_zeros(L, force_non_empty_form=False)
-        assert L_z.empty()
-
-        L_z = eliminate_zeros(L, force_non_empty_form=True)
-        assert not L_z.empty()
-        b = Cofunction(space.dual())
-        assemble(L_z, tensor=b)
-        assert var_linf_norm(b) == 0.0
+        L_z = eliminate_zeros(L)
+        assert isinstance(L_z, ufl.classes.ZeroBaseForm)
 
 
 @pytest.mark.firedrake
@@ -1275,13 +1269,7 @@ def test_eliminate_zeros_arity_1(setup_test, test_leaks,
             + Constant(1.0) * inner(grad(F), grad(test)) * dx)
 
     zero_form = eliminate_zeros(form)
-    assert len(zero_form.integrals()) == 0
-
-    zero_form = eliminate_zeros(form, force_non_empty_form=True)
-    assert F not in extract_coefficients(zero_form)
-    b = Cofunction(space.dual())
-    assemble(zero_form, tensor=b)
-    assert var_linf_norm(b) == 0.0
+    assert isinstance(zero_form, ufl.classes.ZeroBaseForm)
 
 
 @pytest.mark.firedrake

--- a/tests/firedrake/test_equations.py
+++ b/tests/firedrake/test_equations.py
@@ -2,6 +2,7 @@ from firedrake import *
 from tlm_adjoint.firedrake import *
 from tlm_adjoint.firedrake.backend_code_generator_interface import (
     assemble_linear_solver)
+from tlm_adjoint.firedrake.functions import extract_coefficients
 
 from .test_base import *
 

--- a/tests/firedrake/test_equations.py
+++ b/tests/firedrake/test_equations.py
@@ -1172,7 +1172,8 @@ def rhs_FormSum(alpha, m, test):
                                  functools.partial(rhs_FormSum, 0.5),
                                  functools.partial(rhs_FormSum, -0.5),
                                  functools.partial(rhs_FormSum, 0.5 + 0.5j)])
-def test_EquationSolver_FormSum(setup_test, test_leaks,
+@seed_test
+def test_EquationSolver_FormSum(setup_test, test_leaks, test_configurations,
                                 solve_eq, rhs):
     mesh = UnitIntervalMesh(10)
     X = SpatialCoordinate(mesh)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,6 +1,7 @@
 from tlm_adjoint import DEFAULT_COMM, VectorEquation
 from tlm_adjoint.override import override_function, override_method
 
+import functools
 import hashlib
 import inspect
 import json
@@ -31,7 +32,9 @@ def seed_test(fn):
             # Raises an error if tmp_path is a positional argument
             del kwargs["tmp_path"]
         for key, value in kwargs.items():
-            if callable(value):
+            if isinstance(value, functools.partial):
+                kwargs[key] = ("partial", value.func.__name__)
+            elif callable(value):
                 kwargs[key] = value.__name__
 
         h = hashlib.sha256()

--- a/tlm_adjoint/equations.py
+++ b/tlm_adjoint/equations.py
@@ -163,7 +163,7 @@ class LinearCombination(Equation):
         alpha = []
         Y = []
         for a, y in args:
-            if a.imag == 0:
+            if a.imag == 0.0:
                 a = a.real
             check_space_types(x, y)
 

--- a/tlm_adjoint/equations.py
+++ b/tlm_adjoint/equations.py
@@ -163,7 +163,7 @@ class LinearCombination(Equation):
         alpha = []
         Y = []
         for a, y in args:
-            if a.imag == 0.0:
+            if a.imag == 0:
                 a = a.real
             check_space_types(x, y)
 

--- a/tlm_adjoint/fenics/backend_code_generator_interface.py
+++ b/tlm_adjoint/fenics/backend_code_generator_interface.py
@@ -2,7 +2,7 @@ from .backend import (
     LUSolver, KrylovSolver, Parameters, TestFunction, UserExpression,
     as_backend_type, backend_Constant, backend_DirichletBC, backend_Function,
     backend_ScalarType, backend_assemble, backend_assemble_system,
-    backend_solve as solve, complex_mode, has_lu_solver_method, parameters)
+    backend_solve as solve, has_lu_solver_method, parameters)
 from ..interface import (
     check_space_type, check_space_types, is_var, space_new, var_assign,
     var_get_values, var_inner, var_new_conjugate_dual, var_set_values,
@@ -22,8 +22,6 @@ except ImportError:
 
 __all__ = \
     [
-        "complex_mode",
-
         "assemble_linear_solver",
         "assemble_matrix",
         "linear_solver",

--- a/tlm_adjoint/fenics/backend_code_generator_interface.py
+++ b/tlm_adjoint/fenics/backend_code_generator_interface.py
@@ -1,9 +1,8 @@
 from .backend import (
     LUSolver, KrylovSolver, Parameters, TestFunction, UserExpression,
     as_backend_type, backend_Constant, backend_DirichletBC, backend_Function,
-    backend_ScalarType, backend_Vector, backend_assemble,
-    backend_assemble_system, backend_solve as solve, complex_mode,
-    has_lu_solver_method, parameters)
+    backend_ScalarType, backend_assemble, backend_assemble_system,
+    backend_solve as solve, complex_mode, has_lu_solver_method, parameters)
 from ..interface import (
     check_space_type, check_space_types, is_var, space_new, var_assign,
     var_get_values, var_inner, var_new_conjugate_dual, var_set_values,
@@ -256,26 +255,6 @@ def matrix_multiply(A, x, *,
     tensor.apply("insert")
 
     return tensor
-
-
-def rhs_copy(x):
-    if not isinstance(x, backend_Vector):
-        raise TypeError("Invalid RHS")
-    if hasattr(x, "_tlm_adjoint__function"):
-        check_space_type(x._tlm_adjoint__function, "conjugate_dual")
-    return x.copy()
-
-
-def rhs_addto(x, y):
-    if not isinstance(x, backend_Vector):
-        raise TypeError("Invalid RHS")
-    if not isinstance(y, backend_Vector):
-        raise TypeError("Invalid RHS")
-    if hasattr(x, "_tlm_adjoint__function"):
-        check_space_type(x._tlm_adjoint__function, "conjugate_dual")
-    if hasattr(y, "_tlm_adjoint__function"):
-        check_space_type(y._tlm_adjoint__function, "conjugate_dual")
-    x.axpy(1.0, y)
 
 
 def parameters_key(parameters):

--- a/tlm_adjoint/fenics/backend_interface.py
+++ b/tlm_adjoint/fenics/backend_interface.py
@@ -14,7 +14,7 @@ from ..override import override_method
 from .equations import Assembly
 from .functions import (
     Caches, ConstantInterface, ConstantSpaceInterface, ReplacementFunction,
-    Zero, define_var_alias, new_count, r0_space)
+    ReplacementZeroFunction, Zero, define_var_alias, new_count, r0_space)
 
 import functools
 import numbers
@@ -245,8 +245,12 @@ class FunctionInterface(VariableInterface):
     def _replacement(self):
         if "replacement" not in self._tlm_adjoint__var_interface_attrs:
             count = self._tlm_adjoint__var_interface_attrs["replacement_count"]
-            self._tlm_adjoint__var_interface_attrs["replacement"] = \
-                ReplacementFunction(self, count=count)
+            if isinstance(self, Zero):
+                self._tlm_adjoint__var_interface_attrs["replacement"] = \
+                    ReplacementZeroFunction(self, count=count)
+            else:
+                self._tlm_adjoint__var_interface_attrs["replacement"] = \
+                    ReplacementFunction(self, count=count)
         return self._tlm_adjoint__var_interface_attrs["replacement"]
 
     def _is_replacement(self):

--- a/tlm_adjoint/fenics/caches.py
+++ b/tlm_adjoint/fenics/caches.py
@@ -221,9 +221,6 @@ def split_form(form):
 
     def add_integral(integrals, base_integral, terms):
         if len(terms) > 0:
-            assert all(term.ufl_shape == () for term in terms)
-            assert all(term.ufl_free_indices == () for term in terms)
-            assert all(term.ufl_index_dimensions == () for term in terms)
             integrand = sum(terms, expr_zero(terms[0]))
             integral = base_integral.reconstruct(integrand=integrand)
             integrals.append(integral)
@@ -328,6 +325,8 @@ class AssemblyCache(Cache):
             linear_solver_parameters = {}
 
         form = eliminate_zeros(form)
+        if form.empty():
+            raise ValueError("Form cannot be empty")
         if replace_map is None:
             assemble_form = form
         else:
@@ -398,6 +397,8 @@ class LinearSolverCache(Cache):
             linear_solver_parameters = {}
 
         form = eliminate_zeros(form)
+        if form.empty():
+            raise ValueError("Form cannot be empty")
         if replace_map is None:
             assemble_form = form
         else:

--- a/tlm_adjoint/fenics/caches.py
+++ b/tlm_adjoint/fenics/caches.py
@@ -273,9 +273,9 @@ def split_form(form):
     mat_forms = {}
     for dep_id in mat_integrals:
         mat_forms[dep_id] = ufl.classes.Form(mat_integrals[dep_id])
-    non_cached_forms = ufl.classes.Form(non_cached_integrals)
+    non_cached_form = ufl.classes.Form(non_cached_integrals)
 
-    return cached_form, mat_forms, non_cached_forms
+    return cached_form, mat_forms, non_cached_form
 
 
 def form_key(*forms):

--- a/tlm_adjoint/fenics/caches.py
+++ b/tlm_adjoint/fenics/caches.py
@@ -212,6 +212,9 @@ def split_terms(terms, base_integral,
 
 
 def split_form(form):
+    if form.empty():
+        return ufl.classes.Form([]), {}, ufl.classes.Form([])
+
     if len(form.arguments()) != 1:
         raise ValueError("Arity 1 form required")
     form = ufl.algorithms.remove_complex_nodes.remove_complex_nodes(form)
@@ -324,7 +327,7 @@ class AssemblyCache(Cache):
         if linear_solver_parameters is None:
             linear_solver_parameters = {}
 
-        form = eliminate_zeros(form, force_non_empty_form=True)
+        form = eliminate_zeros(form)
         if replace_map is None:
             assemble_form = form
         else:
@@ -394,7 +397,7 @@ class LinearSolverCache(Cache):
         if linear_solver_parameters is None:
             linear_solver_parameters = {}
 
-        form = eliminate_zeros(form, force_non_empty_form=True)
+        form = eliminate_zeros(form)
         if replace_map is None:
             assemble_form = form
         else:

--- a/tlm_adjoint/fenics/caches.py
+++ b/tlm_adjoint/fenics/caches.py
@@ -13,8 +13,8 @@ from .backend_code_generator_interface import (
 from ..caches import Cache
 
 from .functions import (
-    ReplacementFunction, derivative, eliminate_zeros, extract_coefficients,
-    replaced_form)
+    ReplacementFunction, derivative, eliminate_zeros, expr_zero,
+    extract_coefficients, replaced_form)
 
 from collections import defaultdict
 import itertools
@@ -84,7 +84,7 @@ def form_simplify_conj(form):
                 return expr_simplify_conj(x)
             elif isinstance(expr, ufl.classes.Sum):
                 return sum(map(expr_conj, expr.ufl_operands),
-                           ufl.classes.Zero(shape=expr.ufl_shape))
+                           expr_zero(expr))
             elif isinstance(expr, ufl.classes.Product):
                 x, y = expr.ufl_operands
                 return expr_conj(x) * expr_conj(y)
@@ -97,7 +97,7 @@ def form_simplify_conj(form):
                 return expr_conj(x)
             elif isinstance(expr, ufl.classes.Sum):
                 return sum(map(expr_simplify_conj, expr.ufl_operands),
-                           ufl.classes.Zero(shape=expr.ufl_shape))
+                           expr_zero(expr))
             elif isinstance(expr, ufl.classes.Product):
                 x, y = expr.ufl_operands
                 return expr_simplify_conj(x) * expr_simplify_conj(y)
@@ -254,7 +254,10 @@ def split_form(form):
 
     def add_integral(integrals, base_integral, terms):
         if len(terms) > 0:
-            integrand = sum(terms, ufl.classes.Zero())
+            assert all(term.ufl_shape == () for term in terms)
+            assert all(term.ufl_free_indices == () for term in terms)
+            assert all(term.ufl_index_dimensions == () for term in terms)
+            integrand = sum(terms, expr_zero(terms[0]))
             integral = base_integral.reconstruct(integrand=integrand)
             integrals.append(integral)
 

--- a/tlm_adjoint/fenics/equations.py
+++ b/tlm_adjoint/fenics/equations.py
@@ -51,8 +51,7 @@ def extract_derivative_coefficients(expr, dep):
     return extract_coefficients(dexpr)
 
 
-def extract_dependencies(expr, *,
-                         space_type="primal"):
+def extract_dependencies(expr, *, space_type=None):
     deps = {}
     nl_deps = {}
     for dep in extract_coefficients(expr):
@@ -69,8 +68,9 @@ def extract_dependencies(expr, *,
                for nl_dep_id in sorted(nl_deps.keys())}
 
     assert len(set(nl_deps.keys()).difference(set(deps.keys()))) == 0
-    for dep in deps.values():
-        check_space_type(dep, space_type)
+    if space_type is not None:
+        for dep in deps.values():
+            check_space_type(dep, space_type)
 
     return deps, nl_deps
 
@@ -149,7 +149,7 @@ class Assembly(ExprEquation):
         else:
             raise ValueError("Must be an arity 0 or arity 1 form")
 
-        deps, nl_deps = extract_dependencies(rhs)
+        deps, nl_deps = extract_dependencies(rhs, space_type="primal")
         if var_id(x) in deps:
             raise ValueError("Invalid dependency")
         deps, nl_deps = list(deps.values()), tuple(nl_deps.values())
@@ -360,7 +360,7 @@ class EquationSolver(ExprEquation):
             J = derivative(F, x)
             J = ufl.algorithms.expand_derivatives(J)
 
-        deps, nl_deps = extract_dependencies(F)
+        deps, nl_deps = extract_dependencies(F, space_type="primal")
         if nl_solve_J is not None:
             for dep in extract_coefficients(nl_solve_J):
                 if is_var(dep):
@@ -882,7 +882,7 @@ class ExprInterpolation(ExprEquation):
     """
 
     def __init__(self, x, rhs):
-        deps, nl_deps = extract_dependencies(rhs)
+        deps, nl_deps = extract_dependencies(rhs, space_type="primal")
         if var_id(x) in deps:
             raise ValueError("Invalid dependency")
         deps, nl_deps = list(deps.values()), tuple(nl_deps.values())

--- a/tlm_adjoint/fenics/equations.py
+++ b/tlm_adjoint/fenics/equations.py
@@ -138,8 +138,6 @@ class Assembly(ExprEquation):
         if match_quadrature is None:
             match_quadrature = parameters["tlm_adjoint"]["Assembly"]["match_quadrature"]  # noqa: E501
 
-        rhs = ufl.classes.Form(rhs.integrals())
-
         arity = len(rhs.arguments())
         if arity == 0:
             check_space_type(x, "primal")
@@ -337,12 +335,7 @@ class EquationSolver(ExprEquation):
 
         lhs, rhs = eq.lhs, eq.rhs
         del eq
-        lhs = ufl.classes.Form(lhs.integrals())
         linear = isinstance(rhs, ufl.classes.Form)
-        if linear:
-            rhs = ufl.classes.Form(rhs.integrals())
-        if J is not None:
-            J = ufl.classes.Form(J.integrals())
 
         if linear:
             if len(lhs.arguments()) != 2:

--- a/tlm_adjoint/fenics/equations.py
+++ b/tlm_adjoint/fenics/equations.py
@@ -23,7 +23,7 @@ from ..equations import Assignment
 from .caches import assembly_cache, is_cached, linear_solver_cache, split_form
 from .functions import (
     ReplacementConstant, bcs_is_cached, bcs_is_homogeneous, bcs_is_static,
-    derivative, eliminate_zeros, extract_coefficients)
+    derivative, eliminate_zeros, expr_zero, extract_coefficients)
 
 import itertools
 import numpy as np
@@ -929,7 +929,7 @@ class ExprInterpolation(ExprEquation):
     def tangent_linear(self, M, dM, tlm_map):
         x = self.x()
 
-        tlm_rhs = ufl.classes.Zero(shape=x.ufl_shape)
+        tlm_rhs = expr_zero(x)
         for dep in self.dependencies():
             if dep != x:
                 tau_dep = tlm_map[dep]

--- a/tlm_adjoint/fenics/equations.py
+++ b/tlm_adjoint/fenics/equations.py
@@ -477,7 +477,7 @@ class EquationSolver(ExprEquation):
         eq_deps = self.dependencies()
 
         if self._forward_b_pa is None:
-            rhs = eliminate_zeros(self._rhs, force_non_empty_form=True)
+            rhs = eliminate_zeros(self._rhs)
             cached_form, mat_forms_, non_cached_form = split_form(rhs)
 
             dep_indices = {var_id(dep): dep_index

--- a/tlm_adjoint/fenics/fenics_equations.py
+++ b/tlm_adjoint/fenics/fenics_equations.py
@@ -215,7 +215,7 @@ class LocalSolverCache(Cache):
         if solver_type is None:
             solver_type = LocalSolver.SolverType.LU
 
-        form = eliminate_zeros(form, force_non_empty_form=True)
+        form = eliminate_zeros(form)
         if replace_map is None:
             assemble_form = form
         else:

--- a/tlm_adjoint/fenics/fenics_equations.py
+++ b/tlm_adjoint/fenics/fenics_equations.py
@@ -216,6 +216,8 @@ class LocalSolverCache(Cache):
             solver_type = LocalSolver.SolverType.LU
 
         form = eliminate_zeros(form)
+        if form.empty():
+            raise ValueError("Form cannot be empty")
         if replace_map is None:
             assemble_form = form
         else:

--- a/tlm_adjoint/fenics/functions.py
+++ b/tlm_adjoint/fenics/functions.py
@@ -197,8 +197,12 @@ class ConstantInterface(VariableInterface):
     def _replacement(self):
         if "replacement" not in self._tlm_adjoint__var_interface_attrs:
             count = self._tlm_adjoint__var_interface_attrs["replacement_count"]
-            self._tlm_adjoint__var_interface_attrs["replacement"] = \
-                ReplacementConstant(self, count=count)
+            if isinstance(self, Zero):
+                self._tlm_adjoint__var_interface_attrs["replacement"] = \
+                    ReplacementZeroConstant(self, count=count)
+            else:
+                self._tlm_adjoint__var_interface_attrs["replacement"] = \
+                    ReplacementConstant(self, count=count)
         return self._tlm_adjoint__var_interface_attrs["replacement"]
 
     def _is_replacement(self):
@@ -560,9 +564,21 @@ class ReplacementConstant(Replacement):
     """
 
 
+class ReplacementZeroConstant(ReplacementConstant, Zero):
+    def __init__(self, *args, **kwargs):
+        ReplacementConstant.__init__(self, *args, **kwargs)
+        Zero.__init__(self)
+
+
 class ReplacementFunction(Replacement):
     """Represents a symbolic DOLFIN `Function`, but has no value.
     """
+
+
+class ReplacementZeroFunction(ReplacementFunction, Zero):
+    def __init__(self, *args, **kwargs):
+        ReplacementFunction.__init__(self, *args, **kwargs)
+        Zero.__init__(self)
 
 
 def replaced_form(form):

--- a/tlm_adjoint/fenics/functions.py
+++ b/tlm_adjoint/fenics/functions.py
@@ -410,6 +410,12 @@ def derivative(expr, x, argument=None, *,
     return ufl.derivative(expr, x, argument=argument)
 
 
+def expr_zero(expr):
+    return ufl.classes.Zero(shape=expr.ufl_shape,
+                            free_indices=expr.ufl_free_indices,
+                            index_dimensions=expr.ufl_index_dimensions)
+
+
 def eliminate_zeros(expr, *, force_non_empty_form=False):
     """Apply zero elimination for :class:`.Zero` objects in the supplied
     :class:`ufl.core.expr.Expr` or :class:`ufl.Form`.
@@ -424,7 +430,7 @@ def eliminate_zeros(expr, *, force_non_empty_form=False):
 
     @form_cached("_tlm_adjoint__simplified_form")
     def simplified(expr):
-        replace_map = {c: ufl.classes.Zero(shape=c.ufl_shape)
+        replace_map = {c: expr_zero(c)
                        for c in extract_coefficients(expr)
                        if isinstance(c, Zero)}
         if len(replace_map) == 0:

--- a/tlm_adjoint/fenics/functions.py
+++ b/tlm_adjoint/fenics/functions.py
@@ -27,7 +27,6 @@ import weakref
 __all__ = \
     [
         "Constant",
-        "extract_coefficients",
 
         "Zero",
         "ZeroConstant",
@@ -323,11 +322,6 @@ class ZeroConstant(Constant, Zero):
 
 
 def extract_coefficients(expr):
-    """
-    :returns: Coefficients on which the supplied :class:`ufl.core.expr.Expr` or
-        :class:`ufl.Form` depends.
-    """
-
     return ufl.algorithms.extract_coefficients(expr)
 
 

--- a/tlm_adjoint/fenics/functions.py
+++ b/tlm_adjoint/fenics/functions.py
@@ -36,6 +36,8 @@ __all__ = \
         "Replacement",
         "ReplacementConstant",
         "ReplacementFunction",
+        "ReplacementZeroConstant",
+        "ReplacementZeroFunction",
 
         "DirichletBC",
         "HomogeneousDirichletBC"
@@ -540,18 +542,24 @@ class ReplacementConstant(Replacement):
     """
 
 
-class ReplacementZeroConstant(ReplacementConstant, Zero):
-    def __init__(self, *args, **kwargs):
-        ReplacementConstant.__init__(self, *args, **kwargs)
-        Zero.__init__(self)
-
-
 class ReplacementFunction(Replacement):
     """Represents a symbolic DOLFIN `Function`, but has no value.
     """
 
 
+class ReplacementZeroConstant(ReplacementConstant, Zero):
+    """Represents a symbolic DOLFIN `Constant` which is zero, but has no value.
+    """
+
+    def __init__(self, *args, **kwargs):
+        ReplacementConstant.__init__(self, *args, **kwargs)
+        Zero.__init__(self)
+
+
 class ReplacementZeroFunction(ReplacementFunction, Zero):
+    """Represents a symbolic DOLFIN `Function` which is zero, but has no value.
+    """
+
     def __init__(self, *args, **kwargs):
         ReplacementFunction.__init__(self, *args, **kwargs)
         Zero.__init__(self)

--- a/tlm_adjoint/fenics/functions.py
+++ b/tlm_adjoint/fenics/functions.py
@@ -324,7 +324,7 @@ class ZeroConstant(Constant, Zero):
 
 def extract_coefficients(expr):
     """
-    :returns: Variables on which the supplied :class:`ufl.core.expr.Expr` or
+    :returns: Coefficients on which the supplied :class:`ufl.core.expr.Expr` or
         :class:`ufl.Form` depends.
     """
 

--- a/tlm_adjoint/firedrake/backend_code_generator_interface.py
+++ b/tlm_adjoint/firedrake/backend_code_generator_interface.py
@@ -121,10 +121,19 @@ def _assemble(form, tensor=None, bcs=None, *,
     if form_compiler_parameters is None:
         form_compiler_parameters = {}
 
-    form = eliminate_zeros(form, force_non_empty_form=True)
-    b = backend_assemble(
-        form, tensor=tensor, bcs=bcs,
-        form_compiler_parameters=form_compiler_parameters, mat_type=mat_type)
+    form = eliminate_zeros(form)
+    if len(form.arguments()) == 1:
+        b = backend_assemble(
+            form, tensor=tensor,
+            form_compiler_parameters=form_compiler_parameters,
+            mat_type=mat_type)
+        for bc in bcs:
+            bc.apply(b.riesz_representation("l2"))
+    else:
+        b = backend_assemble(
+            form, tensor=tensor, bcs=bcs,
+            form_compiler_parameters=form_compiler_parameters,
+            mat_type=mat_type)
 
     return b
 

--- a/tlm_adjoint/firedrake/backend_code_generator_interface.py
+++ b/tlm_adjoint/firedrake/backend_code_generator_interface.py
@@ -5,8 +5,7 @@ from .backend import (
     parameters)
 from ..interface import (
     check_space_type, check_space_types, is_var, space_new, var_assign,
-    var_axpy, var_copy, var_inner, var_new_conjugate_dual, var_space,
-    var_space_type)
+    var_copy, var_inner, var_new_conjugate_dual, var_space, var_space_type)
 
 from ..manager import manager_disabled
 from ..override import override_method
@@ -302,17 +301,6 @@ def matrix_multiply(A, x, *,
             A.petscmat.mult(x_v, tensor_v)
 
     return tensor
-
-
-def rhs_copy(x):
-    check_space_type(x, "conjugate_dual")
-    return var_copy(x)
-
-
-def rhs_addto(x, y):
-    check_space_type(x, "conjugate_dual")
-    check_space_type(y, "conjugate_dual")
-    var_axpy(x, 1.0, y)
 
 
 def parameters_key(parameters):

--- a/tlm_adjoint/firedrake/backend_code_generator_interface.py
+++ b/tlm_adjoint/firedrake/backend_code_generator_interface.py
@@ -119,6 +119,8 @@ def _assemble(form, tensor=None, bcs=None, *,
         form_compiler_parameters = {}
 
     form = eliminate_zeros(form)
+    if isinstance(form, ufl.classes.ZeroBaseForm):
+        raise ValueError("Form cannot be a ZeroBaseForm")
     if len(form.arguments()) == 1:
         b = backend_assemble(
             form, tensor=tensor,

--- a/tlm_adjoint/firedrake/backend_code_generator_interface.py
+++ b/tlm_adjoint/firedrake/backend_code_generator_interface.py
@@ -1,8 +1,7 @@
 from .backend import (
     LinearSolver, Interpolator, Parameters, backend_Cofunction,
     backend_Constant, backend_DirichletBC, backend_Function, backend_Matrix,
-    backend_assemble, backend_solve, complex_mode, extract_args, homogenize,
-    parameters)
+    backend_assemble, backend_solve, extract_args, homogenize, parameters)
 from ..interface import (
     check_space_type, check_space_types, is_var, space_new, var_assign,
     var_copy, var_inner, var_new_conjugate_dual, var_space, var_space_type)
@@ -19,8 +18,6 @@ import ufl
 
 __all__ = \
     [
-        "complex_mode",
-
         "assemble_linear_solver",
         "assemble_matrix",
         "linear_solver",

--- a/tlm_adjoint/firedrake/backend_interface.py
+++ b/tlm_adjoint/firedrake/backend_interface.py
@@ -17,7 +17,8 @@ from ..manager import paused_manager
 from .equations import Assembly
 from .functions import (
     Caches, ConstantInterface, ConstantSpaceInterface, Replacement,
-    ReplacementFunction, Zero, constant_space, define_var_alias, new_count)
+    ReplacementFunction, ReplacementZeroFunction, Zero, constant_space,
+    define_var_alias, new_count)
 
 import mpi4py.MPI as MPI
 import numbers
@@ -266,8 +267,12 @@ class FunctionInterface(FunctionInterfaceBase):
     def _replacement(self):
         if "replacement" not in self._tlm_adjoint__var_interface_attrs:
             count = self._tlm_adjoint__var_interface_attrs["replacement_count"]
-            self._tlm_adjoint__var_interface_attrs["replacement"] = \
-                ReplacementFunction(self, count=count)
+            if isinstance(self, Zero):
+                self._tlm_adjoint__var_interface_attrs["replacement"] = \
+                    ReplacementZeroFunction(self, count=count)
+            else:
+                self._tlm_adjoint__var_interface_attrs["replacement"] = \
+                    ReplacementFunction(self, count=count)
         return self._tlm_adjoint__var_interface_attrs["replacement"]
 
 

--- a/tlm_adjoint/firedrake/backend_interface.py
+++ b/tlm_adjoint/firedrake/backend_interface.py
@@ -1,6 +1,7 @@
 from .backend import (
-    backend_Cofunction, backend_CofunctionSpace, backend_Constant,
-    backend_Function, backend_FunctionSpace, backend_ScalarType)
+    TestFunction, backend_Cofunction, backend_CofunctionSpace,
+    backend_Constant, backend_Function, backend_FunctionSpace,
+    backend_ScalarType)
 from ..interface import (
     DEFAULT_COMM, SpaceInterface, VariableInterface, add_interface,
     add_replacement_interface, check_space_type, comm_dup_cached, new_space_id,
@@ -487,6 +488,10 @@ class ReplacementCofunction(Replacement, ufl.classes.Cofunction):
         Replacement.__init__(self)
         ufl.classes.Cofunction.__init__(self, var_space(x), count=count)
         add_replacement_interface(self, x)
+
+    def _analyze_form_arguments(self):
+        self._arguments = (TestFunction(var_space(self).dual()),)
+        self._coefficients = (self,)
 
     def equals(self, other):
         if self is other:

--- a/tlm_adjoint/firedrake/backend_overrides.py
+++ b/tlm_adjoint/firedrake/backend_overrides.py
@@ -17,7 +17,7 @@ from ..override import (
 from .equations import (
     Assembly, EquationSolver, ExprInterpolation, Projection, expr_new_x,
     linear_equation_new_x)
-from .functions import Constant, define_var_alias
+from .functions import Constant, define_var_alias, expr_zero
 from .firedrake_equations import ExprAssignment, LocalProjection
 
 import numbers
@@ -237,7 +237,7 @@ def Function_assign(self, orig, orig_args, expr, subset=None, *,
             x_0 = assign(None, self)
             expr = ufl.replace(expr, {self: x_0})
             x_1 = assign(None, self, subset=subset)
-            assign(self, ufl.classes.Zero(shape=self.ufl_shape))
+            assign(self, expr_zero(self))
             eq = ExprAssignment(self, expr, subset=subset)
         else:
             raise TypeError(f"Unexpected type: {type(expr)}")

--- a/tlm_adjoint/firedrake/caches.py
+++ b/tlm_adjoint/firedrake/caches.py
@@ -274,9 +274,6 @@ def _split_form(form):
 
     def add_integral(integrals, base_integral, terms):
         if len(terms) > 0:
-            assert all(term.ufl_shape == () for term in terms)
-            assert all(term.ufl_free_indices == () for term in terms)
-            assert all(term.ufl_index_dimensions == () for term in terms)
             integrand = sum(terms, expr_zero(terms[0]))
             integral = base_integral.reconstruct(integrand=integrand)
             integrals.append(integral)
@@ -382,6 +379,8 @@ class AssemblyCache(Cache):
             linear_solver_parameters = {}
 
         form = eliminate_zeros(form)
+        if isinstance(form, ufl.classes.ZeroBaseForm):
+            raise ValueError("Form cannot be a ZeroBaseForm")
         if replace_map is None:
             assemble_form = form
         else:
@@ -452,6 +451,8 @@ class LinearSolverCache(Cache):
             linear_solver_parameters = {}
 
         form = eliminate_zeros(form)
+        if isinstance(form, ufl.classes.ZeroBaseForm):
+            raise ValueError("Form cannot be a ZeroBaseForm")
         if replace_map is None:
             assemble_form = form
         else:

--- a/tlm_adjoint/firedrake/caches.py
+++ b/tlm_adjoint/firedrake/caches.py
@@ -40,6 +40,9 @@ def is_cached(expr):
 
 
 def form_simplify_sign(form):
+    if not isinstance(form, ufl.classes.Form):
+        raise TypeError("form must be a Form")
+
     integrals = []
 
     for integral in form.integrals():
@@ -74,6 +77,9 @@ def form_simplify_sign(form):
 
 
 def form_simplify_conj(form):
+    if not isinstance(form, ufl.classes.Form):
+        raise TypeError("form must be a Form")
+
     if complex_mode:
         def expr_conj(expr):
             if isinstance(expr, ufl.classes.Conj):
@@ -263,7 +269,9 @@ def split_form(form):
 
 
 def _split_form(form):
-    assert isinstance(form, ufl.classes.Form)
+    if not isinstance(form, ufl.classes.Form):
+        raise TypeError("form must be a Form")
+
     if form.empty():
         return ufl.classes.Form([]), {}, ufl.classes.Form([])
 
@@ -310,8 +318,9 @@ def form_key(*forms):
         form = ufl.algorithms.expand_derivatives(form)
         form = ufl.algorithms.apply_algebra_lowering.apply_algebra_lowering(form)  # noqa: E501
         form = ufl.algorithms.expand_indices(form)
-        form = form_simplify_conj(form)
-        form = form_simplify_sign(form)
+        if isinstance(form, ufl.classes.Form):
+            form = form_simplify_conj(form)
+            form = form_simplify_sign(form)
 
         key.extend((form, deps_key))
 
@@ -377,7 +386,7 @@ class AssemblyCache(Cache):
         if linear_solver_parameters is None:
             linear_solver_parameters = {}
 
-        form = eliminate_zeros(form, force_non_empty_form=True)
+        form = eliminate_zeros(form)
         if replace_map is None:
             assemble_form = form
         else:
@@ -447,7 +456,7 @@ class LinearSolverCache(Cache):
         if linear_solver_parameters is None:
             linear_solver_parameters = {}
 
-        form = eliminate_zeros(form, force_non_empty_form=True)
+        form = eliminate_zeros(form)
         if replace_map is None:
             assemble_form = form
         else:

--- a/tlm_adjoint/firedrake/caches.py
+++ b/tlm_adjoint/firedrake/caches.py
@@ -2,13 +2,14 @@
 caching.
 """
 
-from .backend import TrialFunction, backend_DirichletBC, backend_Function
+from .backend import (
+    TrialFunction, backend_DirichletBC, backend_Function, complex_mode)
 from ..interface import (
     is_var, var_caches, var_id, var_is_cached, var_is_replacement,
     var_replacement, var_space, var_state)
 from .backend_code_generator_interface import (
-    assemble, assemble_arguments, assemble_matrix, complex_mode, linear_solver,
-    matrix_copy, parameters_key)
+    assemble, assemble_arguments, assemble_matrix, linear_solver, matrix_copy,
+    parameters_key)
 
 from ..caches import Cache
 

--- a/tlm_adjoint/firedrake/caches.py
+++ b/tlm_adjoint/firedrake/caches.py
@@ -14,7 +14,7 @@ from ..caches import Cache
 
 from .functions import (
     ReplacementFunction, derivative, eliminate_zeros, extract_coefficients,
-    replaced_form)
+    iter_expr, replaced_form)
 
 from collections import defaultdict
 import itertools
@@ -243,19 +243,10 @@ def split_terms(terms, base_integral,
     return cached_terms, dict(mat_terms), non_cached_terms
 
 
-def iter_form(form):
-    if isinstance(form, ufl.classes.FormSum):
-        yield from zip(form.weights(), form.components())
-    elif isinstance(form, (ufl.classes.Form, ufl.classes.Cofunction)):  # noqa: E501
-        yield (1.0, form)
-    else:
-        raise TypeError(f"Unexpected type: {type(form)}")
-
-
 def split_form(form):
     forms = ufl.classes.Form([])
     cofunctions = ufl.classes.ZeroBaseForm(form.arguments())
-    for weight, comp in iter_form(form):
+    for weight, comp in iter_expr(form):
         if isinstance(comp, ufl.classes.Form):
             forms = forms + weight * comp
         elif isinstance(comp, ufl.classes.Cofunction):

--- a/tlm_adjoint/firedrake/caches.py
+++ b/tlm_adjoint/firedrake/caches.py
@@ -13,8 +13,8 @@ from .backend_code_generator_interface import (
 from ..caches import Cache
 
 from .functions import (
-    ReplacementFunction, derivative, eliminate_zeros, extract_coefficients,
-    iter_expr, replaced_form)
+    ReplacementFunction, derivative, eliminate_zeros, expr_zero,
+    extract_coefficients, iter_expr, replaced_form)
 
 from collections import defaultdict
 import itertools
@@ -87,7 +87,7 @@ def form_simplify_conj(form):
                 return expr_simplify_conj(x)
             elif isinstance(expr, ufl.classes.Sum):
                 return sum(map(expr_conj, expr.ufl_operands),
-                           ufl.classes.Zero(shape=expr.ufl_shape))
+                           expr_zero(expr))
             elif isinstance(expr, ufl.classes.Product):
                 x, y = expr.ufl_operands
                 return expr_conj(x) * expr_conj(y)
@@ -100,7 +100,7 @@ def form_simplify_conj(form):
                 return expr_conj(x)
             elif isinstance(expr, ufl.classes.Sum):
                 return sum(map(expr_simplify_conj, expr.ufl_operands),
-                           ufl.classes.Zero(shape=expr.ufl_shape))
+                           expr_zero(expr))
             elif isinstance(expr, ufl.classes.Product):
                 x, y = expr.ufl_operands
                 return expr_simplify_conj(x) * expr_simplify_conj(y)
@@ -282,7 +282,10 @@ def _split_form(form):
 
     def add_integral(integrals, base_integral, terms):
         if len(terms) > 0:
-            integrand = sum(terms, ufl.classes.Zero())
+            assert all(term.ufl_shape == () for term in terms)
+            assert all(term.ufl_free_indices == () for term in terms)
+            assert all(term.ufl_index_dimensions == () for term in terms)
+            integrand = sum(terms, expr_zero(terms[0]))
             integral = base_integral.reconstruct(integrand=integrand)
             integrals.append(integral)
 

--- a/tlm_adjoint/firedrake/caches.py
+++ b/tlm_adjoint/firedrake/caches.py
@@ -41,9 +41,6 @@ def is_cached(expr):
 
 
 def form_simplify_sign(form):
-    if not isinstance(form, ufl.classes.Form):
-        raise TypeError("form must be a Form")
-
     integrals = []
 
     for integral in form.integrals():
@@ -78,9 +75,6 @@ def form_simplify_sign(form):
 
 
 def form_simplify_conj(form):
-    if not isinstance(form, ufl.classes.Form):
-        raise TypeError("form must be a Form")
-
     if complex_mode:
         def expr_conj(expr):
             if isinstance(expr, ufl.classes.Conj):
@@ -270,9 +264,6 @@ def split_form(form):
 
 
 def _split_form(form):
-    if not isinstance(form, ufl.classes.Form):
-        raise TypeError("form must be a Form")
-
     if form.empty():
         return ufl.classes.Form([]), {}, ufl.classes.Form([])
 

--- a/tlm_adjoint/firedrake/caches.py
+++ b/tlm_adjoint/firedrake/caches.py
@@ -254,7 +254,12 @@ def split_form(form):
         else:
             raise TypeError(f"Unexpected type: {type(comp)}")
 
-    return tuple(_split_form(forms)) + (cofunctions,)
+    cached_form, mat_forms, non_cached_form = _split_form(forms)
+    if non_cached_form.empty():
+        non_cached_form = cofunctions
+    else:
+        non_cached_form = non_cached_form + cofunctions
+    return cached_form, mat_forms, non_cached_form
 
 
 def _split_form(form):
@@ -288,9 +293,9 @@ def _split_form(form):
     mat_forms = {}
     for dep_id in mat_integrals:
         mat_forms[dep_id] = ufl.classes.Form(mat_integrals[dep_id])
-    non_cached_forms = ufl.classes.Form(non_cached_integrals)
+    non_cached_form = ufl.classes.Form(non_cached_integrals)
 
-    return cached_form, mat_forms, non_cached_forms
+    return cached_form, mat_forms, non_cached_form
 
 
 def form_key(*forms):

--- a/tlm_adjoint/firedrake/equations.py
+++ b/tlm_adjoint/firedrake/equations.py
@@ -14,8 +14,7 @@ from .backend_code_generator_interface import (
     assemble, assemble_linear_solver, copy_parameters_dict,
     form_compiler_quadrature_parameters, homogenize, interpolate_expression,
     matrix_multiply, process_adjoint_solver_parameters,
-    process_solver_parameters, rhs_addto, rhs_copy, solve,
-    update_parameters_dict, verify_assembly)
+    process_solver_parameters, solve, update_parameters_dict, verify_assembly)
 
 from ..caches import CacheRef
 from ..equation import Equation, ZeroAssignment
@@ -77,7 +76,7 @@ def apply_rhs_bcs(b, hbcs, *, b_bc=None):
     for bc in hbcs:
         bc.apply(b)
     if b_bc is not None:
-        rhs_addto(b, b_bc)
+        var_axpy(b, 1.0, b_bc)
 
 
 class ExprEquation(Equation):
@@ -544,9 +543,9 @@ class EquationSolver(ExprEquation):
                     form_compiler_parameters=self._form_compiler_parameters,
                     replace_map=self._replace_map(deps))
             if b is None:
-                b = rhs_copy(cached_b)
+                b = cached_b.copy(deepcopy=True)
             else:
-                rhs_addto(b, cached_b)
+                var_axpy(b, 1.0, cached_b)
 
         if non_cached_expr is not None:
             if b is None:

--- a/tlm_adjoint/firedrake/equations.py
+++ b/tlm_adjoint/firedrake/equations.py
@@ -48,8 +48,7 @@ def extract_derivative_coefficients(expr, dep):
     return extract_coefficients(dexpr)
 
 
-def extract_dependencies(expr, *,
-                         space_type="primal"):
+def extract_dependencies(expr, *, space_type=None):
     deps = {}
     nl_deps = {}
     for dep in extract_coefficients(expr):
@@ -66,8 +65,9 @@ def extract_dependencies(expr, *,
                for nl_dep_id in sorted(nl_deps.keys())}
 
     assert len(set(nl_deps.keys()).difference(set(deps.keys()))) == 0
-    for dep in deps.values():
-        check_space_type(dep, space_type)
+    if space_type is not None:
+        for dep in deps.values():
+            check_space_type(dep, space_type)
 
     return deps, nl_deps
 
@@ -883,7 +883,7 @@ class ExprInterpolation(ExprEquation):
     """
 
     def __init__(self, x, rhs):
-        deps, nl_deps = extract_dependencies(rhs)
+        deps, nl_deps = extract_dependencies(rhs, space_type="primal")
         if var_id(x) in deps:
             raise ValueError("Invalid dependency")
         deps, nl_deps = list(deps.values()), tuple(nl_deps.values())

--- a/tlm_adjoint/firedrake/equations.py
+++ b/tlm_adjoint/firedrake/equations.py
@@ -333,7 +333,7 @@ class EquationSolver(ExprEquation):
 
         lhs, rhs = eq.lhs, eq.rhs
         del eq
-        linear = isinstance(rhs, ufl.classes.Form)
+        linear = isinstance(rhs, ufl.classes.BaseForm)
 
         if linear:
             if len(lhs.arguments()) != 2:
@@ -450,7 +450,7 @@ class EquationSolver(ExprEquation):
 
         self._F = ufl.replace(self._F, replace_map)
         self._lhs = ufl.replace(self._lhs, replace_map)
-        if isinstance(self._rhs, ufl.classes.Form):
+        if isinstance(self._rhs, ufl.classes.BaseForm):
             self._rhs = ufl.replace(self._rhs, replace_map)
         self._J = ufl.replace(self._J, replace_map)
         if self._nl_solve_J is not None:
@@ -801,7 +801,7 @@ class Projection(EquationSolver):
     def __init__(self, x, rhs, *args, **kwargs):
         space = var_space(x)
         test, trial = TestFunction(space), TrialFunction(space)
-        if not isinstance(rhs, ufl.classes.Form):
+        if not isinstance(rhs, ufl.classes.BaseForm):
             rhs = ufl.inner(rhs, test) * ufl.dx
         super().__init__(ufl.inner(trial, test) * ufl.dx == rhs, x,
                          *args, **kwargs)

--- a/tlm_adjoint/firedrake/equations.py
+++ b/tlm_adjoint/firedrake/equations.py
@@ -23,7 +23,7 @@ from ..equations import Assignment
 from .caches import assembly_cache, is_cached, linear_solver_cache, split_form
 from .functions import (
     ReplacementConstant, bcs_is_cached, bcs_is_homogeneous, bcs_is_static,
-    derivative, eliminate_zeros, extract_coefficients, iter_expr)
+    derivative, eliminate_zeros, expr_zero, extract_coefficients, iter_expr)
 
 import itertools
 import numbers
@@ -956,7 +956,7 @@ class ExprInterpolation(ExprEquation):
     def tangent_linear(self, M, dM, tlm_map):
         x = self.x()
 
-        tlm_rhs = ufl.classes.Zero(shape=x.ufl_shape)
+        tlm_rhs = expr_zero(x)
         for dep in self.dependencies():
             if dep != x:
                 tau_dep = tlm_map[dep]

--- a/tlm_adjoint/firedrake/equations.py
+++ b/tlm_adjoint/firedrake/equations.py
@@ -135,8 +135,6 @@ class Assembly(ExprEquation):
         if match_quadrature is None:
             match_quadrature = parameters["tlm_adjoint"]["Assembly"]["match_quadrature"]  # noqa: E501
 
-        rhs = ufl.classes.Form(rhs.integrals())
-
         arity = len(rhs.arguments())
         if arity == 0:
             check_space_type(x, "primal")
@@ -335,12 +333,7 @@ class EquationSolver(ExprEquation):
 
         lhs, rhs = eq.lhs, eq.rhs
         del eq
-        lhs = ufl.classes.Form(lhs.integrals())
         linear = isinstance(rhs, ufl.classes.Form)
-        if linear:
-            rhs = ufl.classes.Form(rhs.integrals())
-        if J is not None:
-            J = ufl.classes.Form(J.integrals())
 
         if linear:
             if len(lhs.arguments()) != 2:

--- a/tlm_adjoint/firedrake/equations.py
+++ b/tlm_adjoint/firedrake/equations.py
@@ -206,7 +206,7 @@ class Assembly(ExprEquation):
         dF = derivative(self._rhs, dep)
         dF = ufl.algorithms.expand_derivatives(dF)
         dF = eliminate_zeros(dF)
-        if dF.empty():
+        if isinstance(dF, ufl.classes.ZeroBaseForm):
             return None
 
         dF = self._nonlinear_replace(dF, nl_deps)
@@ -485,7 +485,7 @@ class EquationSolver(ExprEquation):
         eq_deps = self.dependencies()
 
         if self._forward_b_pa is None:
-            rhs = eliminate_zeros(self._rhs, force_non_empty_form=True)
+            rhs = eliminate_zeros(self._rhs)
             cached_form, mat_forms_, non_cached_form = split_form(rhs)
 
             dep_indices = {var_id(dep): dep_index
@@ -642,7 +642,7 @@ class EquationSolver(ExprEquation):
                             dF_term = derivative(comp, dep)
                             dF_term = ufl.algorithms.expand_derivatives(dF_term)  # noqa: E501
                             dF_term = eliminate_zeros(dF_term)
-                            if not dF_term.empty():
+                            if not isinstance(dF_term, ufl.classes.ZeroBaseForm):  # noqa: E501
                                 dF_forms = dF_forms + weight * adjoint(dF_term)
                     elif isinstance(comp, ufl.classes.Cofunction):
                         # Note: Ignores weight dependencies

--- a/tlm_adjoint/firedrake/equations.py
+++ b/tlm_adjoint/firedrake/equations.py
@@ -4,7 +4,7 @@ variational problems.
 """
 
 from .backend import (
-    Coargument, TestFunction, TrialFunction, adjoint, backend_Constant,
+    TestFunction, TrialFunction, adjoint, backend_Constant,
     backend_DirichletBC, backend_Function, parameters)
 from ..interface import (
     check_space_type, is_var, var_assign, var_axpy, var_id,
@@ -146,7 +146,7 @@ class Assembly(ExprEquation):
         else:
             raise ValueError("Must be an arity 0 or arity 1 form")
 
-        deps, nl_deps = extract_dependencies(rhs)
+        deps, nl_deps = extract_dependencies(rhs, space_type="primal")
         if var_id(x) in deps:
             raise ValueError("Invalid dependency")
         deps, nl_deps = list(deps.values()), tuple(nl_deps.values())
@@ -635,7 +635,7 @@ class EquationSolver(ExprEquation):
             if dep_index not in self._adjoint_dF_cache:
                 dep = self.dependencies()[dep_index]
                 dF_forms = ufl.classes.Form([])
-                dF_cofunctions = ufl.classes.ZeroBaseForm((Coargument(var_space(self.x()).dual(), number=0),))  # noqa: E501
+                dF_cofunctions = ufl.classes.ZeroBaseForm((TestFunction(var_space(self.x()).dual()),))  # noqa: E501
                 for weight, comp in iter_expr(self._F):
                     if isinstance(comp, ufl.classes.Form):
                         if dep in extract_coefficients(comp):
@@ -816,7 +816,7 @@ class Projection(EquationSolver):
     :arg x: A :class:`firedrake.function.Function` defining the forward
         solution.
     :arg rhs: A :class:`ufl.core.expr.Expr` defining the expression to project
-        onto the space for `x`, or a :class:`ufl.Form` defining the
+        onto the space for `x`, or a :class:`ufl.form.BaseForm` defining the
         right-hand-side of the finite element variational problem. Should not
         depend on `x`.
 

--- a/tlm_adjoint/firedrake/equations.py
+++ b/tlm_adjoint/firedrake/equations.py
@@ -363,7 +363,7 @@ class EquationSolver(ExprEquation):
                     and len(tuple(c for c in extract_coefficients(weight)
                                   if is_var(c))) > 0:
                 # See Firedrake issue #3292
-                raise NotImplementedError("FormSum weights cannot depend on"
+                raise NotImplementedError("FormSum weights cannot depend on "
                                           "variables")
 
         deps, nl_deps = extract_dependencies(F)

--- a/tlm_adjoint/firedrake/firedrake_equations.py
+++ b/tlm_adjoint/firedrake/firedrake_equations.py
@@ -146,7 +146,7 @@ class LocalProjection(EquationSolver):
         space = x.function_space()
         test, trial = TestFunction(space), TrialFunction(space)
         lhs = ufl.inner(trial, test) * ufl.dx
-        if not isinstance(rhs, ufl.classes.Form):
+        if not isinstance(rhs, ufl.classes.BaseForm):
             rhs = ufl.inner(rhs, test) * ufl.dx
 
         super().__init__(
@@ -216,7 +216,7 @@ class LocalProjection(EquationSolver):
             if dep != x:
                 tau_dep = tlm_map[dep]
                 if tau_dep is not None:
-                    tlm_rhs += derivative(self._rhs, dep, argument=tau_dep)
+                    tlm_rhs = tlm_rhs + derivative(self._rhs, dep, argument=tau_dep)  # noqa: E501
 
         tlm_rhs = ufl.algorithms.expand_derivatives(tlm_rhs)
         if tlm_rhs.empty():

--- a/tlm_adjoint/firedrake/firedrake_equations.py
+++ b/tlm_adjoint/firedrake/firedrake_equations.py
@@ -219,7 +219,7 @@ class LocalProjection(EquationSolver):
                     for weight, comp in iter_expr(self._rhs):
                         # Note: Ignores weight dependencies
                         tlm_rhs = (tlm_rhs
-                                   + weight * derivative(comp, dep, argument=tau_dep))  # noqa: E501 # noqa: E501
+                                   + weight * derivative(comp, dep, argument=tau_dep))  # noqa: E501
 
         tlm_rhs = ufl.algorithms.expand_derivatives(tlm_rhs)
         if isinstance(tlm_rhs, ufl.classes.ZeroBaseForm):

--- a/tlm_adjoint/firedrake/firedrake_equations.py
+++ b/tlm_adjoint/firedrake/firedrake_equations.py
@@ -43,9 +43,6 @@ def LocalSolver(form, *,
     if form_compiler_parameters is None:
         form_compiler_parameters = {}
 
-    # Perform zero elimination here, rather than in overridden assemble, as
-    # Tensor(form).inv is not a Form
-    form = eliminate_zeros(form, force_non_empty_form=True)
     local_solver = backend_assemble(
         Tensor(form).inv,
         form_compiler_parameters=form_compiler_parameters)
@@ -82,7 +79,7 @@ class LocalSolverCache(Cache):
         if form_compiler_parameters is None:
             form_compiler_parameters = {}
 
-        form = eliminate_zeros(form, force_non_empty_form=True)
+        form = eliminate_zeros(form)
         if replace_map is None:
             assemble_form = form
         else:

--- a/tlm_adjoint/firedrake/firedrake_equations.py
+++ b/tlm_adjoint/firedrake/firedrake_equations.py
@@ -19,7 +19,8 @@ from ..equation import Equation, ZeroAssignment
 from .caches import form_dependencies, form_key, parameters_key
 from .equations import (
     EquationSolver, ExprEquation, derivative, extract_dependencies)
-from .functions import ReplacementConstant, eliminate_zeros, iter_expr
+from .functions import (
+    ReplacementConstant, eliminate_zeros, expr_zero, iter_expr)
 
 import itertools
 import numpy as np
@@ -482,7 +483,7 @@ class ExprAssignment(ExprEquation):
     def tangent_linear(self, M, dM, tlm_map):
         x = self.x()
 
-        tlm_rhs = ufl.classes.Zero(shape=x.ufl_shape)
+        tlm_rhs = expr_zero(x)
         for dep in self.dependencies():
             if dep != x:
                 tau_dep = tlm_map[dep]

--- a/tlm_adjoint/firedrake/firedrake_equations.py
+++ b/tlm_adjoint/firedrake/firedrake_equations.py
@@ -44,6 +44,9 @@ def LocalSolver(form, *,
     if form_compiler_parameters is None:
         form_compiler_parameters = {}
 
+    form = eliminate_zeros(form)
+    if isinstance(form, ufl.classes.ZeroBaseForm):
+        raise ValueError("Form cannot be a ZeroBaseForm")
     local_solver = backend_assemble(
         Tensor(form).inv,
         form_compiler_parameters=form_compiler_parameters)
@@ -81,6 +84,8 @@ class LocalSolverCache(Cache):
             form_compiler_parameters = {}
 
         form = eliminate_zeros(form)
+        if isinstance(form, ufl.classes.ZeroBaseForm):
+            raise ValueError("Form cannot be a ZeroBaseForm")
         if replace_map is None:
             assemble_form = form
         else:
@@ -127,7 +132,7 @@ class LocalProjection(EquationSolver):
     :arg x: A :class:`firedrake.function.Function` defining the forward
         solution.
     :arg rhs: A :class:`ufl.core.expr.Expr` defining the expression to project
-        onto the space for `x`, or a :class:`ufl.Form` defining the
+        onto the space for `x`, or a :class:`ufl.form.BaseForm` defining the
         right-hand-side of the finite element variational problem. Should not
         depend on `x`.
 

--- a/tlm_adjoint/firedrake/functions.py
+++ b/tlm_adjoint/firedrake/functions.py
@@ -370,7 +370,7 @@ def iter_expr(expr, *, evaluate_weights=False):
             yield (weight, comp)
     elif isinstance(expr, (ufl.classes.Form, ufl.classes.Cofunction,
                            ufl.classes.Expr)):
-        yield (1.0, expr)
+        yield (1, expr)
     else:
         raise TypeError(f"Unexpected type: {type(expr)}")
 

--- a/tlm_adjoint/firedrake/functions.py
+++ b/tlm_adjoint/firedrake/functions.py
@@ -32,6 +32,8 @@ __all__ = \
         "Replacement",
         "ReplacementConstant",
         "ReplacementFunction",
+        "ReplacementZeroConstant",
+        "ReplacementZeroFunction",
 
         "DirichletBC",
         "HomogeneousDirichletBC"
@@ -595,12 +597,6 @@ class ReplacementConstant(Replacement, ufl.classes.ConstantValue,
         return self._tlm_adjoint__ufl_shape
 
 
-class ReplacementZeroConstant(ReplacementConstant, Zero):
-    def __init__(self, *args, **kwargs):
-        ReplacementConstant.__init__(self, *args, **kwargs)
-        Zero.__init__(self)
-
-
 class ReplacementFunction(Replacement, ufl.classes.Coefficient):
     """Represents a symbolic :class:`firedrake.function.Function`, but has no
     value.
@@ -616,7 +612,21 @@ class ReplacementFunction(Replacement, ufl.classes.Coefficient):
                                                *args, **kwargs)
 
 
+class ReplacementZeroConstant(ReplacementConstant, Zero):
+    """Represents a symbolic :class:`firedrake.constant.Constant` which is
+    zero, but has no value.
+    """
+
+    def __init__(self, *args, **kwargs):
+        ReplacementConstant.__init__(self, *args, **kwargs)
+        Zero.__init__(self)
+
+
 class ReplacementZeroFunction(ReplacementFunction, Zero):
+    """Represents a symbolic :class:`firedrake.function.Function` which is
+    zero, but has no value.
+    """
+
     def __init__(self, *args, **kwargs):
         ReplacementFunction.__init__(self, *args, **kwargs)
         Zero.__init__(self)

--- a/tlm_adjoint/firedrake/functions.py
+++ b/tlm_adjoint/firedrake/functions.py
@@ -412,6 +412,7 @@ def derivative(expr, x, argument=None, *,
     if argument is not None:
         argument = ufl.replace(argument, replace_map)
     dexpr = ufl.derivative(expr, replace_map.get(x, x), argument=argument)
+    dexpr = ufl.algorithms.expand_derivatives(dexpr)
     return ufl.replace(dexpr, replace_map_inverse)
 
 

--- a/tlm_adjoint/firedrake/functions.py
+++ b/tlm_adjoint/firedrake/functions.py
@@ -23,7 +23,6 @@ import weakref
 __all__ = \
     [
         "Constant",
-        "extract_coefficients",
 
         "Zero",
         "ZeroConstant",
@@ -362,11 +361,6 @@ def constant_space(shape, *, domain=None):
 
 
 def extract_coefficients(expr):
-    """
-    :returns: Coefficients on which the supplied :class:`ufl.core.expr.Expr` or
-        :class:`ufl.Form` depends.
-    """
-
     if isinstance(expr, ufl.classes.Form) \
             and "_tlm_adjoint__form_coefficients" in expr._cache:
         return expr._cache["_tlm_adjoint__form_coefficients"]

--- a/tlm_adjoint/firedrake/functions.py
+++ b/tlm_adjoint/firedrake/functions.py
@@ -363,7 +363,7 @@ def constant_space(shape, *, domain=None):
 
 def extract_coefficients(expr):
     """
-    :returns: Variables on which the supplied :class:`ufl.core.expr.Expr` or
+    :returns: Coefficients on which the supplied :class:`ufl.core.expr.Expr` or
         :class:`ufl.Form` depends.
     """
 
@@ -372,7 +372,7 @@ def extract_coefficients(expr):
         return expr._cache["_tlm_adjoint__form_coefficients"]
 
     deps = []
-    for c in (ufl.classes.Coefficient, backend_Constant):
+    for c in (ufl.coefficient.BaseCoefficient, backend_Constant):
         deps.extend(sorted(ufl.algorithms.extract_type(expr, c),
                            key=lambda dep: dep.count()))
 

--- a/tlm_adjoint/firedrake/functions.py
+++ b/tlm_adjoint/firedrake/functions.py
@@ -193,8 +193,12 @@ class ConstantInterface(VariableInterface):
     def _replacement(self):
         if "replacement" not in self._tlm_adjoint__var_interface_attrs:
             count = self._tlm_adjoint__var_interface_attrs["replacement_count"]
-            self._tlm_adjoint__var_interface_attrs["replacement"] = \
-                ReplacementConstant(self, count=count)
+            if isinstance(self, Zero):
+                self._tlm_adjoint__var_interface_attrs["replacement"] = \
+                    ReplacementZeroConstant(self, count=count)
+            else:
+                self._tlm_adjoint__var_interface_attrs["replacement"] = \
+                    ReplacementConstant(self, count=count)
         return self._tlm_adjoint__var_interface_attrs["replacement"]
 
     def _is_replacement(self):
@@ -591,6 +595,12 @@ class ReplacementConstant(Replacement, ufl.classes.ConstantValue,
         return self._tlm_adjoint__ufl_shape
 
 
+class ReplacementZeroConstant(ReplacementConstant, Zero):
+    def __init__(self, *args, **kwargs):
+        ReplacementConstant.__init__(self, *args, **kwargs)
+        Zero.__init__(self)
+
+
 class ReplacementFunction(Replacement, ufl.classes.Coefficient):
     """Represents a symbolic :class:`firedrake.function.Function`, but has no
     value.
@@ -604,6 +614,12 @@ class ReplacementFunction(Replacement, ufl.classes.Coefficient):
     def __new__(cls, x, *args, **kwargs):
         return ufl.classes.Coefficient.__new__(cls, var_space(x),
                                                *args, **kwargs)
+
+
+class ReplacementZeroFunction(ReplacementFunction, Zero):
+    def __init__(self, *args, **kwargs):
+        ReplacementFunction.__init__(self, *args, **kwargs)
+        Zero.__init__(self)
 
 
 def replaced_form(form):

--- a/tlm_adjoint/firedrake/functions.py
+++ b/tlm_adjoint/firedrake/functions.py
@@ -399,7 +399,7 @@ def derivative(expr, x, argument=None, *,
             raise ValueError("Unexpected argument")
     if argument is not None:
         for expr_argument in ufl.algorithms.extract_arguments(argument):
-            if expr_argument.number() < arity:
+            if expr_argument.number() < arity - int(isinstance(x, ufl.classes.Cofunction)):  # noqa: E501
                 raise ValueError("Invalid argument")
 
     expr, replace_map, replace_map_inverse = with_coefficient(expr, x)

--- a/tlm_adjoint/firedrake/functions.py
+++ b/tlm_adjoint/firedrake/functions.py
@@ -442,6 +442,12 @@ def derivative(expr, x, argument=None, *,
     return ufl.replace(dexpr, replace_map_inverse)
 
 
+def expr_zero(expr):
+    return ufl.classes.Zero(shape=expr.ufl_shape,
+                            free_indices=expr.ufl_free_indices,
+                            index_dimensions=expr.ufl_index_dimensions)
+
+
 @form_cached("_tlm_adjoint__simplified_form")
 def eliminate_zeros(expr):
     """Apply zero elimination for :class:`.Zero` objects in the supplied
@@ -452,7 +458,7 @@ def eliminate_zeros(expr):
         zero elimination applied. May return `expr`.
     """
 
-    replace_map = {c: ufl.classes.Zero(shape=c.ufl_shape)
+    replace_map = {c: expr_zero(c)
                    for c in extract_coefficients(expr)
                    if isinstance(c, Zero)}
     if len(replace_map) == 0:

--- a/tlm_adjoint/firedrake/functions.py
+++ b/tlm_adjoint/firedrake/functions.py
@@ -15,6 +15,7 @@ from ..interface import (
 from ..caches import Caches
 from ..manager import paused_manager
 
+import functools
 import numbers
 import numpy as np
 import ufl
@@ -375,11 +376,24 @@ def iter_expr(expr, *, evaluate_weights=False):
         raise TypeError(f"Unexpected type: {type(expr)}")
 
 
-def extract_coefficients(expr):
-    if isinstance(expr, ufl.classes.Form) \
-            and "_tlm_adjoint__form_coefficients" in expr._cache:
-        return expr._cache["_tlm_adjoint__form_coefficients"]
+def form_cached(key):
+    def wrapper(fn):
+        @functools.wraps(fn)
+        def wrapped(expr, *args, **kwargs):
+            if isinstance(expr, ufl.classes.Form) and key in expr._cache:
+                value = expr._cache[key]
+            else:
+                value = fn(expr, *args, **kwargs)
+                if isinstance(expr, ufl.classes.Form):
+                    assert key not in expr._cache
+                    expr._cache[key] = value
+            return value
+        return wrapped
+    return wrapper
 
+
+@form_cached("_tlm_adjoint__form_coefficients")
+def extract_coefficients(expr):
     deps = []
     for c in (ufl.coefficient.BaseCoefficient, backend_Constant):
         deps.extend(sorted(ufl.algorithms.extract_type(expr, c),
@@ -387,8 +401,6 @@ def extract_coefficients(expr):
 
     # Note: Misses FormSum weight dependencies -- see Firedrake issue #3292
 
-    if isinstance(expr, ufl.classes.Form):
-        expr._cache["_tlm_adjoint__form_coefficients"] = deps
     return deps
 
 
@@ -439,47 +451,36 @@ def eliminate_zeros(expr, *, force_non_empty_form=False):
         elimination applied. May return `expr`.
     """
 
-    if isinstance(expr, ufl.classes.Form) \
-            and "_tlm_adjoint__simplified_form" in expr._cache:
-        simplified_expr = expr._cache["_tlm_adjoint__simplified_form"]
-    else:
-        replace_map = {}
-        for c in extract_coefficients(expr):
-            if isinstance(c, Zero):
-                replace_map[c] = ufl.classes.Zero(shape=c.ufl_shape)
-
+    @form_cached("_tlm_adjoint__simplified_form")
+    def simplified(expr):
+        replace_map = {c: ufl.classes.Zero(shape=c.ufl_shape)
+                       for c in extract_coefficients(expr)
+                       if isinstance(c, Zero)}
         if len(replace_map) == 0:
-            simplified_expr = expr
+            return expr
         else:
-            simplified_expr = ufl.replace(expr, replace_map)
+            return ufl.replace(expr, replace_map)
 
-        if isinstance(expr, ufl.classes.Form):
-            expr._cache["_tlm_adjoint__simplified_form"] = simplified_expr
-
-    if force_non_empty_form \
-            and isinstance(simplified_expr, ufl.classes.Form) \
-            and simplified_expr.empty():
-        if "_tlm_adjoint__simplified_form_non_empty" in expr._cache:
-            simplified_expr = expr._cache["_tlm_adjoint__simplified_form_non_empty"]  # noqa: E501
+    @form_cached("_tlm_adjoint__simplified_form_non_empty")
+    def simplified_non_empty(base_expr, expr):
+        if not isinstance(expr, ufl.classes.Form) or not expr.empty():
+            return expr
+        arguments = base_expr.arguments()
+        zero = ZeroConstant()
+        if len(arguments) == 0:
+            domain, = base_expr.ufl_domains()
+            return zero * ufl.ds(domain)
+        elif len(arguments) == 1:
+            test, = arguments
+            return ufl.inner(zero, test[tuple(0 for _ in test.ufl_shape)]) * ufl.ds  # noqa: E501
         else:
-            # Inefficient, but it is very difficult to generate a non-empty but
-            # zero valued form
-            arguments = expr.arguments()
-            zero = ZeroConstant()
-            if len(arguments) == 0:
-                domain, = expr.ufl_domains()
-                simplified_expr = zero * ufl.ds(domain)
-            elif len(arguments) == 1:
-                test, = arguments
-                simplified_expr = ufl.inner(zero, test[tuple(0 for _ in test.ufl_shape)]) * ufl.ds  # noqa: E501
-            else:
-                test, trial = arguments
-                simplified_expr = zero * ufl.inner(trial[tuple(0 for _ in trial.ufl_shape)],  # noqa: E501
-                                                   test[tuple(0 for _ in test.ufl_shape)]) * ufl.ds  # noqa: E501
+            test, trial = arguments
+            return zero * ufl.inner(trial[tuple(0 for _ in trial.ufl_shape)],
+                                    test[tuple(0 for _ in test.ufl_shape)]) * ufl.ds  # noqa: E501
 
-            if isinstance(expr, ufl.classes.Form):
-                expr._cache["_tlm_adjoint__simplified_form_non_empty"] = simplified_expr  # noqa: E501
-
+    simplified_expr = simplified(expr)
+    if force_non_empty_form:
+        simplified_expr = simplified_non_empty(expr, simplified_expr)
     return simplified_expr
 
 


### PR DESCRIPTION
Handles some `FormSum` cases in `EquationSolver`.

There are a number of places where `FormSum` weight dependencies are discarded. The `EquationSolver` constructor currently checks that the weights have no variables as dependencies.

Some possible future steps:

- Handle weight dependencies. This is currently difficult as `ufl.replace` does not update `Constant`s in the weights.
- Check for `FormSum` compatibility elsewhere in the code -- at least checking for use of `Form`s where needed.
- Refactor the `EquationSolver` class. This PR further adds to its complexity.

Closes #445