### PR TITLE
Require `Projection` and `LocalProjection` to be supplied with an `Expr`

### DIFF
--- a/tests/firedrake/test_base.py
+++ b/tests/firedrake/test_base.py
@@ -48,6 +48,7 @@ __all__ = \
         "test_rhs",
 
         "ls_parameters_cg",
+        "ls_parameters_gmres",
         "ns_parameters_newton_cg",
         "ns_parameters_newton_gmres"
     ]
@@ -312,6 +313,13 @@ ls_parameters_cg = {"ksp_type": "cg",
                     "pc_type": "sor",
                     "ksp_rtol": 1.0e-14,
                     "ksp_atol": 1.0e-16}
+
+
+ls_parameters_gmres = {"ksp_type": "gmres",
+                       "pc_type": "sor",
+                       "ksp_rtol": 1.0e-14,
+                       "ksp_atol": 1.0e-16}
+
 
 ns_parameters_newton_cg = {"snes_type": "newtonls",
                            "ksp_type": "cg",

--- a/tlm_adjoint/fenics/backend.py
+++ b/tlm_adjoint/fenics/backend.py
@@ -19,6 +19,7 @@ backend_Constant = Constant
 backend_DirichletBC = DirichletBC
 backend_Function = Function
 backend_FunctionSpace = FunctionSpace
+backend_LocalSolver = LocalSolver
 backend_Matrix = fenics.cpp.la.GenericMatrix
 backend_Vector = fenics.cpp.la.GenericVector
 backend_assemble = assemble

--- a/tlm_adjoint/fenics/backend_patches.py
+++ b/tlm_adjoint/fenics/backend_patches.py
@@ -531,7 +531,7 @@ def Vector_apply(self, orig, orig_args, *args, **kwargs):
     return return_value
 
 
-@manager_method(backend_Matrix, "__mul__")
+@patch_method(backend_Matrix, "__mul__")
 def Matrix__mul__(self, orig, orig_args, other):
     return_value = orig_args()
 

--- a/tlm_adjoint/fenics/backend_patches.py
+++ b/tlm_adjoint/fenics/backend_patches.py
@@ -313,7 +313,7 @@ def Constant_init_assign(self, value):
         eq._post_process()
 
 
-@patch_method(backend_Constant, "__init__")
+@manager_method(backend_Constant, "__init__", patch_without_manager=True)
 def backend_Constant__init__(self, orig, orig_args, value, *args,
                              domain=None, space=None, comm=None, **kwargs):
     if domain is not None and hasattr(domain, "ufl_domain"):

--- a/tlm_adjoint/fenics/backend_patches.py
+++ b/tlm_adjoint/fenics/backend_patches.py
@@ -2,9 +2,9 @@ from .backend import (
     Form, KrylovSolver, LUSolver, LinearVariationalSolver,
     NonlinearVariationalProblem, NonlinearVariationalSolver, as_backend_type,
     backend_Constant, backend_DirichletBC, backend_Function,
-    backend_FunctionSpace, backend_Matrix, backend_ScalarType, backend_Vector,
-    backend_assemble, backend_project, backend_solve, cpp_Assembler,
-    cpp_PETScVector, cpp_SystemAssembler)
+    backend_FunctionSpace, backend_LocalSolver, backend_Matrix,
+    backend_ScalarType, backend_Vector, backend_assemble, backend_project,
+    backend_solve, cpp_Assembler, cpp_PETScVector, cpp_SystemAssembler)
 from ..interface import (
     DEFAULT_COMM, add_interface, comm_dup_cached, comm_parent, is_var,
     new_space_id, new_var_id, space_id, space_new, var_assign, var_comm,
@@ -22,7 +22,7 @@ from .interpolation import ExprInterpolation
 from .parameters import (
     copy_parameters, parameters_equal, process_form_compiler_parameters)
 from .projection import Projection
-from .solve import EquationSolver
+from .solve import EquationSolver, LocalEquationSolver
 from .variables import (
     Constant, ConstantInterface, ConstantSpaceInterface, FunctionInterface,
     FunctionSpaceInterface, define_var_alias)
@@ -716,6 +716,63 @@ def KrylovSolver_solve(self, orig, orig_args, *args):
                            "preconditioner": preconditioner,
                            "krylov_solver": self.parameters},
         form_compiler_parameters=form_compiler_parameters,
+        cache_jacobian=False, cache_rhs_assembly=False)
+
+    eq._pre_process()
+    return_value = orig_args()
+    eq._post_process()
+    return return_value
+
+
+@patch_method(backend_LocalSolver, "__init__")
+def LocalSolver__init__(self, orig, orig_args, a, L=None,
+                        solver_type=backend_LocalSolver.SolverType.LU):
+    orig_args()
+    self._tlm_adjoint__solver_type = solver_type
+    self._tlm_adjoint__factorized = False
+
+
+@patch_method(backend_LocalSolver, "factorize")
+def LocalSolver_factorize(self, orig, orig_args, *args, **kwargs):
+    orig_args()
+    self._tlm_adjoint__factorized = True
+
+
+@patch_method(backend_LocalSolver, "clear_factorization")
+def LocalSolver_clear_factorization(self, orig, orig_args, *args, **kwargs):
+    orig_args()
+    self._tlm_adjoint__factorized = False
+
+
+def LocalSolver_solve_local_pre_call(self, x, b, dofmap_b):
+    if isinstance(x, backend_Function):
+        x = x.vector()
+    if isinstance(b, backend_Function):
+        b = b.vector()
+    return (x, b, dofmap_b), {}
+
+
+def LocalSolver_solve_local_post_call(self, return_value, x, b, dofmap_b):
+    if hasattr(x, "_tlm_adjoint__function"):
+        var_update_state(x._tlm_adjoint__function)
+    return return_value
+
+
+@manager_method(backend_LocalSolver, "solve_local",
+                pre_call=LocalSolver_solve_local_pre_call,
+                post_call=LocalSolver_solve_local_post_call)
+def LocalSolver_solve_local(self, orig, orig_args, x, b, dofmap_b):
+    if isinstance(x, backend_Function):
+        x = x.vector()
+    if isinstance(b, backend_Function):
+        b = b.vector()
+    if self._tlm_adjoint__factorized:
+        raise NotImplementedError("Factorization not supported")
+
+    eq = LocalEquationSolver(
+        self.a_ufl == b._tlm_adjoint__form, x._tlm_adjoint__function,
+        solver_type=self._tlm_adjoint__solver_type,
+        form_compiler_parameters=b._tlm_adjoint__form_compiler_parameters,
         cache_jacobian=False, cache_rhs_assembly=False)
 
     eq._pre_process()

--- a/tlm_adjoint/fenics/backend_patches.py
+++ b/tlm_adjoint/fenics/backend_patches.py
@@ -523,6 +523,14 @@ def Function_vector(self, orig, orig_args):
     return vector
 
 
+@patch_method(backend_Vector, "apply")
+def Vector_apply(self, orig, orig_args, *args, **kwargs):
+    return_value = orig_args()
+    if hasattr(self, "_tlm_adjoint__function"):
+        var_update_state(self._tlm_adjoint__function)
+    return return_value
+
+
 @manager_method(backend_Matrix, "__mul__")
 def Matrix__mul__(self, orig, orig_args, other):
     return_value = orig_args()

--- a/tlm_adjoint/fenics/caches.py
+++ b/tlm_adjoint/fenics/caches.py
@@ -3,8 +3,8 @@ caching.
 """
 
 from .backend import (
-    Parameters, LocalSolver, TrialFunction, backend_DirichletBC,
-    backend_Function)
+    Parameters, TrialFunction, backend_DirichletBC, backend_Function,
+    backend_LocalSolver)
 from ..interface import (
     is_var, var_caches, var_id, var_is_cached, var_is_replacement,
     var_replacement, var_space, var_state)
@@ -12,7 +12,7 @@ from ..interface import (
 from ..caches import Cache
 
 from .backend_interface import (
-    assemble, assemble_matrix, linear_solver, matrix_copy)
+    LocalSolver, assemble, assemble_matrix, linear_solver, matrix_copy)
 from .expr import (
     derivative, eliminate_zeros, expr_zero, extract_coefficients, form_cached,
     replaced_form)
@@ -458,17 +458,17 @@ class LocalSolverCache(Cache):
 
         :arg form: An arity two :class:`ufl.Form`, defining the element-wise
             local block diagonal matrix.
-        :arg local_solver: `dolfin.LocalSolver.SolverType`. Defaults to
+        :arg solver_type: `dolfin.LocalSolver.SolverType`. Defaults to
             `dolfin.LocalSolver.SolverType.LU`.
         :arg replace_map: A :class:`Mapping` defining a map from symbolic
             variables to values.
         :returns: A :class:`tuple` `(value_ref, value)`. `value` is a
-            DOLFIN `LocalSolver` and `value_ref` is a :class:`.CacheRef`
-            storing a reference to `value`.
+            `tlm_adjoint.fenics.backend_interface.LocalSolver` and `value_ref`
+            is a :class:`.CacheRef` storing a reference to `value`.
         """
 
         if solver_type is None:
-            solver_type = LocalSolver.SolverType.LU
+            solver_type = backend_LocalSolver.SolverType.LU
 
         form = eliminate_zeros(form)
         if form.empty():
@@ -482,9 +482,7 @@ class LocalSolverCache(Cache):
                solver_type)
 
         def value():
-            local_solver = LocalSolver(assemble_form, solver_type=solver_type)
-            local_solver.factorize()
-            return local_solver
+            return LocalSolver(assemble_form, solver_type=solver_type)
 
         return self.add(key, value,
                         deps=form_dependencies(form, assemble_form))

--- a/tlm_adjoint/fenics/projection.py
+++ b/tlm_adjoint/fenics/projection.py
@@ -1,13 +1,10 @@
 """Projection operations with FEniCS.
 """
 
-from .backend import LocalSolver, TestFunction, TrialFunction
-from ..interface import var_space, var_update_caches
+from .backend import TestFunction, TrialFunction
+from ..interface import var_space
 
-from ..equation import ZeroAssignment
-
-from .caches import local_solver_cache
-from .solve import EquationSolver
+from .solve import EquationSolver, LocalEquationSolver
 
 try:
     import ufl_legacy as ufl
@@ -42,111 +39,23 @@ class Projection(EquationSolver):
         super().__init__(lhs == rhs, x, *args, **kwargs)
 
 
-class LocalProjection(EquationSolver):
+class LocalProjection(LocalEquationSolver):
     """Represents the solution of a finite element variational problem
     performing a projection onto the space for `x`, for the case where the mass
     matrix is element-wise local block diagonal.
 
     :arg x: A DOLFIN `Function` defining the forward solution.
     :arg rhs: A :class:`ufl.core.expr.Expr` defining the expression to project
-        onto the space for `x`, or a :class:`ufl.Form` defining the
-        right-hand-side of the finite element variational problem. Should not
-        depend on `x`.
+        onto the space for `x`. Should not depend on `x`.
 
     Remaining arguments are passed to the
-    :class:`tlm_adjoint.fenics.solve.EquationSolver` constructor.
+    :class:`tlm_adjoint.fenics.solve.LocalEquationSolver` constructor.
     """
 
-    def __init__(self, x, rhs, *,
-                 form_compiler_parameters=None, cache_jacobian=None,
-                 cache_rhs_assembly=None, match_quadrature=None):
-        if form_compiler_parameters is None:
-            form_compiler_parameters = {}
-
-        space = x.function_space()
+    def __init__(self, x, rhs, *args, **kwargs):
+        space = var_space(x)
         test, trial = TestFunction(space), TrialFunction(space)
         lhs = ufl.inner(trial, test) * ufl.dx
-        if not isinstance(rhs, ufl.classes.Form):
-            rhs = ufl.inner(rhs, test) * ufl.dx
+        rhs = ufl.inner(rhs, test) * ufl.dx
 
-        super().__init__(
-            lhs == rhs, x,
-            form_compiler_parameters=form_compiler_parameters,
-            solver_parameters={"linear_solver": "direct"},
-            cache_jacobian=cache_jacobian,
-            cache_rhs_assembly=cache_rhs_assembly,
-            match_quadrature=match_quadrature)
-        self._local_solver_type = LocalSolver.SolverType.Cholesky
-
-    def _local_solver(self, *args, cache_key=None, **kwargs):
-        if cache_key is None:
-            return self._assemble_local_solver(*args, **kwargs)
-        else:
-            return self._assemble_local_solver_cached(
-                cache_key, *args, **kwargs)
-
-    def _assemble_local_solver(self, form, *,
-                               eq_deps, deps):
-        if deps is not None:
-            assert len(eq_deps) == len(deps)
-            form = ufl.replace(form, dict(zip(eq_deps, deps)))
-
-        return LocalSolver(
-            form, solver_type=self._local_solver_type)
-
-    def _assemble_local_solver_cached(self, key, form, *,
-                                      eq_deps, deps):
-        if deps is not None:
-            assert len(eq_deps) == len(deps)
-            replace_map = dict(zip(eq_deps, deps))
-        else:
-            replace_map = None
-
-        var_update_caches(*eq_deps, value=deps)
-        value = self._solver_cache[key]()
-        if value is None:
-            self._solver_cache[key], value = \
-                local_solver_cache().local_solver(
-                    form, self._local_solver_type,
-                    replace_map=replace_map)
-        return value
-
-    def forward_solve(self, x, deps=None):
-        eq_deps = self.dependencies()
-
-        assert self._linear
-        assert len(self._hbcs) == 0
-        x_0, b = self._assemble_rhs(x, (), deps=deps)
-        assert x_0 is x
-
-        J_solver = self._local_solver(
-            self._J, eq_deps=eq_deps, deps=deps,
-            cache_key="J_solver_local" if self._cache_jacobian else None)
-
-        J_solver.solve_local(x.vector(), b, x.function_space().dofmap())
-
-    def adjoint_jacobian_solve(self, adj_x, nl_deps, b):
-        adj_x = self.new_adj_x()
-        eq_nl_deps = self.nonlinear_dependencies()
-
-        assert len(self._hbcs) == 0
-        J_solver = self._local_solver(
-            self._J, eq_deps=eq_nl_deps, deps=nl_deps,
-            cache_key="J_solver_local" if self._cache_jacobian else None)
-
-        J_solver.solve_local(adj_x.vector(), b.vector(),
-                             adj_x.function_space().dofmap())
-        return adj_x
-
-    def tangent_linear(self, M, dM, tlm_map):
-        x = self.x()
-        tlm_rhs = self._tangent_linear_rhs(tlm_map)
-        assert len(self._hbcs) == 0
-        if tlm_rhs.empty():
-            return ZeroAssignment(tlm_map[x])
-        else:
-            return LocalProjection(
-                tlm_map[x], tlm_rhs,
-                form_compiler_parameters=self._form_compiler_parameters,
-                cache_jacobian=self._cache_jacobian,
-                cache_rhs_assembly=self._cache_rhs_assembly)
+        super().__init__(lhs == rhs, x, *args, **kwargs)

--- a/tlm_adjoint/fenics/projection.py
+++ b/tlm_adjoint/fenics/projection.py
@@ -27,9 +27,7 @@ class Projection(EquationSolver):
 
     :arg x: A DOLFIN `Function` defining the forward solution.
     :arg rhs: A :class:`ufl.core.expr.Expr` defining the expression to project
-        onto the space for `x`, or a :class:`ufl.Form` defining the
-        right-hand-side of the finite element variational problem. Should not
-        depend on `x`.
+        onto the space for `x`. Should not depend on `x`.
 
     Remaining arguments are passed to the
     :class:`tlm_adjoint.fenics.solve.EquationSolver` constructor.
@@ -38,10 +36,10 @@ class Projection(EquationSolver):
     def __init__(self, x, rhs, *args, **kwargs):
         space = var_space(x)
         test, trial = TestFunction(space), TrialFunction(space)
-        if not isinstance(rhs, ufl.classes.Form):
-            rhs = ufl.inner(rhs, test) * ufl.dx
-        super().__init__(ufl.inner(trial, test) * ufl.dx == rhs, x,
-                         *args, **kwargs)
+        lhs = ufl.inner(trial, test) * ufl.dx
+        rhs = ufl.inner(rhs, test) * ufl.dx
+
+        super().__init__(lhs == rhs, x, *args, **kwargs)
 
 
 class LocalProjection(EquationSolver):

--- a/tlm_adjoint/firedrake/backend_patches.py
+++ b/tlm_adjoint/firedrake/backend_patches.py
@@ -11,7 +11,7 @@ from ..interface import (
 
 from ..equation import ZeroAssignment
 from ..equations import Assignment, LinearCombination
-from ..manager import annotation_enabled, paused_manager, tlm_enabled
+from ..manager import annotation_enabled, tlm_enabled
 from ..patch import (
     add_manager_controls, manager_method, patch_function, patch_method,
     patch_property)
@@ -138,12 +138,11 @@ def Constant_init_assign(self, value):
         eq._post_process()
 
 
-@patch_method(backend_Constant, "__init__")
+@manager_method(backend_Constant, "__init__", patch_without_manager=True)
 def backend_Constant__init__(self, orig, orig_args, value, domain=None, *,
                              name=None, space=None, comm=None,
                              **kwargs):
-    with paused_manager():
-        orig(self, value, domain=domain, name=name, **kwargs)
+    orig(self, value, domain=domain, name=name, **kwargs)
 
     if name is None:
         name = self.name

--- a/tlm_adjoint/firedrake/projection.py
+++ b/tlm_adjoint/firedrake/projection.py
@@ -2,12 +2,9 @@
 """
 
 from .backend import TestFunction, TrialFunction
-from ..interface import var_space, var_update_caches
+from ..interface import var_space
 
-from ..equation import ZeroAssignment
-
-from .caches import LocalSolver, local_solver_cache
-from .solve import EquationSolver
+from .solve import EquationSolver, LocalEquationSolver
 
 import ufl
 
@@ -40,7 +37,7 @@ class Projection(EquationSolver):
         super().__init__(lhs == rhs, x, *args, **kwargs)
 
 
-class LocalProjection(EquationSolver):
+class LocalProjection(LocalEquationSolver):
     """Represents the solution of a finite element variational problem
     performing a projection onto the space for `x`, for the case where the mass
     matrix is element-wise local block diagonal.
@@ -48,103 +45,16 @@ class LocalProjection(EquationSolver):
     :arg x: A :class:`firedrake.function.Function` defining the forward
         solution.
     :arg rhs: A :class:`ufl.core.expr.Expr` defining the expression to project
-        onto the space for `x`, or a :class:`ufl.form.BaseForm` defining the
-        right-hand-side of the finite element variational problem. Should not
-        depend on `x`.
+        onto the space for `x`. Should not depend on `x`.
 
     Remaining arguments are passed to the
-    :class:`tlm_adjoint.firedrake.solve.EquationSolver` constructor.
+    :class:`tlm_adjoint.firedrake.solve.LocalEquationSolver` constructor.
     """
 
-    def __init__(self, x, rhs, *,
-                 form_compiler_parameters=None, cache_jacobian=None,
-                 cache_rhs_assembly=None, match_quadrature=None):
-        if form_compiler_parameters is None:
-            form_compiler_parameters = {}
-
-        space = x.function_space()
+    def __init__(self, x, rhs, *args, **kwargs):
+        space = var_space(x)
         test, trial = TestFunction(space), TrialFunction(space)
         lhs = ufl.inner(trial, test) * ufl.dx
-        if not isinstance(rhs, ufl.classes.BaseForm):
-            rhs = ufl.inner(rhs, test) * ufl.dx
+        rhs = ufl.inner(rhs, test) * ufl.dx
 
-        super().__init__(
-            lhs == rhs, x,
-            form_compiler_parameters=form_compiler_parameters,
-            solver_parameters={},
-            cache_jacobian=cache_jacobian,
-            cache_rhs_assembly=cache_rhs_assembly,
-            match_quadrature=match_quadrature)
-
-    def _local_solver(self, *args, cache_key=None, **kwargs):
-        if cache_key is None:
-            return self._assemble_local_solver(*args, **kwargs)
-        else:
-            return self._assemble_local_solver_cached(
-                cache_key, *args, **kwargs)
-
-    def _assemble_local_solver(self, form, *,
-                               eq_deps, deps):
-        if deps is not None:
-            assert len(eq_deps) == len(deps)
-            form = ufl.replace(form, dict(zip(eq_deps, deps)))
-
-        return LocalSolver(
-            form, form_compiler_parameters=self._form_compiler_parameters)
-
-    def _assemble_local_solver_cached(self, key, form, *,
-                                      eq_deps, deps):
-        if deps is not None:
-            assert len(eq_deps) == len(deps)
-            replace_map = dict(zip(eq_deps, deps))
-        else:
-            replace_map = None
-
-        var_update_caches(*eq_deps, value=deps)
-        value = self._solver_cache[key]()
-        if value is None:
-            self._solver_cache[key], value = \
-                local_solver_cache().local_solver(
-                    form,
-                    form_compiler_parameters=self._form_compiler_parameters,
-                    replace_map=replace_map)
-        return value
-
-    def forward_solve(self, x, deps=None):
-        eq_deps = self.dependencies()
-
-        assert self._linear
-        assert len(self._hbcs) == 0
-        x_0, b = self._assemble_rhs(x, (), deps=deps)
-        assert x_0 is x
-
-        J_solver = self._local_solver(
-            self._J, eq_deps=eq_deps, deps=deps,
-            cache_key="J_solver_local" if self._cache_jacobian else None)
-
-        J_solver._tlm_adjoint__solve_local(x, b)
-
-    def adjoint_jacobian_solve(self, adj_x, nl_deps, b):
-        eq_nl_deps = self.nonlinear_dependencies()
-
-        assert len(self._hbcs) == 0
-        J_solver = self._local_solver(
-            self._J, eq_deps=eq_nl_deps, deps=nl_deps,
-            cache_key="J_solver_local" if self._cache_jacobian else None)
-
-        adj_x = self.new_adj_x()
-        J_solver._tlm_adjoint__solve_local(adj_x, b)
-        return adj_x
-
-    def tangent_linear(self, M, dM, tlm_map):
-        x = self.x()
-        tlm_rhs = self._tangent_linear_rhs(tlm_map)
-        assert len(self._hbcs) == 0
-        if isinstance(tlm_rhs, ufl.classes.ZeroBaseForm):
-            return ZeroAssignment(tlm_map[x])
-        else:
-            return LocalProjection(
-                tlm_map[x], tlm_rhs,
-                form_compiler_parameters=self._form_compiler_parameters,
-                cache_jacobian=self._cache_jacobian,
-                cache_rhs_assembly=self._cache_rhs_assembly)
+        super().__init__(lhs == rhs, x, *args, **kwargs)

--- a/tlm_adjoint/firedrake/projection.py
+++ b/tlm_adjoint/firedrake/projection.py
@@ -25,9 +25,7 @@ class Projection(EquationSolver):
     :arg x: A :class:`firedrake.function.Function` defining the forward
         solution.
     :arg rhs: A :class:`ufl.core.expr.Expr` defining the expression to project
-        onto the space for `x`, or a :class:`ufl.form.BaseForm` defining the
-        right-hand-side of the finite element variational problem. Should not
-        depend on `x`.
+        onto the space for `x`. Should not depend on `x`.
 
     Remaining arguments are passed to the
     :class:`tlm_adjoint.firedrake.solve.EquationSolver` constructor.
@@ -36,10 +34,10 @@ class Projection(EquationSolver):
     def __init__(self, x, rhs, *args, **kwargs):
         space = var_space(x)
         test, trial = TestFunction(space), TrialFunction(space)
-        if not isinstance(rhs, ufl.classes.BaseForm):
-            rhs = ufl.inner(rhs, test) * ufl.dx
-        super().__init__(ufl.inner(trial, test) * ufl.dx == rhs, x,
-                         *args, **kwargs)
+        lhs = ufl.inner(trial, test) * ufl.dx
+        rhs = ufl.inner(rhs, test) * ufl.dx
+
+        super().__init__(lhs == rhs, x, *args, **kwargs)
 
 
 class LocalProjection(EquationSolver):

--- a/tlm_adjoint/firedrake/solve.py
+++ b/tlm_adjoint/firedrake/solve.py
@@ -10,8 +10,10 @@ from ..caches import CacheRef
 from ..equation import ZeroAssignment
 
 from .backend_interface import (
-    assemble, assemble_linear_solver, matrix_multiply, solve)
-from .caches import assembly_cache, is_cached, linear_solver_cache, split_form
+    LocalSolver, assemble, assemble_linear_solver, matrix_multiply, solve)
+from .caches import (
+    assembly_cache, is_cached, linear_solver_cache, local_solver_cache,
+    split_form)
 from .expr import (
     ExprEquation, derivative, eliminate_zeros, expr_zero, extract_coefficients,
     extract_dependencies, iter_expr)
@@ -25,7 +27,8 @@ import ufl
 
 __all__ = \
     [
-        "EquationSolver"
+        "EquationSolver",
+        "LocalEquationSolver"
     ]
 
 
@@ -424,10 +427,11 @@ class EquationSolver(ExprEquation):
             assert len(eq_deps) == len(deps)
             form = ufl.replace(form, dict(zip(eq_deps, deps)))
 
-        return assemble_linear_solver(
+        solver, _, b_bc = assemble_linear_solver(
             form, bcs=bcs,
             form_compiler_parameters=self._form_compiler_parameters,
             linear_solver_parameters=linear_solver_parameters)
+        return solver, b_bc
 
     def _assemble_linear_solver_cached(self, key, form, bcs, *,
                                        linear_solver_parameters,
@@ -447,7 +451,8 @@ class EquationSolver(ExprEquation):
                     form_compiler_parameters=self._form_compiler_parameters,
                     linear_solver_parameters=linear_solver_parameters,
                     replace_map=replace_map)
-        return value
+        solver, _, b_bc = value
+        return solver, b_bc
 
     def forward_solve(self, x, deps=None):
         eq_deps = self.dependencies()
@@ -456,7 +461,7 @@ class EquationSolver(ExprEquation):
         if self._linear:
             x_0, b = self._assemble_rhs(x, bcs, deps=deps)
 
-            J_solver, _, _ = self._linear_solver(
+            J_solver, _ = self._linear_solver(
                 self._J, bcs=self._hbcs,
                 linear_solver_parameters=self._linear_solver_parameters,
                 eq_deps=eq_deps, deps=deps,
@@ -561,7 +566,7 @@ class EquationSolver(ExprEquation):
             adj_x = self.new_adj_x()
         eq_nl_deps = self.nonlinear_dependencies()
 
-        J_solver, _, _ = self._linear_solver(
+        J_solver, _ = self._linear_solver(
             adjoint(self._J), bcs=self._hbcs,
             linear_solver_parameters=self._adjoint_solver_parameters,
             eq_deps=eq_nl_deps, deps=nl_deps,
@@ -607,6 +612,81 @@ class EquationSolver(ExprEquation):
                 solver_parameters=self._tlm_solver_parameters,
                 adjoint_solver_parameters=self._adjoint_solver_parameters,
                 tlm_solver_parameters=self._tlm_solver_parameters,
+                cache_jacobian=self._cache_tlm_jacobian,
+                cache_adjoint_jacobian=self._cache_adjoint_jacobian,
+                cache_tlm_jacobian=self._cache_tlm_jacobian,
+                cache_rhs_assembly=self._cache_rhs_assembly)
+
+
+class LocalEquationSolver(EquationSolver):
+    """Represents the solution of a linear finite element variational problem,
+    for the case where the matrix is element-wise local block diagonal.
+
+    Remaining arguments are passed to the :class:`.EquationSolver` constructor.
+    """
+
+    def __init__(self, eq, x, *,
+                 form_compiler_parameters=None, cache_jacobian=None,
+                 cache_adjoint_jacobian=None, cache_tlm_jacobian=None,
+                 cache_rhs_assembly=None, match_quadrature=None):
+        super().__init__(
+            eq, x,
+            form_compiler_parameters=form_compiler_parameters,
+            solver_parameters={"ksp_type": "preonly",
+                               "pc_type": "lu"},
+            cache_jacobian=cache_jacobian,
+            cache_adjoint_jacobian=cache_adjoint_jacobian,
+            cache_tlm_jacobian=cache_tlm_jacobian,
+            cache_rhs_assembly=cache_rhs_assembly,
+            match_quadrature=match_quadrature)
+        if not self._linear:
+            raise ValueError("Must be a linear variational problem")
+
+    def _assemble_linear_solver(self, form, bcs, *,
+                                linear_solver_parameters,
+                                eq_deps, deps):
+        if len(bcs) > 0:
+            raise ValueError("Unexpected boundary conditions")
+        if deps is not None:
+            assert len(eq_deps) == len(deps)
+            form = ufl.replace(form, dict(zip(eq_deps, deps)))
+
+        solver = LocalSolver(
+            form, form_compiler_parameters=self._form_compiler_parameters)
+        return solver, None
+
+    def _assemble_linear_solver_cached(self, key, form, bcs, *,
+                                       linear_solver_parameters,
+                                       eq_deps, deps):
+        if len(bcs) > 0:
+            raise ValueError("Unexpected boundary conditions")
+        if deps is not None:
+            assert len(eq_deps) == len(deps)
+            replace_map = dict(zip(eq_deps, deps))
+        else:
+            replace_map = None
+
+        var_update_caches(*eq_deps, value=deps)
+        value = self._solver_cache[key]()
+        if value is None:
+            self._solver_cache[key], value = \
+                local_solver_cache().local_solver(
+                    form,
+                    form_compiler_parameters=self._form_compiler_parameters,
+                    replace_map=replace_map)
+        return value, None
+
+    def tangent_linear(self, M, dM, tlm_map):
+        x = self.x()
+        tlm_rhs = self._tangent_linear_rhs(tlm_map)
+        if len(self._hbcs) != 0:
+            raise RuntimeError("Unexpected boundary conditions")
+        if tlm_rhs.empty():
+            return ZeroAssignment(tlm_map[x])
+        else:
+            return LocalEquationSolver(
+                self._J == tlm_rhs, tlm_map[x],
+                form_compiler_parameters=self._form_compiler_parameters,
                 cache_jacobian=self._cache_tlm_jacobian,
                 cache_adjoint_jacobian=self._cache_adjoint_jacobian,
                 cache_tlm_jacobian=self._cache_tlm_jacobian,


### PR DESCRIPTION
Previously `Projection` and `LocalProjection` could be supplied with a form, but this is fragile with the introduction of Firedrake `Cofunction`s.

Also:

- Add `LocalEquationSolver`, a superclass of `LocalProjection`.
- FEniCS backend: Annotate `LocalSolver.solve_local`.
- FEniCS backend: Add a state update in `Vector.apply`.
- Firedrake backend: Update test_EquationSolver_DirichletBC.