### PR TITLE
Remove most usage of `manager`, `annotate`, and `tlm` arguments

### DIFF
--- a/tests/fenics/test_models.py
+++ b/tests/fenics/test_models.py
@@ -17,8 +17,8 @@ pytestmark = pytest.mark.skipif(
 
 
 def oscillator_ref():
-    assert not manager().annotation_enabled()
-    assert not manager().tlm_enabled()
+    assert not annotation_enabled()
+    assert not tlm_enabled()
 
     nsteps = 20
     dt = Constant(0.01)
@@ -48,8 +48,8 @@ def oscillator_ref():
 
 
 def diffusion_ref():
-    assert not manager().annotation_enabled()
-    assert not manager().tlm_enabled()
+    assert not annotation_enabled()
+    assert not tlm_enabled()
 
     n_steps = 20
     dt = Constant(0.01)

--- a/tests/firedrake/test_models.py
+++ b/tests/firedrake/test_models.py
@@ -17,8 +17,8 @@ pytestmark = pytest.mark.skipif(
 
 
 def oscillator_ref():
-    assert not manager().annotation_enabled()
-    assert not manager().tlm_enabled()
+    assert not annotation_enabled()
+    assert not tlm_enabled()
 
     nsteps = 20
     dt = Constant(0.01)
@@ -46,8 +46,8 @@ def oscillator_ref():
 
 
 def diffusion_ref():
-    assert not manager().annotation_enabled()
-    assert not manager().tlm_enabled()
+    assert not annotation_enabled()
+    assert not tlm_enabled()
 
     n_steps = 20
     dt = Constant(0.01)

--- a/tlm_adjoint/equation.py
+++ b/tlm_adjoint/equation.py
@@ -4,7 +4,7 @@ from .interface import (
 
 from .alias import gc_disabled
 from .manager import manager as _manager
-from .manager import paused_manager, restore_manager, set_manager
+from .manager import paused_manager
 
 from collections.abc import Sequence
 import inspect
@@ -338,35 +338,26 @@ class Equation(Referrer):
         else:
             return var_new(self.X(m), rel_space_type=self.adj_X_type(m))
 
-    def _pre_process(self, manager=None, annotate=None):
-        if manager is None:
-            manager = _manager()
+    def _pre_process(self, *, annotate=None):
+        manager = _manager()
         for dep in self.initial_condition_dependencies():
             manager.add_initial_condition(dep, annotate=annotate)
 
-    def _post_process(self, manager=None, annotate=None, tlm=None):
-        if manager is None:
-            manager = _manager()
+    def _post_process(self, *, annotate=None, tlm=None):
+        manager = _manager()
         manager.add_equation(self, annotate=annotate, tlm=tlm)
 
-    @restore_manager
-    def solve(self, *, manager=None, annotate=None, tlm=None):
+    def solve(self, *, annotate=None, tlm=None):
         """Compute the forward solution.
 
-        :arg manager: The :class:`.EquationManager`. Defaults to `manager()`.
         :arg annotate: Whether the :class:`.EquationManager` should record the
             solution of equations.
         :arg tlm: Whether tangent-linear equations should be solved.
         """
 
-        if manager is not None:
-            set_manager(manager)
-
         self._pre_process(annotate=annotate)
-
         with paused_manager():
             self.forward(self.X())
-
         self._post_process(annotate=annotate, tlm=tlm)
 
     def forward(self, X, deps=None):

--- a/tlm_adjoint/firedrake/equations.py
+++ b/tlm_adjoint/firedrake/equations.py
@@ -8,7 +8,7 @@ from .backend import (
     backend_DirichletBC, backend_Function, complex_mode, parameters)
 from ..interface import (
     check_space_type, is_var, var_assign, var_axpy, var_id,
-    var_increment_state_lock, var_is_scalar, var_new, var_new_conjugate_dual,
+    var_increment_state_lock, var_is_scalar, var_new_conjugate_dual,
     var_replacement, var_scalar_value, var_space, var_update_caches, var_zero)
 from .backend_code_generator_interface import (
     assemble, assemble_linear_solver, copy_parameters_dict,
@@ -18,7 +18,6 @@ from .backend_code_generator_interface import (
 
 from ..caches import CacheRef
 from ..equation import Equation, ZeroAssignment
-from ..equations import Assignment
 
 from .caches import assembly_cache, is_cached, linear_solver_cache, split_form
 from .functions import (
@@ -35,9 +34,7 @@ __all__ = \
         "DirichletBCApplication",
         "EquationSolver",
         "ExprInterpolation",
-        "Projection",
-        "expr_new_x",
-        "linear_equation_new_x"
+        "Projection"
     ]
 
 
@@ -799,61 +796,6 @@ class EquationSolver(ExprEquation):
                 cache_adjoint_jacobian=self._cache_adjoint_jacobian,
                 cache_tlm_jacobian=self._cache_tlm_jacobian,
                 cache_rhs_assembly=self._cache_rhs_assembly)
-
-
-def expr_new_x(expr, x, *,
-               annotate=None, tlm=None):
-    """If an expression depends on `x`, then record the assignment `x_old =
-    x`, and replace `x` with `x_old` in the expression.
-
-    :arg expr: A :class:`ufl.core.expr.Expr`.
-    :arg x: Defines `x`.
-    :arg annotate: Whether the :class:`.EquationManager` should record the
-        solution of equations.
-    :arg tlm: Whether tangent-linear equations should be solved.
-    :returns: A :class:`ufl.core.expr.Expr` with `x` replaced with `x_old`, or
-        `expr` if the expression does not depend on `x`.
-    """
-
-    if x in extract_coefficients(expr):
-        x_old = var_new(x)
-        Assignment(x_old, x).solve(annotate=annotate, tlm=tlm)
-        return ufl.replace(expr, {x: x_old})
-    else:
-        return expr
-
-
-def linear_equation_new_x(eq, x, *,
-                          annotate=None, tlm=None):
-    """If a symbolic expression for a linear finite element variational problem
-    depends on the symbolic variable representing the problem solution `x`,
-    then record the assignment `x_old = x`, and replace `x` with `x_old` in the
-    symbolic expression.
-
-    :arg eq: A :class:`ufl.equation.Equation` defining the finite element
-        variational problem.
-    :arg x: A :class:`firedrake.function.Function` defining the solution to the
-        finite element variational problem.
-    :arg annotate: Whether the :class:`.EquationManager` should record the
-        solution of equations.
-    :arg tlm: Whether tangent-linear equations should be solved.
-    :returns: A :class:`ufl.equation.Equation` with `x` replaced with `x_old`,
-        or `eq` if the symbolic expression does not depend on `x`.
-    """
-
-    lhs, rhs = eq.lhs, eq.rhs
-    lhs_x_dep = x in extract_coefficients(lhs)
-    rhs_x_dep = x in extract_coefficients(rhs)
-    if lhs_x_dep or rhs_x_dep:
-        x_old = var_new(x)
-        Assignment(x_old, x).solve(annotate=annotate, tlm=tlm)
-        if lhs_x_dep:
-            lhs = ufl.replace(lhs, {x: x_old})
-        if rhs_x_dep:
-            rhs = ufl.replace(rhs, {x: x_old})
-        return lhs == rhs
-    else:
-        return eq
 
 
 class Projection(EquationSolver):

--- a/tlm_adjoint/functional.py
+++ b/tlm_adjoint/functional.py
@@ -26,44 +26,38 @@ class Functional(Float):
                           DeprecationWarning, stacklevel=2)
         super().__init__(*args, **kwargs)
 
-    def assign(self, y, *, annotate=None, tlm=None):
+    def assign(self, y):
         """Assign to the :class:`.Functional`.
 
         :arg y: The value.
-        :arg annotate: Whether the :class:`.EquationManager` should record the
-            solution of equations.
-        :arg tlm: Whether tangent-linear equations should be solved.
         :returns: The :class:`.Functional`.
         """
 
         if is_var(y) and var_is_scalar(y):
-            Assignment(self, y).solve(annotate=annotate, tlm=tlm)
+            Assignment(self, y).solve()
             return self
         elif isinstance(y, (numbers.Complex, sp.Expr)):
-            return super().assign(y, annotate=annotate, tlm=tlm)
+            return super().assign(y)
         else:
-            functional_term_eq(self, y).solve(annotate=annotate, tlm=tlm)
+            functional_term_eq(self, y).solve()
             return self
 
-    def addto(self, y, *, annotate=None, tlm=None):
+    def addto(self, y):
         """Add to the :class:`.Functional`.
 
         :arg y: The value to add.
-        :arg annotate: Whether the :class:`.EquationManager` should record the
-            solution of equations.
-        :arg tlm: Whether tangent-linear equations should be solved.
         """
 
         if is_var(y) and var_is_scalar(y):
-            J_old = self.new(self, annotate=annotate, tlm=tlm)
-            Axpy(self, J_old, 1.0, y).solve(annotate=annotate, tlm=tlm)
+            J_old = self.new(self)
+            Axpy(self, J_old, 1.0, y).solve()
         elif isinstance(y, (numbers.Complex, sp.Expr)):
-            super().addto(y, annotate=annotate, tlm=tlm)
+            super().addto(y)
         else:
-            J_old = self.new(self, annotate=annotate, tlm=tlm)
+            J_old = self.new(self)
             b = self.new()
-            functional_term_eq(b, y).solve(annotate=annotate, tlm=tlm)
-            Axpy(self, J_old, 1.0, b).solve(annotate=annotate, tlm=tlm)
+            functional_term_eq(b, y).solve()
+            Axpy(self, J_old, 1.0, b).solve()
 
     def function(self):
         ""

--- a/tlm_adjoint/optimization.py
+++ b/tlm_adjoint/optimization.py
@@ -33,7 +33,8 @@ class ReducedFunctional:
     def __init__(self, forward, *,
                  manager=None):
         if manager is None:
-            manager = _manager().new()
+            manager = _manager()
+        manager = manager.new()
 
         self._manager = manager
         self._forward = forward
@@ -124,7 +125,7 @@ class ReducedFunctional:
             if not issubclass(var_dtype(dm), np.floating):
                 raise ValueError("Invalid dtype")
 
-        ddJ = Hessian(self._forward, manager=self._manager.new())
+        ddJ = Hessian(self._forward, manager=self._manager)
         _, _, ddJ = ddJ.action(M, dM)
 
         for ddJ_i in ddJ:

--- a/tlm_adjoint/overloaded_float.py
+++ b/tlm_adjoint/overloaded_float.py
@@ -341,15 +341,11 @@ class _tlm_adjoint__SymbolicFloat(sp.Symbol):  # noqa: N801
     :arg dtype: The data type associated with the :class:`.SymbolicFloat`.
         Typically :class:`numpy.double` or :class:`numpy.cdouble`.
     :arg comm: The communicator associated with the :class:`.SymbolicFloat`.
-    :arg annotate: Whether the :class:`.EquationManager` should record the
-        solution of equations.
-    :arg tlm: Whether tangent-linear equations should be solved.
     """
 
     def __init__(self, value=0.0, *, name=None, space_type="primal",
                  static=False, cache=None,
-                 dtype=None, comm=None,
-                 annotate=None, tlm=None):
+                 dtype=None, comm=None):
         id = new_var_id()
         if name is None:
             # Following FEniCS 2019.1.0 behaviour
@@ -372,7 +368,7 @@ class _tlm_adjoint__SymbolicFloat(sp.Symbol):  # noqa: N801
             if value != 0.0:
                 var_assign(self, value)
         else:
-            self.assign(value, annotate=annotate, tlm=tlm)
+            self.assign(value)
 
     def __new__(cls, *args, dtype=None, **kwargs):
         if dtype is None:
@@ -384,8 +380,7 @@ class _tlm_adjoint__SymbolicFloat(sp.Symbol):  # noqa: N801
 
     def new(self, value=0.0, *,
             name=None,
-            static=False, cache=None,
-            annotate=None, tlm=None):
+            static=False, cache=None):
         """Return a new object, which same type and space type as this
         :class:`.SymbolicFloat`.
 
@@ -399,9 +394,7 @@ class _tlm_adjoint__SymbolicFloat(sp.Symbol):  # noqa: N801
             if value != 0.0:
                 var_assign(x, value)
         else:
-            x.assign(
-                value,
-                annotate=annotate, tlm=tlm)
+            x.assign(value)
         return x
 
     def __float__(self):
@@ -430,28 +423,21 @@ class _tlm_adjoint__SymbolicFloat(sp.Symbol):  # noqa: N801
 
         return self._space_type
 
-    def assign(self, y, *, annotate=None, tlm=None):
+    def assign(self, y):
         """:class:`.SymbolicFloat` assignment.
 
         :arg y: A :class:`numbers.Complex` or :class:`sympy.core.expr.Expr`
             defining the value.
-        :arg annotate: Whether the :class:`.EquationManager` should record the
-            solution of equations.
-        :arg tlm: Whether tangent-linear equations should be solved.
         :returns: The :class:`.SymbolicFloat`.
         """
 
-        if annotate is None or annotate:
-            annotate = annotation_enabled()
-        if tlm is None or tlm:
-            tlm = tlm_enabled()
+        annotate = annotation_enabled()
+        tlm = tlm_enabled()
         if annotate or tlm:
             if isinstance(y, numbers.Complex):
-                Assignment(self, self.new(y)).solve(
-                    annotate=annotate, tlm=tlm)
+                Assignment(self, self.new(y)).solve()
             elif isinstance(y, sp.Expr):
-                FloatEquation(self, y).solve(
-                    annotate=annotate, tlm=tlm)
+                FloatEquation(self, y).solve()
             else:
                 raise TypeError(f"Unexpected type: {type(y)}")
         else:
@@ -466,19 +452,16 @@ class _tlm_adjoint__SymbolicFloat(sp.Symbol):  # noqa: N801
                 raise TypeError(f"Unexpected type: {type(y)}")
         return self
 
-    def addto(self, y, *, annotate=None, tlm=None):
+    def addto(self, y):
         """:class:`.SymbolicFloat` in-place addition.
 
         :arg y: A :class:`numbers.Complex` or :class:`sympy.core.expr.Expr`
             defining the value to add.
-        :arg annotate: Whether the :class:`.EquationManager` should record the
-            solution of equations.
-        :arg tlm: Whether tangent-linear equations should be solved.
         """
 
-        x_old = self.new().assign(self, annotate=annotate, tlm=tlm)
-        y = self.new().assign(y, annotate=annotate, tlm=tlm)
-        Axpy(self, x_old, 1.0, y).solve(annotate=annotate, tlm=tlm)
+        x_old = self.new().assign(self)
+        y = self.new().assign(y)
+        Axpy(self, x_old, 1.0, y).solve()
 
     @property
     def value(self):
@@ -504,14 +487,13 @@ class _tlm_adjoint__SymbolicFloat(sp.Symbol):  # noqa: N801
 class SymbolicFloat(_tlm_adjoint__SymbolicFloat):
     def new(self, value=0.0, *,
             name=None,
-            static=False, cache=None,
-            annotate=None, tlm=None):
+            static=False, cache=None):
         pass
 
-    def assign(self, y, *, annotate=None, tlm=None):
+    def assign(self, y):
         pass
 
-    def addto(self, y, *, annotate=None, tlm=None):
+    def addto(self, y):
         pass
 
     @property

--- a/tlm_adjoint/patch.py
+++ b/tlm_adjoint/patch.py
@@ -113,7 +113,7 @@ def manager_method(cls, name, *,
             if annotate or tlm or patch_without_manager:
                 return patch(self, wrapped_orig,
                              lambda: wrapped_orig(self, *args, **kwargs),
-                             *args, annotate=annotate, tlm=tlm, **kwargs)
+                             *args, **kwargs)
             else:
                 return wrapped_orig(self, *args, **kwargs)
 

--- a/tlm_adjoint/tlm_adjoint.py
+++ b/tlm_adjoint/tlm_adjoint.py
@@ -627,6 +627,7 @@ class EquationManager:
 
             self._cp.add_initial_condition(x)
 
+    @restore_manager
     def add_equation(self, eq, *, annotate=None, tlm=None):
         """Process an :class:`.Equation` after it has been solved.
 
@@ -637,6 +638,7 @@ class EquationManager:
             solved.
         """
 
+        set_manager(self)
         self.drop_references()
 
         if annotate is None or annotate:
@@ -669,9 +671,7 @@ class EquationManager:
                 node_eq = self._tangent_linear(parent_eq, node_M, node_dM)
                 if node_eq is not None:
                     node_eq.solve(
-                        manager=self,
-                        annotate=annotate and node.is_annotated(),
-                        tlm=False)
+                        annotate=annotate and node.is_annotated(), tlm=False)
                     remaining_eqs.extend(
                         (node_eq, child_M_dM, child)
                         for child_M_dM, child in node.items())


### PR DESCRIPTION
Retained in `EquationSolver.solve` and patched methods. These might later be replaced with use of `paused_manager` etc.