### PR TITLE
Firedrake backend: `assemble` annotation

### DIFF
--- a/tlm_adjoint/fenics/equations.py
+++ b/tlm_adjoint/fenics/equations.py
@@ -231,7 +231,7 @@ class Assembly(ExprEquation):
     def tangent_linear(self, M, dM, tlm_map):
         x = self.x()
 
-        tlm_rhs = ufl.classes.Form([])
+        tlm_rhs = expr_zero(self._rhs)
         for dep in self.dependencies():
             if dep != x:
                 tau_dep = tlm_map[dep]
@@ -700,7 +700,7 @@ class EquationSolver(ExprEquation):
     def tangent_linear(self, M, dM, tlm_map):
         x = self.x()
 
-        tlm_rhs = ufl.classes.Form([])
+        tlm_rhs = expr_zero(self._F)
         for dep in self.dependencies():
             if dep != x:
                 tau_dep = tlm_map[dep]

--- a/tlm_adjoint/fenics/fenics_equations.py
+++ b/tlm_adjoint/fenics/fenics_equations.py
@@ -17,7 +17,7 @@ from ..linear_equation import LinearEquation, Matrix
 
 from .caches import form_dependencies, form_key
 from .equations import EquationSolver, derivative
-from .functions import eliminate_zeros
+from .functions import eliminate_zeros, expr_zero
 
 import functools
 import mpi4py.MPI as MPI
@@ -341,7 +341,7 @@ class LocalProjection(EquationSolver):
     def tangent_linear(self, M, dM, tlm_map):
         x = self.x()
 
-        tlm_rhs = ufl.classes.Form([])
+        tlm_rhs = expr_zero(self._rhs)
         for dep in self.dependencies():
             if dep != x:
                 tau_dep = tlm_map[dep]

--- a/tlm_adjoint/fenics/functions.py
+++ b/tlm_adjoint/fenics/functions.py
@@ -423,9 +423,14 @@ def derivative(expr, x, argument=None, *,
 
 
 def expr_zero(expr):
-    return ufl.classes.Zero(shape=expr.ufl_shape,
-                            free_indices=expr.ufl_free_indices,
-                            index_dimensions=expr.ufl_index_dimensions)
+    if isinstance(expr, ufl.classes.Form):
+        return ufl.classes.Form([])
+    elif isinstance(expr, ufl.classes.Expr):
+        return ufl.classes.Zero(shape=expr.ufl_shape,
+                                free_indices=expr.ufl_free_indices,
+                                index_dimensions=expr.ufl_index_dimensions)
+    else:
+        raise TypeError(f"Unexpected type: {type(expr)}")
 
 
 @form_cached("_tlm_adjoint__simplified_form")

--- a/tlm_adjoint/firedrake/equations.py
+++ b/tlm_adjoint/firedrake/equations.py
@@ -263,7 +263,7 @@ class Assembly(ExprEquation):
     def tangent_linear(self, M, dM, tlm_map):
         x = self.x()
 
-        tlm_rhs = ufl.classes.ZeroBaseForm(self._rhs.arguments())
+        tlm_rhs = expr_zero(self._rhs)
         for dep in self.dependencies():
             if dep != x:
                 tau_dep = tlm_map[dep]
@@ -759,7 +759,7 @@ class EquationSolver(ExprEquation):
     def tangent_linear(self, M, dM, tlm_map):
         x = self.x()
 
-        tlm_rhs = ufl.classes.ZeroBaseForm(self._F.arguments())
+        tlm_rhs = expr_zero(self._F)
         for dep in self.dependencies():
             if dep != x:
                 tau_dep = tlm_map[dep]

--- a/tlm_adjoint/firedrake/firedrake_equations.py
+++ b/tlm_adjoint/firedrake/firedrake_equations.py
@@ -214,7 +214,7 @@ class LocalProjection(EquationSolver):
     def tangent_linear(self, M, dM, tlm_map):
         x = self.x()
 
-        tlm_rhs = ufl.classes.ZeroBaseForm(self._rhs.arguments())
+        tlm_rhs = expr_zero(self._rhs)
         for dep in self.dependencies():
             if dep != x:
                 tau_dep = tlm_map[dep]

--- a/tlm_adjoint/firedrake/functions.py
+++ b/tlm_adjoint/firedrake/functions.py
@@ -387,28 +387,6 @@ def iter_expr(expr, *, evaluate_weights=False):
         raise TypeError(f"Unexpected type: {type(expr)}")
 
 
-def reconstruct_expr(expr, *args):
-    weight_iter = (weight for weight, _ in iter_expr(expr))
-    comp_iter = iter(args)
-
-    rexpr = expr_zero(expr)
-    for weight, comp in zip(weight_iter, comp_iter):
-        rexpr = rexpr + weight * comp
-
-    try:
-        next(weight_iter)
-        raise ValueError("Incompatible lengths")
-    except StopIteration:
-        pass
-    try:
-        next(comp_iter)
-        raise ValueError("Incompatible lengths")
-    except StopIteration:
-        pass
-
-    return rexpr
-
-
 def form_cached(key):
     def wrapper(fn):
         @functools.wraps(fn)

--- a/tlm_adjoint/firedrake/functions.py
+++ b/tlm_adjoint/firedrake/functions.py
@@ -391,7 +391,7 @@ def reconstruct_expr(expr, *args):
     weight_iter = (weight for weight, _ in iter_expr(expr))
     comp_iter = iter(args)
 
-    rexpr = ufl.classes.ZeroBaseForm(expr.arguments())
+    rexpr = expr_zero(expr)
     for weight, comp in zip(weight_iter, comp_iter):
         rexpr = rexpr + weight * comp
 
@@ -474,9 +474,14 @@ def derivative(expr, x, argument=None, *,
 
 
 def expr_zero(expr):
-    return ufl.classes.Zero(shape=expr.ufl_shape,
-                            free_indices=expr.ufl_free_indices,
-                            index_dimensions=expr.ufl_index_dimensions)
+    if isinstance(expr, ufl.classes.BaseForm):
+        return ufl.classes.ZeroBaseForm(expr.arguments())
+    elif isinstance(expr, ufl.classes.Expr):
+        return ufl.classes.Zero(shape=expr.ufl_shape,
+                                free_indices=expr.ufl_free_indices,
+                                index_dimensions=expr.ufl_index_dimensions)
+    else:
+        raise TypeError(f"Unexpected type: {type(expr)}")
 
 
 @form_cached("_tlm_adjoint__simplified_form")

--- a/tlm_adjoint/firedrake/functions.py
+++ b/tlm_adjoint/firedrake/functions.py
@@ -387,6 +387,28 @@ def iter_expr(expr, *, evaluate_weights=False):
         raise TypeError(f"Unexpected type: {type(expr)}")
 
 
+def reconstruct_expr(expr, *args):
+    weight_iter = (weight for weight, _ in iter_expr(expr))
+    comp_iter = iter(args)
+
+    rexpr = ufl.classes.ZeroBaseForm(expr.arguments())
+    for weight, comp in zip(weight_iter, comp_iter):
+        rexpr = rexpr + weight * comp
+
+    try:
+        next(weight_iter)
+        raise ValueError("Incompatible lengths")
+    except StopIteration:
+        pass
+    try:
+        next(comp_iter)
+        raise ValueError("Incompatible lengths")
+    except StopIteration:
+        pass
+
+    return rexpr
+
+
 def form_cached(key):
     def wrapper(fn):
         @functools.wraps(fn)


### PR DESCRIPTION
Uses approach 3 of #492.

Note that a single `assemble` call may be associated with multiple tape records. This avoids further complicating the `Assembly` class, at the cost of a more complicated computational graph.

Closes #492