### PR TITLE
Firedrake backend: Do not manually update `dat_version`

### DIFF
--- a/tests/firedrake/test_caches.py
+++ b/tests/firedrake/test_caches.py
@@ -57,7 +57,9 @@ def test_clear_caches(setup_test, test_leaks):
     # Clear on state update
     cached_form = cache_item(F)
     test_not_cleared(F, cached_form)
-    var_update_state(F)
+    with F.dat.vec as F_v:
+        F_v.shift(1.0)
+    var_update_caches(F)
     test_cleared(F, cached_form)
 
     # Clear on cache update, new Function
@@ -77,13 +79,17 @@ def test_clear_caches(setup_test, test_leaks):
     # Clear on state update of value
     cached_form = cache_item(F, F_value)
     test_not_cleared(F, cached_form, F_value)
-    var_update_state(F_value)
+    with F_value.dat.vec as F_v:
+        F_v.shift(1.0)
+    var_update_caches(F, value=F_value)
     test_cleared(F, cached_form, F_value)
 
     # Clear on state update of value, replacement
     cached_form = cache_item(var_replacement(F), F_value)
     test_not_cleared(F, cached_form, F_value)
-    var_update_state(F_value)
+    with F_value.dat.vec as F_v:
+        F_v.shift(1.0)
+    var_update_caches(var_replacement(F), value=F_value)
     test_cleared(F, cached_form, F_value)
 
 

--- a/tests/firedrake/test_interface.py
+++ b/tests/firedrake/test_interface.py
@@ -140,17 +140,15 @@ def test_var_alias(setup_test, test_leaks,
         *[space.ufl_element() for _ in range(dim)]))
 
     def test_state(F, F_i):
-        state = var_state(F_i)
-        assert var_state(F_i) == var_state(F)
-        var_update_state(F)
-        assert var_state(F_i) > state
-        assert var_state(F_i) == var_state(F)
+        state_i = var_state(F_i)
+        with F.dat.vec as F_v:
+            F_v.shift(1.0)
+        assert var_state(F_i) > state_i
 
-        state = var_state(F_i)
-        assert var_state(F_i) == var_state(F)
-        var_update_state(F_i)
-        assert var_state(F_i) > state
-        assert var_state(F_i) == var_state(F)
+        state = var_state(F)
+        with F_i.dat.vec as F_i_v:
+            F_i_v.shift(1.0)
+        assert var_state(F) > state
 
     F = cls(space, name="F")
     for F_i in F.subfunctions:

--- a/tlm_adjoint/firedrake/backend_patches.py
+++ b/tlm_adjoint/firedrake/backend_patches.py
@@ -262,7 +262,6 @@ def Function__init__(self, orig, orig_args, function_space, val=None,
     orig_args()
     add_interface(self, FunctionInterface,
                   {"comm": comm_dup_cached(self.comm), "id": new_var_id(),
-                   "state": [self.dat, getattr(self.dat, "dat_version", None)],
                    "space_type": "primal", "static": False, "cache": False,
                    "replacement_count": new_count(self._counted_class)})
     if isinstance(val, backend_Function):
@@ -436,7 +435,6 @@ def Cofunction__init__(self, orig, orig_args, function_space, val=None,
     orig_args()
     add_interface(self, CofunctionInterface,
                   {"comm": comm_dup_cached(self.comm), "id": new_var_id(),
-                   "state": [self.dat, getattr(self.dat, "dat_version", None)],
                    "space_type": "conjugate_dual", "static": False,
                    "cache": False,
                    "replacement_count": new_count(self._counted_class)})

--- a/tlm_adjoint/firedrake/variables.py
+++ b/tlm_adjoint/firedrake/variables.py
@@ -387,19 +387,10 @@ class FunctionInterfaceBase(VariableInterface):
         return self.name()
 
     def _state(self):
-        dat, count = self._tlm_adjoint__var_interface_attrs["state"]
-        if count is not None and count > dat.dat_version:
-            raise RuntimeError("Invalid state")
-        return dat.dat_version
+        return self.dat.dat_version
 
     def _update_state(self):
-        dat, count = self._tlm_adjoint__var_interface_attrs["state"]
-        if count is None or count == dat.dat_version:
-            # Make sure that the dat version has been incremented at least once
-            dat.increment_dat_version()
-        elif count > dat.dat_version:
-            raise RuntimeError("Invalid state")
-        self._tlm_adjoint__var_interface_attrs["state"][1] = dat.dat_version
+        pass
 
     def _is_static(self):
         return self._tlm_adjoint__var_interface_attrs["static"]
@@ -773,8 +764,9 @@ def define_var_alias(x, parent, *, key):
                 "static", var_is_static(parent))
             x._tlm_adjoint__var_interface_attrs.d_setitem(
                 "cache", var_is_cached(parent))
-            x._tlm_adjoint__var_interface_attrs.d_setitem(
-                "state", parent._tlm_adjoint__var_interface_attrs["state"])
+            if hasattr(x._tlm_adjoint__var_interface_attrs, "state"):
+                x._tlm_adjoint__var_interface_attrs.d_setitem(
+                    "state", parent._tlm_adjoint__var_interface_attrs["state"])
 
 
 register_subtract_adjoint_derivative_action(

--- a/tlm_adjoint/interface.py
+++ b/tlm_adjoint/interface.py
@@ -1057,11 +1057,7 @@ def var_locked(*X):
 
 def var_update_state(*X):
     """Ensure that variable state is updated, and check for cache invalidation.
-
-    May delegate updating of the state to a backend library, in which case this
-    function checks that the state has been updated since the last
-    :func:`.var_update_state` call (or since instantiation on the first call),
-    and updates the backend state again only if needed.
+    May delegate updating of the state to a backend library.
 
     :arg X: A :class:`tuple` of variables.
     """


### PR DESCRIPTION
Catches many important cases of extra cache invalidation in #180.