### PR TITLE
Fix dtype and communicator in `to_float`

### DIFF
--- a/tests/fenics/test_equations.py
+++ b/tests/fenics/test_equations.py
@@ -663,7 +663,7 @@ def test_Assembly_arity_1(setup_test, test_leaks):
 @seed_test
 def test_Storage(setup_test, test_leaks,
                  tmp_path):
-    comm = manager().comm()
+    comm = comm_dup_cached(manager().comm(), key="test_Storage")
 
     mesh = UnitSquareMesh(20, 20)
     X = SpatialCoordinate(mesh)

--- a/tests/firedrake/test_equations.py
+++ b/tests/firedrake/test_equations.py
@@ -856,7 +856,7 @@ def test_Assembly_arity_1(setup_test, test_leaks):
 @seed_test
 def test_Storage(setup_test, test_leaks,
                  tmp_path):
-    comm = manager().comm()
+    comm = comm_dup_cached(manager().comm(), key="test_Storage")
 
     mesh = UnitSquareMesh(20, 20)
     X = SpatialCoordinate(mesh)

--- a/tests/firedrake/test_overrides.py
+++ b/tests/firedrake/test_overrides.py
@@ -382,8 +382,8 @@ def test_Nullspace(setup_test, test_leaks):
         solve(inner(grad(trial), grad(test)) * dx
               == -inner(F * F, test) * dx, psi,
               solver_parameters=ls_parameters_cg,
-              nullspace=VectorSpaceBasis(constant=True, comm=var_comm(psi)),
-              transpose_nullspace=VectorSpaceBasis(constant=True, comm=var_comm(psi)))  # noqa: E501
+              nullspace=VectorSpaceBasis(constant=True, comm=psi.comm),
+              transpose_nullspace=VectorSpaceBasis(constant=True, comm=psi.comm))  # noqa: E501
 
         J = Functional(name="J")
         J.assign((dot(psi, psi) ** 2) * dx

--- a/tlm_adjoint/checkpointing.py
+++ b/tlm_adjoint/checkpointing.py
@@ -701,8 +701,8 @@ class PickleCheckpoints(Checkpoints):
     def __init__(self, prefix, *, comm=None):
         if comm is None:
             comm = DEFAULT_COMM
-
         comm = comm_dup_cached(comm)
+
         cp_filenames = {}
 
         def finalize_callback(cp_filenames):
@@ -807,8 +807,8 @@ class HDF5Checkpoints(Checkpoints):
     def __init__(self, prefix, *, comm=None):
         if comm is None:
             comm = DEFAULT_COMM
-
         comm = comm_dup_cached(comm, key="HDF5Checkpoints")
+
         cp_filenames = {}
 
         def finalize_callback(comm, rank, cp_filenames):

--- a/tlm_adjoint/fenics/backend_interface.py
+++ b/tlm_adjoint/fenics/backend_interface.py
@@ -3,10 +3,11 @@ from .backend import (
     backend_ScalarType, backend_Vector, cpp_PETScVector)
 from ..interface import (
     DEFAULT_COMM, SpaceInterface, VariableInterface, add_interface,
-    check_space_types, comm_dup_cached, is_var, new_space_id, new_var_id,
-    register_functional_term_eq, register_subtract_adjoint_derivative_action,
-    space_id, subtract_adjoint_derivative_action_base, var_axpy, var_copy,
-    var_linf_norm, var_lock_state, var_new, var_space, var_space_type)
+    check_space_types, comm_dup_cached, comm_parent, is_var, new_space_id,
+    new_var_id, register_functional_term_eq,
+    register_subtract_adjoint_derivative_action, space_id,
+    subtract_adjoint_derivative_action_base, var_axpy, var_copy, var_linf_norm,
+    var_lock_state, var_new, var_space, var_space_type)
 
 from ..equations import Conversion
 from ..override import override_method
@@ -44,6 +45,7 @@ def Constant__init__(self, orig, orig_args, *args, domain=None, space=None,
             comm = DEFAULT_COMM
         else:
             comm = domain.ufl_cargo().mpi_comm()
+    comm = comm_parent(comm)
 
     orig(self, *args, **kwargs)
 

--- a/tlm_adjoint/fenics/functions.py
+++ b/tlm_adjoint/fenics/functions.py
@@ -8,10 +8,10 @@ from .backend import (
     backend_Function, backend_ScalarType, cpp_Constant)
 from ..interface import (
     SpaceInterface, VariableInterface, VariableStateChangeError,
-    add_replacement_interface, comm_parent, is_var, manager_disabled,
-    space_comm, var_comm, var_dtype, var_increment_state_lock, var_is_cached,
-    var_is_replacement, var_is_static, var_linf_norm, var_lock_state,
-    var_replacement, var_scalar_value, var_space, var_space_type)
+    add_replacement_interface, is_var, manager_disabled, space_comm, var_comm,
+    var_dtype, var_increment_state_lock, var_is_cached, var_is_replacement,
+    var_is_static, var_linf_norm, var_lock_state, var_replacement,
+    var_scalar_value, var_space, var_space_type)
 
 from ..caches import Caches
 from ..manager import paused_manager
@@ -288,7 +288,7 @@ class Constant(backend_Constant):
 
         # Default comm
         if comm is None and space is not None:
-            comm = comm_parent(space_comm(space))
+            comm = space_comm(space)
 
         if cache is None:
             cache = static

--- a/tlm_adjoint/firedrake/backend_interface.py
+++ b/tlm_adjoint/firedrake/backend_interface.py
@@ -4,11 +4,11 @@ from .backend import (
     backend_ScalarType)
 from ..interface import (
     DEFAULT_COMM, SpaceInterface, VariableInterface, add_interface,
-    add_replacement_interface, check_space_type, comm_dup_cached, new_space_id,
-    new_var_id, register_garbage_cleanup, register_functional_term_eq,
-    register_subtract_adjoint_derivative_action, relative_space_type, space_id,
-    subtract_adjoint_derivative_action_base, var_is_alias, var_linf_norm,
-    var_lock_state, var_space, var_space_type)
+    add_replacement_interface, check_space_type, comm_dup_cached, comm_parent,
+    new_space_id, new_var_id, register_functional_term_eq,
+    register_garbage_cleanup, register_subtract_adjoint_derivative_action,
+    relative_space_type, space_id, subtract_adjoint_derivative_action_base,
+    var_is_alias, var_linf_norm, var_lock_state, var_space, var_space_type)
 
 from ..equations import Conversion
 from ..override import override_method, override_property
@@ -56,6 +56,7 @@ def Constant__init__(self, orig, orig_args, value, domain=None, *,
             comm = DEFAULT_COMM
         else:
             comm = domain.comm
+    comm = comm_parent(comm)
 
     if space is None:
         space = constant_space(self.ufl_shape, domain=domain)

--- a/tlm_adjoint/firedrake/functions.py
+++ b/tlm_adjoint/firedrake/functions.py
@@ -7,10 +7,10 @@ from .backend import (
     backend_Constant, backend_DirichletBC, backend_ScalarType)
 from ..interface import (
     SpaceInterface, VariableInterface, VariableStateChangeError,
-    add_replacement_interface, comm_parent, is_var, space_comm, var_comm,
-    var_dtype, var_increment_state_lock, var_is_cached, var_is_replacement,
-    var_is_static, var_linf_norm, var_lock_state, var_replacement,
-    var_scalar_value, var_space, var_space_type)
+    add_replacement_interface, is_var, space_comm, var_comm, var_dtype,
+    var_increment_state_lock, var_is_cached, var_is_replacement, var_is_static,
+    var_linf_norm, var_lock_state, var_replacement, var_scalar_value,
+    var_space, var_space_type)
 
 from ..caches import Caches
 from ..manager import paused_manager
@@ -285,7 +285,7 @@ class Constant(backend_Constant):
 
         # Default comm
         if comm is None and space is not None:
-            comm = comm_parent(space_comm(space))
+            comm = space_comm(space)
 
         if cache is None:
             cache = static

--- a/tlm_adjoint/instructions.py
+++ b/tlm_adjoint/instructions.py
@@ -34,9 +34,10 @@ class GarbageCollection(Instruction):
     def __init__(self, comm=None, *, generation=2, garbage_cleanup=True):
         if comm is None:
             comm = DEFAULT_COMM
+        comm = comm_dup_cached(comm)
 
         super().__init__()
-        self._comm = comm_dup_cached(comm)
+        self._comm = comm
         self._generation = generation
         self._garbage_cleanup = garbage_cleanup
 

--- a/tlm_adjoint/jax.py
+++ b/tlm_adjoint/jax.py
@@ -97,6 +97,7 @@ class VectorSpace:
             dtype = _default_dtype
         if comm is None:
             comm = DEFAULT_COMM
+        comm = comm_dup_cached(comm)
 
         dtype = np.dtype(dtype).type
         if not issubclass(dtype, (np.floating, np.complexfloating)):
@@ -104,7 +105,7 @@ class VectorSpace:
 
         self._n = n
         self._dtype = dtype
-        self._comm = comm_dup_cached(comm)
+        self._comm = comm
 
         N = self._n
         if MPI is not None:

--- a/tlm_adjoint/optimization.py
+++ b/tlm_adjoint/optimization.py
@@ -794,6 +794,7 @@ def l_bfgs(F, Fp, X0, *,
 
     if comm is None:
         comm = var_comm(X0[0])
+    comm = comm_dup_cached(comm)
 
     X = vars_copy(X0)
     del X0

--- a/tlm_adjoint/overloaded_float.py
+++ b/tlm_adjoint/overloaded_float.py
@@ -20,8 +20,8 @@ from .interface import (
     DEFAULT_COMM, SpaceInterface, VariableInterface, add_interface,
     check_space_type, comm_dup_cached, is_var, new_space_id, new_var_id,
     register_subtract_adjoint_derivative_action, space_comm, space_dtype,
-    subtract_adjoint_derivative_action_base, var_assign, var_id, var_new,
-    var_new_conjugate_dual, var_scalar_value, var_space_type)
+    subtract_adjoint_derivative_action_base, var_assign, var_comm, var_dtype,
+    var_id, var_new, var_new_conjugate_dual, var_scalar_value, var_space_type)
 
 from .alias import Alias
 from .caches import Caches
@@ -131,12 +131,13 @@ class FloatSpace:
             dtype = _default_dtype
         if comm is None:
             comm = DEFAULT_COMM
+        comm = comm_dup_cached(comm)
 
         dtype = np.dtype(dtype).type
         if not issubclass(dtype, (np.floating, np.complexfloating)):
             raise TypeError("Invalid dtype")
 
-        self._comm = comm_dup_cached(comm)
+        self._comm = comm
         self._dtype = dtype
         self._float_cls = float_cls
 
@@ -930,7 +931,8 @@ def to_float(y, *, name=None):
     :returns: The :class:`.SymbolicFloat`.
     """
 
-    x = Float(name=name, space_type=var_space_type(y))
+    x = Float(name=name, space_type=var_space_type(y), dtype=var_dtype(y),
+              comm=var_comm(y))
     Assignment(x, y).solve()
     return x
 

--- a/tlm_adjoint/tlm_adjoint.py
+++ b/tlm_adjoint/tlm_adjoint.py
@@ -90,10 +90,9 @@ class EquationManager:
     def __init__(self, *, comm=None, cp_method="memory", cp_parameters=None):
         if comm is None:
             comm = DEFAULT_COMM
+        comm = comm_dup_cached(comm)
         if cp_parameters is None:
             cp_parameters = {}
-
-        comm = comm_dup_cached(comm)
 
         self._comm = comm
         self._to_drop_references = []


### PR DESCRIPTION
Also:
- Change `comm_dup_cached` behaviour to prevent duplication of duplicated communicators.
- Other communicator duplication fixes.