### PR TITLE
Patch updates

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -11,12 +11,12 @@ autoapi_ignore = ["*/checkpoint_schedules/__init__.py",
                   "*/fenics/__init__.py",
                   "*/fenics/backend.py",
                   "*/fenics/backend_code_generator_interface.py",
-                  "*/fenics/backend_overrides.py",
+                  "*/fenics/backend_patches.py",
                   "*/firedrake/__init__.py",
                   "*/firedrake/backend.py",
                   "*/firedrake/backend_code_generator_interface.py",
-                  "*/firedrake/backend_overrides.py",
-                  "*/override.py"]
+                  "*/firedrake/backend_patches.py",
+                  "*/patch.py"]
 autoapi_add_toctree_entry = False
 autoapi_options = []
 

--- a/tests/fenics/test_base.py
+++ b/tests/fenics/test_base.py
@@ -6,7 +6,7 @@ from tlm_adjoint.fenics.backend import (
 from tlm_adjoint.fenics.backend_code_generator_interface import (
     interpolate_expression)
 from tlm_adjoint.alias import gc_disabled
-from tlm_adjoint.override import override_method
+from tlm_adjoint.patch import patch_method
 
 from ..test_base import chdir_tmp_path, jax_tlm_config, seed_test, tmp_path
 from ..test_base import run_example as _run_example
@@ -114,19 +114,19 @@ def referenced_vars():
                  if F_ref is not None)
 
 
-@override_method(Vector, "__init__")
+@patch_method(Vector, "__init__")
 def Vector__init__(self, orig, orig_args, *args, **kwargs):
     orig_args()
     _var_ids[var_id(self)] = self
 
 
-@override_method(backend_Constant, "__init__")
+@patch_method(backend_Constant, "__init__")
 def Constant__init__(self, orig, orig_args, *args, **kwargs):
     orig_args()
     _var_ids[var_id(self)] = self
 
 
-@override_method(backend_Function, "__init__")
+@patch_method(backend_Function, "__init__")
 def Function__init__(self, orig, orig_args, *args, **kwargs):
     orig_args()
     _var_ids[var_id(self)] = self

--- a/tests/fenics/test_patches.py
+++ b/tests/fenics/test_patches.py
@@ -158,8 +158,8 @@ def project_NonlinearVariationalSolver(F, space, bc):
                                         project_LinearVariationalSolver,
                                         project_NonlinearVariationalSolver])
 @seed_test
-def test_project_overrides(setup_test, test_leaks,
-                           project_fn):
+def test_project_patches(setup_test, test_leaks,
+                         project_fn):
     mesh = UnitSquareMesh(20, 20)
     X = SpatialCoordinate(mesh)
     space = FunctionSpace(mesh, "Lagrange", 1)

--- a/tests/fenics/test_patches.py
+++ b/tests/fenics/test_patches.py
@@ -2,7 +2,8 @@ from fenics import *
 from tlm_adjoint.fenics import *
 from tlm_adjoint.fenics.backend import backend_assemble, backend_Constant
 from tlm_adjoint.fenics.backend_code_generator_interface import (
-    assemble as backend_code_generator_interface_assemble)
+    assemble as backend_code_generator_interface_assemble,
+    copy_parameters_dict)
 
 from .test_base import *
 
@@ -127,7 +128,7 @@ def project_LinearVariationalSolver(F, space, bc):
     eq = inner(trial, test) * dx == inner(F, test) * dx
     problem = LinearVariationalProblem(eq.lhs, eq.rhs, G, bcs=bc)
     solver = LinearVariationalSolver(problem)
-    solver.parameters.update(ls_parameters_cg)
+    solver.parameters.update(copy_parameters_dict(ls_parameters_cg))
     solver.solve()
 
     return G
@@ -144,7 +145,7 @@ def project_NonlinearVariationalSolver(F, space, bc):
     solver = NonlinearVariationalSolver(problem)
     solver.parameters["nonlinear_solver"] = "newton"
     solver.parameters["symmetric"] = True
-    solver.parameters["newton_solver"].update(ns_parameters_newton_cg)
+    solver.parameters["newton_solver"].update(copy_parameters_dict(ns_parameters_newton_cg))  # noqa: E501
     solver.solve()
 
     return G

--- a/tests/firedrake/test_base.py
+++ b/tests/firedrake/test_base.py
@@ -6,7 +6,7 @@ from tlm_adjoint.firedrake.backend import (
 from tlm_adjoint.firedrake.backend_code_generator_interface import (
     interpolate_expression)
 from tlm_adjoint.alias import gc_disabled
-from tlm_adjoint.override import override_method
+from tlm_adjoint.patch import patch_method
 
 from ..test_base import chdir_tmp_path, jax_tlm_config, seed_test, tmp_path
 from ..test_base import (
@@ -107,25 +107,25 @@ def referenced_vars():
                  if F_ref is not None)
 
 
-@override_method(Vector, "__init__")
+@patch_method(Vector, "__init__")
 def Vector__init__(self, orig, orig_args, *args, **kwargs):
     orig_args()
     _var_ids[var_id(self)] = self
 
 
-@override_method(backend_Constant, "__init__")
+@patch_method(backend_Constant, "__init__")
 def Constant__init__(self, orig, orig_args, *args, **kwargs):
     orig_args()
     _var_ids[var_id(self)] = self
 
 
-@override_method(backend_Function, "__init__")
+@patch_method(backend_Function, "__init__")
 def Function__init__(self, orig, orig_args, *args, **kwargs):
     orig_args()
     _var_ids[var_id(self)] = self
 
 
-@override_method(backend_Cofunction, "__init__")
+@patch_method(backend_Cofunction, "__init__")
 def Cofunction__init__(self, orig, orig_args, *args, **kwargs):
     orig_args()
     _var_ids[var_id(self)] = self

--- a/tests/firedrake/test_patches.py
+++ b/tests/firedrake/test_patches.py
@@ -112,8 +112,8 @@ def project_NonlinearVariationalSolver(F, space, bc):
                                         project_LinearVariationalSolver,
                                         project_NonlinearVariationalSolver])
 @seed_test
-def test_project_overrides(setup_test, test_leaks,
-                           project_fn):
+def test_project_patches(setup_test, test_leaks,
+                         project_fn):
     mesh = UnitSquareMesh(20, 20)
     X = SpatialCoordinate(mesh)
     space = FunctionSpace(mesh, "Lagrange", 1)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,5 +1,5 @@
 from tlm_adjoint import DEFAULT_COMM, VectorEquation
-from tlm_adjoint.override import override_function, override_method
+from tlm_adjoint.patch import patch_function, patch_method
 
 import functools
 import hashlib
@@ -21,7 +21,7 @@ __all__ = \
 
 
 def seed_test(fn):
-    @override_function(fn)
+    @patch_function(fn)
     def wrapped_fn(orig, orig_args, *args, **kwargs):
         args_ = list(args)
         for i, arg in enumerate(args_):
@@ -70,7 +70,7 @@ def chdir_tmp_path(tmp_path):
 _jax_with_tlm = True
 
 
-@override_method(VectorEquation, "__init__")
+@patch_method(VectorEquation, "__init__")
 def VectorEquation__init__(self, orig, orig_args, *args, with_tlm=None,
                            **kwargs):
     if with_tlm is None:

--- a/tlm_adjoint/__init__.py
+++ b/tlm_adjoint/__init__.py
@@ -13,7 +13,7 @@ from .linear_equation import *     # noqa: F401
 from .manager import *             # noqa: F401
 from .optimization import *        # noqa: F401
 from .overloaded_float import *    # noqa: F401
-from .override import *            # noqa: F401
+from .patch import *               # noqa: F401
 from .storage import *             # noqa: F401
 from .tangent_linear import *      # noqa: F401
 from .tlm_adjoint import *         # noqa: F401

--- a/tlm_adjoint/fenics/__init__.py
+++ b/tlm_adjoint/fenics/__init__.py
@@ -2,7 +2,7 @@ from .. import *  # noqa: E402,F401
 del adjoint, alias, cached_hessian, caches, checkpointing, \
     eigendecomposition, equation, equations, fixed_point, functional, \
     hessian, instructions, interface, jax, linear_equation, markers, \
-    optimization, overloaded_float, override, storage, tangent_linear, \
+    optimization, overloaded_float, patch, storage, tangent_linear, \
     tlm_adjoint, verification  # noqa: F821
 
 from .backend import backend, backend_RealType, backend_ScalarType  # noqa: E402,E501,F401
@@ -13,4 +13,4 @@ from .equations import *           # noqa: E402,F401
 from .fenics_equations import *    # noqa: E402,F401
 from .functions import *           # noqa: E402,F401
 
-from .backend_overrides import *   # noqa: E402,F401
+from .backend_patches import *     # noqa: E402,F401

--- a/tlm_adjoint/fenics/backend_interface.py
+++ b/tlm_adjoint/fenics/backend_interface.py
@@ -10,7 +10,7 @@ from ..interface import (
     var_lock_state, var_new, var_space, var_space_type)
 
 from ..equations import Conversion
-from ..override import override_method
+from ..patch import patch_method
 
 from .equations import Assembly
 from .functions import (
@@ -35,7 +35,7 @@ __all__ = \
     ]
 
 
-@override_method(backend_Constant, "__init__")
+@patch_method(backend_Constant, "__init__")
 def Constant__init__(self, orig, orig_args, *args, domain=None, space=None,
                      comm=None, **kwargs):
     if domain is not None and hasattr(domain, "ufl_domain"):
@@ -94,7 +94,7 @@ def FunctionSpace_add_interface_disabled(fn):
     return wrapped_fn
 
 
-@override_method(backend_FunctionSpace, "__init__")
+@patch_method(backend_FunctionSpace, "__init__")
 def FunctionSpace__init__(self, orig, orig_args, *args, **kwargs):
     orig_args()
     if _FunctionSpace_add_interface:
@@ -311,7 +311,7 @@ class ZeroFunction(Function, Zero):
 # Aim for compatibility with FEniCS 2019.1.0 API
 
 
-@override_method(backend_Function, "__init__")
+@patch_method(backend_Function, "__init__")
 @FunctionSpace_add_interface_disabled
 def Function__init__(self, orig, orig_args, *args, **kwargs):
     orig_args()
@@ -336,7 +336,7 @@ def Function__init__(self, orig, orig_args, *args, **kwargs):
                   {"comm": comm_dup_cached(space.mesh().mpi_comm()), "id": id})
 
 
-@override_method(backend_Function, "function_space")
+@patch_method(backend_Function, "function_space")
 def Function_function_space(self, orig, orig_args):
     if is_var(self):
         return var_space(self)
@@ -344,7 +344,7 @@ def Function_function_space(self, orig, orig_args):
         return orig_args()
 
 
-@override_method(backend_Function, "split")
+@patch_method(backend_Function, "split")
 def Function_split(self, orig, orig_args, deepcopy=False):
     Y = orig_args()
     if not deepcopy:

--- a/tlm_adjoint/fenics/backend_patches.py
+++ b/tlm_adjoint/fenics/backend_patches.py
@@ -213,7 +213,7 @@ def SystemAssembler_assemble(self, orig, orig_args, *args):
                                              + form._tlm_adjoint__form)
             else:
                 tensor._tlm_adjoint__form = form._tlm_adjoint__form
-                tensor._tlm_adjoint__bcs = []
+                tensor._tlm_adjoint__bcs = list(_getattr(self, "bcs"))
                 tensor._tlm_adjoint__form_compiler_parameters = form_compiler_parameters  # noqa: E501
 
     return return_value

--- a/tlm_adjoint/firedrake/__init__.py
+++ b/tlm_adjoint/firedrake/__init__.py
@@ -2,7 +2,7 @@ from .. import *  # noqa: E402,F401
 del adjoint, alias, cached_hessian, caches, checkpointing, \
     eigendecomposition, equation, equations, fixed_point, functional, \
     hessian, instructions, interface, jax, linear_equation, markers, \
-    optimization, overloaded_float, override, storage, tangent_linear, \
+    optimization, overloaded_float, patch, storage, tangent_linear, \
     tlm_adjoint, verification  # noqa: F821
 
 from .backend import backend, backend_RealType, backend_ScalarType  # noqa: E402,E501,F401
@@ -16,4 +16,4 @@ from .firedrake_equations import *  # noqa: E402,F401
 from .functions import *            # noqa: E402,F401
 from .hessian_system import *       # noqa: E402,F401
 
-from .backend_overrides import *    # noqa: E402,F401
+from .backend_patches import *      # noqa: E402,F401

--- a/tlm_adjoint/firedrake/backend_code_generator_interface.py
+++ b/tlm_adjoint/firedrake/backend_code_generator_interface.py
@@ -7,7 +7,7 @@ from ..interface import (
     var_copy, var_inner, var_new_conjugate_dual, var_space, var_space_type)
 
 from ..manager import manager_disabled
-from ..override import override_method
+from ..patch import patch_method
 
 from .functions import eliminate_zeros, extract_coefficients
 
@@ -183,7 +183,7 @@ def _assemble_system(A_form, b_form=None, bcs=None, *,
     return A, b
 
 
-@override_method(LinearSolver, "_lifted")
+@patch_method(LinearSolver, "_lifted")
 def LinearSolver_lifted(self, orig, orig_args, b):
     if getattr(self.A, "_tlm_adjoint__lift_bcs", True):
         return orig_args()

--- a/tlm_adjoint/firedrake/backend_interface.py
+++ b/tlm_adjoint/firedrake/backend_interface.py
@@ -11,8 +11,8 @@ from ..interface import (
     var_is_alias, var_linf_norm, var_lock_state, var_space, var_space_type)
 
 from ..equations import Conversion
-from ..override import override_method, override_property
 from ..manager import paused_manager
+from ..patch import patch_method, patch_property
 
 from .equations import Assembly
 from .functions import (
@@ -42,7 +42,7 @@ __all__ = \
 # Aim for compatibility with Firedrake API
 
 
-@override_method(backend_Constant, "__init__")
+@patch_method(backend_Constant, "__init__")
 def Constant__init__(self, orig, orig_args, value, domain=None, *,
                      name=None, space=None, comm=None,
                      **kwargs):
@@ -101,7 +101,7 @@ class FunctionSpaceInterface(SpaceInterface):
             raise ValueError("Invalid space type")
 
 
-@override_method(backend_FunctionSpace, "__init__")
+@patch_method(backend_FunctionSpace, "__init__")
 def FunctionSpace__init__(self, orig, orig_args, *args, **kwargs):
     orig_args()
     add_interface(self, FunctionSpaceInterface,
@@ -109,7 +109,7 @@ def FunctionSpace__init__(self, orig, orig_args, *args, **kwargs):
                    "id": new_space_id()})
 
 
-@override_method(backend_FunctionSpace, "dual")
+@patch_method(backend_FunctionSpace, "dual")
 def FunctionSpace_dual(self, orig, orig_args):
     if "space_dual" not in self._tlm_adjoint__space_interface_attrs:
         self._tlm_adjoint__space_interface_attrs["space_dual"] = orig_args()
@@ -119,7 +119,7 @@ def FunctionSpace_dual(self, orig, orig_args):
     return space_dual
 
 
-@override_method(backend_CofunctionSpace, "__init__")
+@patch_method(backend_CofunctionSpace, "__init__")
 def CofunctionSpace__init__(self, orig, orig_args, *args, **kwargs):
     orig_args()
     add_interface(self, FunctionSpaceInterface,
@@ -127,7 +127,7 @@ def CofunctionSpace__init__(self, orig, orig_args, *args, **kwargs):
                    "id": new_space_id()})
 
 
-@override_method(backend_CofunctionSpace, "dual")
+@patch_method(backend_CofunctionSpace, "dual")
 def CofunctionSpace_dual(self, orig, orig_args):
     if "space" not in self._tlm_adjoint__space_interface_attrs:
         self._tlm_adjoint__space_interface_attrs["space"] = orig_args()
@@ -321,7 +321,7 @@ class ZeroFunction(Function, Zero):
             raise RuntimeError("ZeroFunction is not zero-valued")
 
 
-@override_method(backend_Function, "__init__")
+@patch_method(backend_Function, "__init__")
 def Function__init__(self, orig, orig_args, function_space, val=None,
                      *args, **kwargs):
     orig_args()
@@ -334,14 +334,14 @@ def Function__init__(self, orig, orig_args, function_space, val=None,
         define_var_alias(self, val, key=("Function__init__",))
 
 
-@override_method(backend_Function, "__getattr__")
+@patch_method(backend_Function, "__getattr__")
 def Function__getattr__(self, orig, orig_args, key):
     if "_data" not in self.__dict__:
         raise AttributeError(f"No attribute '{key:s}'")
     return orig_args()
 
 
-@override_method(backend_Function, "riesz_representation")
+@patch_method(backend_Function, "riesz_representation")
 def Function_riesz_representation(self, orig, orig_args,
                                   riesz_map="L2", *args, **kwargs):
     if riesz_map != "l2":
@@ -357,7 +357,7 @@ def Function_riesz_representation(self, orig, orig_args,
     return return_value
 
 
-@override_property(backend_Function, "subfunctions", cached=True)
+@patch_property(backend_Function, "subfunctions", cached=True)
 def Function_subfunctions(self, orig):
     Y = orig()
     for i, y in enumerate(Y):
@@ -365,7 +365,7 @@ def Function_subfunctions(self, orig):
     return Y
 
 
-@override_method(backend_Function, "sub")
+@patch_method(backend_Function, "sub")
 def Function_sub(self, orig, orig_args, i):
     self.subfunctions
     y = orig_args()
@@ -451,7 +451,7 @@ class Cofunction(backend_Cofunction):
             return ufl.classes.Cofunction.equals(self, other)
 
 
-@override_method(backend_Cofunction, "__init__")
+@patch_method(backend_Cofunction, "__init__")
 def Cofunction__init__(self, orig, orig_args, function_space, val=None,
                        *args, **kwargs):
     orig_args()
@@ -465,7 +465,7 @@ def Cofunction__init__(self, orig, orig_args, function_space, val=None,
         define_var_alias(self, val, key=("Cofunction__init__",))
 
 
-@override_method(backend_Cofunction, "riesz_representation")
+@patch_method(backend_Cofunction, "riesz_representation")
 def Cofunction_riesz_representation(self, orig, orig_args,
                                     riesz_map="L2", *args, **kwargs):
     if riesz_map != "l2":

--- a/tlm_adjoint/firedrake/backend_patches.py
+++ b/tlm_adjoint/firedrake/backend_patches.py
@@ -2,7 +2,7 @@ from .backend import (
     FormAssembler, LinearSolver, NonlinearVariationalSolver, Parameters,
     Projector, SameMeshInterpolator, backend_Cofunction, backend_Constant,
     backend_DirichletBC, backend_Function, backend_Vector, backend_assemble,
-    backend_interpolate, backend_project, backend_solve, parameters)
+    backend_project, backend_solve, parameters)
 from ..interface import (
     VariableStateChangeError, is_var, space_id, var_comm, var_new, var_space,
     var_state_is_locked, var_update_state)
@@ -31,7 +31,6 @@ import ufl
 __all__ = \
     [
         "assemble",
-        "interpolate",
         "project",
         "solve"
     ]
@@ -536,4 +535,3 @@ fn_globals(backend_assemble)["base_form_assembly_visitor"] = base_form_assembly_
 assemble = add_manager_controls(backend_assemble)
 solve = add_manager_controls(backend_solve)
 project = add_manager_controls(backend_project)
-interpolate = add_manager_controls(backend_interpolate)

--- a/tlm_adjoint/firedrake/backend_patches.py
+++ b/tlm_adjoint/firedrake/backend_patches.py
@@ -12,9 +12,9 @@ from .backend_code_generator_interface import (
 from ..equation import ZeroAssignment
 from ..equations import Assignment, LinearCombination
 from ..manager import annotation_enabled, tlm_enabled
-from ..override import (
-    add_manager_controls, manager_method, override_function, override_method,
-    override_property)
+from ..patch import (
+    add_manager_controls, manager_method, patch_function, patch_method,
+    patch_property)
 
 from .backend_interface import Cofunction
 from .equations import (
@@ -122,8 +122,8 @@ def DirichletBC_function_arg_fset(self, orig, orig_args, g):
     return return_value
 
 
-@override_property(backend_DirichletBC, "function_arg",
-                   fset=DirichletBC_function_arg_fset)
+@patch_property(backend_DirichletBC, "function_arg",
+                fset=DirichletBC_function_arg_fset)
 def DirichletBC_function_arg(self, orig):
     return orig()
 
@@ -183,7 +183,7 @@ def Constant_assign(self, orig, orig_args, value, *, annotate, tlm):
 
 
 def register_in_place(cls, name, op):
-    @override_method(cls, name)
+    @patch_method(cls, name)
     def wrapped_op(self, orig, orig_args, other):
         annotate = annotation_enabled()
         tlm = tlm_enabled()
@@ -294,7 +294,7 @@ def Function_project(self, orig, orig_args, b, bcs=None,
     return return_value
 
 
-@manager_method(backend_Function, "copy", override_without_manager=True)
+@manager_method(backend_Function, "copy", patch_without_manager=True)
 def Function_copy(self, orig, orig_args, deepcopy=False, *, annotate, tlm):
     if deepcopy:
         F = var_new(self)
@@ -393,7 +393,7 @@ def LinearSolver_solve(self, orig, orig_args, x, b, *, annotate, tlm):
     return return_value
 
 
-@override_method(NonlinearVariationalSolver, "__init__")
+@patch_method(NonlinearVariationalSolver, "__init__")
 def NonlinearVariationalSolver__init__(
         self, orig, orig_args, problem, *, appctx=None,
         pre_jacobian_callback=None, post_jacobian_callback=None,
@@ -407,7 +407,7 @@ def NonlinearVariationalSolver__init__(
     self._tlm_adjoint__transfer_manager = None
 
 
-@override_method(NonlinearVariationalSolver, "set_transfer_manager")
+@patch_method(NonlinearVariationalSolver, "set_transfer_manager")
 def NonlinearVariationalSolver_set_transfer_manager(
         self, orig, orig_args, manager):
     orig_args()
@@ -495,7 +495,7 @@ def fn_globals(fn):
     return fn.__globals__
 
 
-@override_function(fn_globals(backend_assemble)["base_form_assembly_visitor"])
+@patch_function(fn_globals(backend_assemble)["base_form_assembly_visitor"])
 def base_form_assembly_visitor(orig, orig_args, expr, tensor, *args, **kwargs):
     annotate = annotation_enabled()
     tlm = tlm_enabled()

--- a/tlm_adjoint/firedrake/backend_patches.py
+++ b/tlm_adjoint/firedrake/backend_patches.py
@@ -104,12 +104,6 @@ def FormAssembler_assemble(self, orig, orig_args, *args,
     return return_value
 
 
-def var_update_state_post_call(self, return_value, *args, **kwargs):
-    if is_var(self):
-        var_update_state(self)
-    return return_value
-
-
 def DirichletBC_function_arg_fset(self, orig, orig_args, g):
     if getattr(self, "_tlm_adjoint__function_arg_set", False) \
             and is_var(self.function_arg) \
@@ -155,6 +149,12 @@ def Constant__init__(self, orig, orig_args, value=None, *args,
     orig_args()
     if value is not None:
         Constant_init_assign(self, value, annotate, tlm)
+
+
+def var_update_state_post_call(self, return_value, *args, **kwargs):
+    if is_var(self):
+        var_update_state(self)
+    return return_value
 
 
 @manager_method(backend_Constant, "assign",


### PR DESCRIPTION
- Rename 'override' to 'patch'.
- FEniCS backend:  No longer require functions to be imported from `tlm_adjoint.fenics` -- apply all patches in-place.
- Firedrake backend: Remove `interpolate` function.