### PR TITLE
FEniCS/Firedrake backends: `derivative` improvements

### DIFF
--- a/tests/fenics/test_equations.py
+++ b/tests/fenics/test_equations.py
@@ -1,7 +1,7 @@
 from fenics import *
 from tlm_adjoint.fenics import *
 from tlm_adjoint.fenics.backend_interface import assemble_linear_solver
-from tlm_adjoint.fenics.expr import extract_coefficients
+from tlm_adjoint.fenics.expr import extract_variables
 
 from .test_base import *
 
@@ -898,8 +898,8 @@ def test_ZeroFunction_expand_derivatives(setup_test, test_leaks):
     F = ZeroFunction(space, name="F")
 
     expr = ufl.algorithms.expand_derivatives(F.dx(0))
-    assert F in extract_coefficients(expr)
-    assert F not in extract_coefficients(eliminate_zeros(expr))
+    assert F in extract_variables(expr)
+    assert F not in extract_variables(eliminate_zeros(expr))
 
 
 @pytest.mark.fenics

--- a/tests/firedrake/test_equations.py
+++ b/tests/firedrake/test_equations.py
@@ -1,7 +1,7 @@
 from firedrake import *
 from tlm_adjoint.firedrake import *
 from tlm_adjoint.firedrake.backend_interface import assemble_linear_solver
-from tlm_adjoint.firedrake.expr import extract_coefficients
+from tlm_adjoint.firedrake.expr import extract_variables
 
 from .test_base import *
 
@@ -1331,8 +1331,8 @@ def test_ZeroFunction_expand_derivatives(setup_test, test_leaks):
     F = ZeroFunction(space, name="F")
 
     expr = ufl.algorithms.expand_derivatives(F.dx(0))
-    assert F in extract_coefficients(expr)
-    assert F not in extract_coefficients(eliminate_zeros(expr))
+    assert F in extract_variables(expr)
+    assert F not in extract_variables(eliminate_zeros(expr))
 
 
 @pytest.mark.firedrake

--- a/tlm_adjoint/fenics/assembly.py
+++ b/tlm_adjoint/fenics/assembly.py
@@ -125,7 +125,6 @@ class Assembly(ExprEquation):
 
         dep = eq_deps[dep_index]
         dF = derivative(self._rhs, dep)
-        dF = ufl.algorithms.expand_derivatives(dF)
         dF = eliminate_zeros(dF)
         if dF.empty():
             return None
@@ -159,7 +158,6 @@ class Assembly(ExprEquation):
                 if tau_dep is not None:
                     tlm_rhs = tlm_rhs + derivative(self._rhs, dep, argument=tau_dep)  # noqa: E501
 
-        tlm_rhs = ufl.algorithms.expand_derivatives(tlm_rhs)
         if tlm_rhs.empty():
             return ZeroAssignment(tlm_map[x])
         else:

--- a/tlm_adjoint/fenics/assembly.py
+++ b/tlm_adjoint/fenics/assembly.py
@@ -10,7 +10,8 @@ from ..equation import ZeroAssignment
 
 from .backend_interface import assemble
 from .expr import (
-    ExprEquation, derivative, eliminate_zeros, expr_zero, extract_dependencies)
+    ExprEquation, action, derivative, eliminate_zeros, expr_zero,
+    extract_dependencies)
 from .parameters import (
     form_compiler_quadrature_parameters, process_form_compiler_parameters,
     update_parameters)
@@ -131,14 +132,15 @@ class Assembly(ExprEquation):
 
         dF = self._nonlinear_replace(dF, nl_deps)
         if self._arity == 0:
+            # dF = adjoint(dF)
             dF = ufl.classes.Form(
                 [integral.reconstruct(integrand=ufl.conj(integral.integrand()))
-                 for integral in dF.integrals()])  # dF = adjoint(dF)
+                 for integral in dF.integrals()])
             dF = assemble(
                 dF, form_compiler_parameters=self._form_compiler_parameters)
             return (-var_scalar_value(adj_x), dF)
         elif self._arity == 1:
-            dF = ufl.action(adjoint(dF), coefficient=adj_x)
+            dF = action(adjoint(dF), adj_x)
             dF = assemble(
                 dF, form_compiler_parameters=self._form_compiler_parameters)
             return (-1.0, dF)

--- a/tlm_adjoint/fenics/backend.py
+++ b/tlm_adjoint/fenics/backend.py
@@ -22,6 +22,7 @@ backend_FunctionSpace = FunctionSpace
 backend_LocalSolver = LocalSolver
 backend_Matrix = fenics.cpp.la.GenericMatrix
 backend_Vector = fenics.cpp.la.GenericVector
+backend_action = action
 backend_assemble = assemble
 backend_assemble_system = assemble_system
 backend_project = project

--- a/tlm_adjoint/fenics/backend_patches.py
+++ b/tlm_adjoint/fenics/backend_patches.py
@@ -17,7 +17,7 @@ from ..patch import (
 
 from .assembly import Assembly
 from .backend_interface import linear_solver
-from .expr import extract_coefficients, new_count
+from .expr import extract_coefficients, extract_variables, new_count
 from .interpolation import ExprInterpolation
 from .parameters import (
     copy_parameters, parameters_equal, process_form_compiler_parameters)
@@ -46,7 +46,7 @@ __all__ = \
 
 
 def expr_new_x(expr, x):
-    if x in extract_coefficients(expr):
+    if x in extract_variables(expr):
         x_old = var_new(x)
         x_old.assign(x)
         return ufl.replace(expr, {x: x_old})
@@ -56,8 +56,8 @@ def expr_new_x(expr, x):
 
 def linear_equation_new_x(eq, x):
     lhs, rhs = eq.lhs, eq.rhs
-    lhs_x_dep = x in extract_coefficients(lhs)
-    rhs_x_dep = x in extract_coefficients(rhs)
+    lhs_x_dep = x in extract_variables(lhs)
+    rhs_x_dep = x in extract_variables(rhs)
     if lhs_x_dep or rhs_x_dep:
         x_old = var_new(x)
         x_old.assign(x)

--- a/tlm_adjoint/fenics/backend_patches.py
+++ b/tlm_adjoint/fenics/backend_patches.py
@@ -17,7 +17,7 @@ from ..patch import (
 
 from .assembly import Assembly
 from .backend_interface import linear_solver
-from .expr import extract_coefficients, extract_variables, new_count
+from .expr import action, extract_coefficients, extract_variables, new_count
 from .interpolation import ExprInterpolation
 from .parameters import (
     copy_parameters, parameters_equal, process_form_compiler_parameters)
@@ -537,9 +537,8 @@ def Matrix__mul__(self, orig, orig_args, other):
         if len(self._tlm_adjoint__bcs) > 0:
             raise NotImplementedError("Boundary conditions not supported")
 
-        return_value._tlm_adjoint__form = ufl.action(
-            self._tlm_adjoint__form,
-            coefficient=other._tlm_adjoint__function)
+        return_value._tlm_adjoint__form = action(
+            self._tlm_adjoint__form, other._tlm_adjoint__function)
         return_value._tlm_adjoint__bcs = []
         return_value._tlm_adjoint__form_compiler_parameters \
             = self._tlm_adjoint__form_compiler_parameters

--- a/tlm_adjoint/fenics/caches.py
+++ b/tlm_adjoint/fenics/caches.py
@@ -104,14 +104,12 @@ def split_arity(form, x, argument):
 
     form_derivative = derivative(form, x, argument=argument,
                                  enable_automatic_argument=False)
-    form_derivative = ufl.algorithms.expand_derivatives(form_derivative)
     if x in extract_coefficients(form_derivative):
         # Non-linear
         return ufl.classes.Form([]), form
 
     try:
-        eq_form = ufl.algorithms.expand_derivatives(
-            ufl.replace(form, {x: argument}))
+        eq_form = ufl.replace(form, {x: argument})
         A = ufl.algorithms.formtransformations.compute_form_with_arity(
             eq_form, arity + 1)
         b = ufl.algorithms.formtransformations.compute_form_with_arity(

--- a/tlm_adjoint/fenics/expr.py
+++ b/tlm_adjoint/fenics/expr.py
@@ -3,7 +3,7 @@
 
 from .backend import (
     FunctionSpace, TensorFunctionSpace, TestFunction, TrialFunction,
-    VectorFunctionSpace, backend_Constant, backend_Function,
+    VectorFunctionSpace, backend_action, backend_Constant, backend_Function,
     backend_ScalarType, cpp_Constant)
 from ..interface import (
     VariableStateChangeError, add_replacement_interface, check_space_type,
@@ -167,7 +167,7 @@ def _derivative(expr, x, argument=None):
                 dexpr = ufl.derivative(expr, x)
                 dexpr = ufl.algorithms.expand_derivatives(dexpr)
                 if not dexpr.empty():
-                    dexpr = ufl.action(dexpr, argument)
+                    dexpr = action(dexpr, argument)
         else:
             raise TypeError(f"Unexpected type: {type(expr)}")
     return dexpr
@@ -191,6 +191,10 @@ def derivative(expr, x, argument=None, *,
                 raise ValueError("Invalid argument")
 
     return _derivative(expr, x, argument=argument)
+
+
+def action(form, coefficient):
+    return backend_action(form, coefficient=coefficient)
 
 
 class Zero:

--- a/tlm_adjoint/fenics/interpolation.py
+++ b/tlm_adjoint/fenics/interpolation.py
@@ -16,8 +16,8 @@ from ..linear_equation import LinearEquation, Matrix
 from ..manager import manager_disabled
 
 from .expr import (
-    ExprEquation, derivative, eliminate_zeros, expr_zero, extract_coefficients,
-    extract_dependencies)
+    ExprEquation, derivative, eliminate_zeros, expr_zero, extract_dependencies,
+    extract_variables)
 from .variables import ReplacementConstant
 
 import functools
@@ -43,9 +43,8 @@ def interpolate_expression(x, expr, *, adj_x=None):
     else:
         check_space_type(x, "conjugate_dual")
         check_space_type(adj_x, "conjugate_dual")
-    for dep in extract_coefficients(expr):
-        if is_var(dep):
-            check_space_type(dep, "primal")
+    for dep in extract_variables(expr):
+        check_space_type(dep, "primal")
 
     expr = eliminate_zeros(expr)
 

--- a/tlm_adjoint/fenics/interpolation.py
+++ b/tlm_adjoint/fenics/interpolation.py
@@ -144,7 +144,6 @@ class ExprInterpolation(ExprEquation):
             dF = derivative(self._rhs, dep, argument=ufl.classes.IntValue(1))
         else:
             dF = derivative(self._rhs, dep)
-        dF = ufl.algorithms.expand_derivatives(dF)
         dF = eliminate_zeros(dF)
         dF = self._nonlinear_replace(dF, nl_deps)
 
@@ -166,7 +165,6 @@ class ExprInterpolation(ExprEquation):
                     tlm_rhs = (tlm_rhs
                                + derivative(self._rhs, dep, argument=tau_dep))
 
-        tlm_rhs = ufl.algorithms.expand_derivatives(tlm_rhs)
         if isinstance(tlm_rhs, ufl.classes.Zero):
             return ZeroAssignment(tlm_map[x])
         else:

--- a/tlm_adjoint/fenics/solve.py
+++ b/tlm_adjoint/fenics/solve.py
@@ -156,14 +156,13 @@ class EquationSolver(ExprEquation):
             F = lhs
             nl_solve_J = J
             J = derivative(F, x)
-            J = ufl.algorithms.expand_derivatives(J)
 
         deps, nl_deps = extract_dependencies(F, space_type="primal")
         if nl_solve_J is not None:
             for dep in extract_coefficients(nl_solve_J):
                 if is_var(dep):
                     deps.setdefault(var_id(dep), dep)
-        deps = list(deps.values())
+        deps = sorted(deps.values(), key=var_id)
         if x in deps:
             deps.remove(x)
         deps.insert(0, x)
@@ -412,7 +411,6 @@ class EquationSolver(ExprEquation):
             if dep_index not in self._adjoint_b_cache:
                 dep = self.dependencies()[dep_index]
                 dF = derivative(self._F, dep)
-                dF = ufl.algorithms.expand_derivatives(dF)
                 dF = eliminate_zeros(dF)
                 if not dF.empty():
                     dF = adjoint(dF)
@@ -465,7 +463,6 @@ class EquationSolver(ExprEquation):
                 if tau_dep is not None:
                     tlm_rhs = (tlm_rhs
                                - derivative(self._F, dep, argument=tau_dep))
-        tlm_rhs = ufl.algorithms.expand_derivatives(tlm_rhs)
         return tlm_rhs
 
     def tangent_linear(self, tlm_map):

--- a/tlm_adjoint/fenics/solve.py
+++ b/tlm_adjoint/fenics/solve.py
@@ -5,8 +5,8 @@ from .backend import (
     Parameters, adjoint, backend_DirichletBC, backend_LocalSolver,
     backend_solve as solve, parameters)
 from ..interface import (
-    check_space_type, is_var, var_axpy, var_copy, var_id,
-    var_new_conjugate_dual, var_replacement, var_update_caches, var_zero)
+    check_space_type, var_axpy, var_copy, var_id, var_new_conjugate_dual,
+    var_replacement, var_update_caches, var_zero)
 
 from ..caches import CacheRef
 from ..equation import ZeroAssignment
@@ -17,8 +17,8 @@ from .caches import (
     assembly_cache, is_cached, linear_solver_cache, local_solver_cache,
     split_form)
 from .expr import (
-    ExprEquation, derivative, eliminate_zeros, expr_zero, extract_coefficients,
-    extract_dependencies)
+    ExprEquation, derivative, eliminate_zeros, expr_zero, extract_dependencies,
+    extract_variables)
 from .parameters import (
     form_compiler_quadrature_parameters, process_adjoint_solver_parameters,
     process_form_compiler_parameters, process_solver_parameters,
@@ -140,8 +140,8 @@ class EquationSolver(ExprEquation):
                 raise ValueError("Invalid left-hand-side arguments")
             if rhs.arguments() != (lhs.arguments()[0],):
                 raise ValueError("Invalid right-hand-side arguments")
-            if x in extract_coefficients(lhs) \
-                    or x in extract_coefficients(rhs):
+            if x in extract_variables(lhs) \
+                    or x in extract_variables(rhs):
                 raise ValueError("Invalid dependency")
 
             F = ufl.action(lhs, coefficient=x) - rhs
@@ -159,9 +159,8 @@ class EquationSolver(ExprEquation):
 
         deps, nl_deps = extract_dependencies(F, space_type="primal")
         if nl_solve_J is not None:
-            for dep in extract_coefficients(nl_solve_J):
-                if is_var(dep):
-                    deps.setdefault(var_id(dep), dep)
+            for dep in extract_variables(nl_solve_J):
+                deps.setdefault(var_id(dep), dep)
         deps = sorted(deps.values(), key=var_id)
         if x in deps:
             deps.remove(x)

--- a/tlm_adjoint/fenics/solve.py
+++ b/tlm_adjoint/fenics/solve.py
@@ -17,8 +17,8 @@ from .caches import (
     assembly_cache, is_cached, linear_solver_cache, local_solver_cache,
     split_form)
 from .expr import (
-    ExprEquation, derivative, eliminate_zeros, expr_zero, extract_dependencies,
-    extract_variables)
+    ExprEquation, action, derivative, eliminate_zeros, expr_zero,
+    extract_dependencies, extract_variables)
 from .parameters import (
     form_compiler_quadrature_parameters, process_adjoint_solver_parameters,
     process_form_compiler_parameters, process_solver_parameters,
@@ -144,7 +144,7 @@ class EquationSolver(ExprEquation):
                     or x in extract_variables(rhs):
                 raise ValueError("Invalid dependency")
 
-            F = ufl.action(lhs, coefficient=x) - rhs
+            F = action(lhs, x) - rhs
             nl_solve_J = None
             J = lhs
         else:
@@ -170,7 +170,7 @@ class EquationSolver(ExprEquation):
         if len(bcs) == 0:
             rhs_bc = expr_zero(F)
         else:
-            rhs_bc = -ufl.action(J, coefficient=x)
+            rhs_bc = -action(J, x)
         bcs = tuple(map(backend_DirichletBC, bcs))
         hbcs = tuple(map(homogenized_bc, bcs))
 
@@ -424,7 +424,7 @@ class EquationSolver(ExprEquation):
                     dep_B.sub(matrix_multiply(mat, adj_x))
                 else:
                     # Cached form
-                    dF = ufl.action(dF, coefficient=adj_x)
+                    dF = action(dF, adj_x)
                     dF = self._assemble(dF,
                                         eq_deps=eq_nl_deps, deps=nl_deps)
                     dep_B.sub(dF)

--- a/tlm_adjoint/firedrake/assembly.py
+++ b/tlm_adjoint/firedrake/assembly.py
@@ -126,7 +126,6 @@ class Assembly(ExprEquation):
                 for weight, comp in iter_expr(self._rhs):
                     if isinstance(comp, ufl.classes.Form):
                         dF = derivative(weight * comp, dep)
-                        dF = ufl.algorithms.expand_derivatives(dF)
                         dF = eliminate_zeros(dF)
                         if not isinstance(dF, ufl.classes.ZeroBaseForm):
                             dF = ufl.classes.Form(
@@ -142,7 +141,6 @@ class Assembly(ExprEquation):
                             raise NotImplementedError("Complex case not "
                                                       "implemented")
                         dF = derivative(weight * comp, dep)
-                        dF = ufl.algorithms.expand_derivatives(dF)
                         dF = eliminate_zeros(dF)
                         for dF_weight, dF_comp in iter_expr(dF, evaluate_weights=True):  # noqa: E501
                             dF_comp = self._nonlinear_replace(dF_comp, nl_deps)
@@ -161,7 +159,6 @@ class Assembly(ExprEquation):
                                               evaluate_weights=True):
                     if isinstance(comp, ufl.classes.Form):
                         dF = derivative(comp, dep)
-                        dF = ufl.algorithms.expand_derivatives(dF)
                         dF = eliminate_zeros(dF)
                         if not isinstance(dF, ufl.classes.ZeroBaseForm):
                             dF = adjoint(dF)
@@ -172,7 +169,6 @@ class Assembly(ExprEquation):
                             dep_B.sub((-weight.conjugate(), dF))
                     elif isinstance(comp, ufl.classes.Cofunction):
                         dF = derivative(comp, dep)
-                        dF = ufl.algorithms.expand_derivatives(dF)
                         dF = eliminate_zeros(dF)
                         for dF_term_weight, dF_term in iter_expr(weight * dF,
                                                                  evaluate_weights=True):  # noqa: E501
@@ -206,7 +202,6 @@ class Assembly(ExprEquation):
                                    + weight * derivative(comp, dep,
                                                          argument=tau_dep))
 
-        tlm_rhs = ufl.algorithms.expand_derivatives(tlm_rhs)
         if isinstance(tlm_rhs, ufl.classes.ZeroBaseForm):
             return ZeroAssignment(tlm_map[x])
         else:

--- a/tlm_adjoint/firedrake/assembly.py
+++ b/tlm_adjoint/firedrake/assembly.py
@@ -4,14 +4,14 @@
 from .backend import adjoint, complex_mode, parameters
 from ..interface import (
     check_space_type, register_functional_term_eq, var_assign, var_id,
-    var_is_scalar, var_new_conjugate_dual, var_replacement, var_scalar_value)
+    var_is_scalar, var_replacement, var_scalar_value)
 
 from ..equation import ZeroAssignment
 
 from .backend_interface import assemble
 from .expr import (
-    ExprEquation, derivative, eliminate_zeros, expr_zero, extract_dependencies,
-    extract_variables, iter_expr)
+    ExprEquation, action, derivative, eliminate_zeros, expr_zero,
+    extract_dependencies, extract_variables, iter_expr)
 from .parameters import (
     form_compiler_quadrature_parameters, process_form_compiler_parameters,
     update_parameters)
@@ -116,67 +116,41 @@ class Assembly(ExprEquation):
 
     def subtract_adjoint_derivative_actions(self, adj_x, nl_deps, dep_Bs):
         eq_deps = self.dependencies()
-        if self._arity == 0:
-            for dep_index, dep_B in dep_Bs.items():
-                if dep_index <= 0 or dep_index >= len(eq_deps):
-                    raise ValueError("Unexpected dep_index")
-                dep = eq_deps[dep_index]
+        for dep_index, dep_B in dep_Bs.items():
+            if dep_index <= 0 or dep_index >= len(eq_deps):
+                raise ValueError("Unexpected dep_index")
+            dep = eq_deps[dep_index]
 
-                for weight, comp in iter_expr(self._rhs):
-                    if isinstance(comp, ufl.classes.Form):
-                        dF = derivative(weight * comp, dep)
-                        dF = eliminate_zeros(dF)
-                        if not isinstance(dF, ufl.classes.ZeroBaseForm):
-                            dF = ufl.classes.Form(
-                                [integral.reconstruct(integrand=ufl.conj(integral.integrand()))  # noqa: E501
-                                 for integral in dF.integrals()])
-                            dF = self._nonlinear_replace(dF, nl_deps)
-                            dF = assemble(
-                                dF, form_compiler_parameters=self._form_compiler_parameters)  # noqa: E501
-                            dep_B.sub((-var_scalar_value(adj_x), dF))
-                    elif isinstance(comp, ufl.classes.Action):
-                        if complex_mode:
-                            # See Firedrake issue #3346
-                            raise NotImplementedError("Complex case not "
-                                                      "implemented")
-                        dF = derivative(weight * comp, dep)
-                        dF = eliminate_zeros(dF)
-                        for dF_weight, dF_comp in iter_expr(dF, evaluate_weights=True):  # noqa: E501
-                            dF_comp = self._nonlinear_replace(dF_comp, nl_deps)
-                            dF_comp = var_new_conjugate_dual(dep).assign(dF_comp)  # noqa: E501
-                            dep_B.sub((-var_scalar_value(adj_x) * dF_weight.conjugate(), dF_comp))  # noqa: E501
-                    else:
-                        raise TypeError(f"Unexpected type: {type(comp)}")
-        elif self._arity == 1:
-            for dep_index, dep_B in dep_Bs.items():
-                if dep_index <= 0 or dep_index >= len(eq_deps):
-                    raise ValueError("Unexpected dep_index")
-                dep = eq_deps[dep_index]
-
+            for weight, comp in iter_expr(self._rhs,
+                                          evaluate_weights=True):
                 # Note: Ignores weight dependencies
-                for weight, comp in iter_expr(self._rhs,
-                                              evaluate_weights=True):
-                    if isinstance(comp, ufl.classes.Form):
-                        dF = derivative(comp, dep)
-                        dF = eliminate_zeros(dF)
-                        if not isinstance(dF, ufl.classes.ZeroBaseForm):
-                            dF = adjoint(dF)
-                            dF = ufl.action(dF, coefficient=adj_x)
-                            dF = self._nonlinear_replace(dF, nl_deps)
-                            dF = assemble(
-                                dF, form_compiler_parameters=self._form_compiler_parameters)  # noqa: E501
-                            dep_B.sub((-weight.conjugate(), dF))
-                    elif isinstance(comp, ufl.classes.Cofunction):
-                        dF = derivative(comp, dep)
-                        dF = eliminate_zeros(dF)
-                        for dF_term_weight, dF_term in iter_expr(weight * dF,
-                                                                 evaluate_weights=True):  # noqa: E501
-                            assert isinstance(dF_term, ufl.classes.Coargument)
-                            dep_B.sub((-dF_term_weight.conjugate(), adj_x))
-                    else:
-                        raise TypeError(f"Unexpected type: {type(comp)}")
-        else:
-            raise ValueError("Must be an arity 0 or arity 1 form")
+                dF = derivative(comp, dep)
+                for dF_weight, dF_comp in iter_expr(weight * dF):
+                    dF_comp = eliminate_zeros(dF_comp)
+                    if not isinstance(dF_comp, ufl.classes.ZeroBaseForm):
+                        if self._arity == 0:
+                            # dF_comp = adjoint(dF_comp)
+                            if isinstance(dF_comp, ufl.classes.Form):
+                                dF_comp = ufl.classes.Form(
+                                    [integral.reconstruct(integrand=ufl.conj(integral.integrand()))  # noqa: E501
+                                     for integral in dF_comp.integrals()])  # noqa: E501
+                            else:
+                                if complex_mode:
+                                    # See Firedrake issue #3346
+                                    raise NotImplementedError(
+                                        "Complex case not implemented")
+                        else:
+                            assert self._arity == 1
+                            dF_comp = adjoint(dF_comp)
+                            dF_comp = action(dF_comp, adj_x)
+                        dF_comp = self._nonlinear_replace(dF_comp, nl_deps)
+                        dF_comp = assemble(
+                            dF_comp, form_compiler_parameters=self._form_compiler_parameters)  # noqa: E501
+                        if self._arity == 0:
+                            dep_B.sub((-var_scalar_value(adj_x) * dF_weight.conjugate(), dF_comp))  # noqa: E501
+                        else:
+                            assert self._arity == 1
+                            dep_B.sub((-dF_weight.conjugate(), dF_comp))
 
     # def adjoint_derivative_action(self, nl_deps, dep_index, adj_x):
     #     # Derived from EquationSolver.derivative_action (see dolfin-adjoint

--- a/tlm_adjoint/firedrake/assembly.py
+++ b/tlm_adjoint/firedrake/assembly.py
@@ -3,15 +3,15 @@
 
 from .backend import adjoint, complex_mode, parameters
 from ..interface import (
-    check_space_type, is_var, register_functional_term_eq, var_assign, var_id,
+    check_space_type, register_functional_term_eq, var_assign, var_id,
     var_is_scalar, var_new_conjugate_dual, var_replacement, var_scalar_value)
 
 from ..equation import ZeroAssignment
 
 from .backend_interface import assemble
 from .expr import (
-    ExprEquation, derivative, eliminate_zeros, expr_zero, extract_coefficients,
-    extract_dependencies, iter_expr)
+    ExprEquation, derivative, eliminate_zeros, expr_zero, extract_dependencies,
+    extract_variables, iter_expr)
 from .parameters import (
     form_compiler_quadrature_parameters, process_form_compiler_parameters,
     update_parameters)
@@ -57,8 +57,7 @@ class Assembly(ExprEquation):
             match_quadrature = parameters["tlm_adjoint"]["Assembly"]["match_quadrature"]  # noqa: E501
 
         for weight, _ in iter_expr(rhs):
-            if len(tuple(c for c in extract_coefficients(weight)
-                         if is_var(c))) > 0:
+            if len(extract_variables(weight)) > 0:
                 # See Firedrake issue #3292
                 raise NotImplementedError("FormSum weights cannot depend on "
                                           "variables")

--- a/tlm_adjoint/firedrake/assignment.py
+++ b/tlm_adjoint/firedrake/assignment.py
@@ -94,7 +94,6 @@ class ExprAssignment(ExprEquation):
             # dF = action(adjoint(dF), adj_x)
             # Missing a conjugate, see below
             dF = ufl.replace(dF, {test: adj_x})
-            dF = ufl.algorithms.expand_derivatives(dF)
             dF = eliminate_zeros(dF)
             dF = self._nonlinear_replace(dF, nl_deps)
 
@@ -115,7 +114,6 @@ class ExprAssignment(ExprEquation):
                 F = F.riesz_representation("l2")
         else:
             dF = derivative(self._rhs, dep, argument=ufl.classes.IntValue(1))
-            dF = ufl.algorithms.expand_derivatives(dF)
             dF = eliminate_zeros(dF)
             dF = self._nonlinear_replace(dF, nl_deps)
 
@@ -153,7 +151,6 @@ class ExprAssignment(ExprEquation):
                     tlm_rhs = (tlm_rhs
                                + derivative(self._rhs, dep, argument=tau_dep))
 
-        tlm_rhs = ufl.algorithms.expand_derivatives(tlm_rhs)
         if isinstance(tlm_rhs, ufl.classes.Zero):
             return ZeroAssignment(tlm_map[x])
         else:

--- a/tlm_adjoint/firedrake/backend.py
+++ b/tlm_adjoint/firedrake/backend.py
@@ -29,6 +29,7 @@ backend_Function = Function
 backend_FunctionSpace = firedrake.functionspaceimpl.WithGeometry
 backend_Matrix = firedrake.matrix.Matrix
 backend_Vector = Vector
+backend_action = action
 backend_assemble = assemble
 backend_interpolate = interpolate
 backend_project = project

--- a/tlm_adjoint/firedrake/backend_patches.py
+++ b/tlm_adjoint/firedrake/backend_patches.py
@@ -245,6 +245,7 @@ def new_space_id_cached(space):
         mesh._tlm_adjoint__space_ids = {}
     space_ids = mesh._tlm_adjoint__space_ids
 
+    # Work around Firedrake issue #3130
     key = (space, ufl.duals.is_primal(space))
     if key not in space_ids:
         space_ids[key] = new_space_id()

--- a/tlm_adjoint/firedrake/caches.py
+++ b/tlm_adjoint/firedrake/caches.py
@@ -14,8 +14,8 @@ from ..caches import Cache
 from .backend_interface import (
     LocalSolver, assemble, assemble_matrix, linear_solver, matrix_copy)
 from .expr import (
-    derivative, eliminate_zeros, expr_zero, extract_coefficients, form_cached,
-    iter_expr, replaced_form)
+    derivative, eliminate_zeros, expr_zero, extract_coefficients,
+    extract_variables, form_cached, iter_expr, replaced_form)
 from .variables import ReplacementFunction
 
 from collections import defaultdict
@@ -307,8 +307,7 @@ def form_key(*forms):
     key = []
 
     for form in forms:
-        deps = [dep for dep in extract_coefficients(form) if is_var(dep)]
-        deps = sorted(deps, key=var_id)
+        deps = extract_variables(form)
         deps_key = tuple((var_id(dep), var_state(dep)) for dep in deps)
 
         form = replaced_form(form)
@@ -327,19 +326,18 @@ def form_key(*forms):
 def form_dependencies(*forms):
     deps = {}
 
-    for dep in itertools.chain.from_iterable(map(extract_coefficients, forms)):
-        if is_var(dep):
-            dep_id = var_id(dep)
-            if dep_id in deps:
-                dep_old = deps[dep_id]
-                assert (dep is dep_old
-                        or dep is var_replacement(dep_old)
-                        or var_replacement(dep) is dep_old)
-                assert var_caches(dep) is var_caches(dep_old)
-                if var_is_replacement(dep_old):
-                    deps[dep_id] = dep
-            else:
+    for dep in itertools.chain.from_iterable(map(extract_variables, forms)):
+        dep_id = var_id(dep)
+        if dep_id in deps:
+            dep_old = deps[dep_id]
+            assert (dep is dep_old
+                    or dep is var_replacement(dep_old)
+                    or var_replacement(dep) is dep_old)
+            assert var_caches(dep) is var_caches(dep_old)
+            if var_is_replacement(dep_old):
                 deps[dep_id] = dep
+        else:
+            deps[dep_id] = dep
 
     return tuple(sorted(deps.values(), key=var_id))
 

--- a/tlm_adjoint/firedrake/caches.py
+++ b/tlm_adjoint/firedrake/caches.py
@@ -136,14 +136,12 @@ def split_arity(form, x, argument):
 
     form_derivative = derivative(form, x, argument=argument,
                                  enable_automatic_argument=False)
-    form_derivative = ufl.algorithms.expand_derivatives(form_derivative)
     if x in extract_coefficients(form_derivative):
         # Non-linear
         return ufl.classes.Form([]), form
 
     try:
-        eq_form = ufl.algorithms.expand_derivatives(
-            ufl.replace(form, {x: argument}))
+        eq_form = ufl.replace(form, {x: argument})
         A = ufl.algorithms.formtransformations.compute_form_with_arity(
             eq_form, arity + 1)
         b = ufl.algorithms.formtransformations.compute_form_with_arity(

--- a/tlm_adjoint/firedrake/expr.py
+++ b/tlm_adjoint/firedrake/expr.py
@@ -79,27 +79,31 @@ def extract_coefficients(expr):
     for c_deps in counted_cls_deps.values():
         deps.extend(sorted(c_deps.values(), key=lambda dep: dep.count()))
 
+    if len(set(map(var_id, deps))) != len(deps):
+        raise RuntimeError("Invalid dependencies")
     return deps
 
 
-def extract_derivative_coefficients(expr, dep):
+@form_cached("_tlm_adjoint__extract_variables")
+def extract_variables(expr):
+    deps = sorted((dep for dep in extract_coefficients(expr) if is_var(dep)),
+                  key=var_id)
+    return tuple(deps)
+
+
+def extract_derivative_variables(expr, dep):
     dexpr = derivative(expr, dep, enable_automatic_argument=False)
-    return extract_coefficients(dexpr)
+    return extract_variables(dexpr)
 
 
 def extract_dependencies(expr, *, space_type=None):
-    deps = {}
-    nl_deps = {}
-    for dep in extract_coefficients(expr):
-        if is_var(dep):
-            deps.setdefault(var_id(dep), dep)
-            for nl_dep in extract_derivative_coefficients(expr, dep):
-                if is_var(nl_dep):
-                    nl_deps.setdefault(var_id(dep), dep)
-                    nl_deps.setdefault(var_id(nl_dep), nl_dep)
+    deps = {var_id(dep): dep for dep in extract_variables(expr)}
 
-    deps = {dep_id: deps[dep_id]
-            for dep_id in sorted(deps.keys())}
+    nl_deps = {}
+    for dep in deps.values():
+        for nl_dep in extract_derivative_variables(expr, dep):
+            nl_deps.setdefault(var_id(dep), dep)
+            nl_deps.setdefault(var_id(nl_dep), nl_dep)
     nl_deps = {nl_dep_id: nl_deps[nl_dep_id]
                for nl_dep_id in sorted(nl_deps.keys())}
 
@@ -114,7 +118,7 @@ def extract_dependencies(expr, *, space_type=None):
 def with_coefficients(*exprs):
     replace_map = {}
     replace_map_inverse = {}
-    for c in itertools.chain.from_iterable(map(extract_coefficients, exprs)):
+    for c in itertools.chain.from_iterable(map(extract_variables, exprs)):
         if not isinstance(c, ufl.classes.Coefficient):
             c_coeff = ufl.classes.Coefficient(var_space(c))
             replace_map[c] = c_coeff
@@ -236,7 +240,7 @@ def eliminate_zeros(expr):
     """
 
     replace_map = {c: expr_zero(c)
-                   for c in extract_coefficients(expr)
+                   for c in extract_variables(expr)
                    if isinstance(c, Zero)}
     if len(replace_map) == 0:
         simplified_expr = expr
@@ -268,8 +272,8 @@ def new_count(counted_class):
 
 def replaced_form(form):
     replace_map = {}
-    for c in extract_coefficients(form):
-        if is_var(c) and not var_is_replacement(c):
+    for c in extract_variables(form):
+        if not var_is_replacement(c):
             c_rep = var_replacement(c)
             if c_rep is not c:
                 replace_map[c] = c_rep

--- a/tlm_adjoint/firedrake/interpolation.py
+++ b/tlm_adjoint/firedrake/interpolation.py
@@ -13,8 +13,8 @@ from ..equation import Equation, ZeroAssignment
 from ..manager import manager_disabled
 
 from .expr import (
-    ExprEquation, derivative, eliminate_zeros, expr_zero, extract_coefficients,
-    extract_dependencies)
+    ExprEquation, derivative, eliminate_zeros, expr_zero, extract_dependencies,
+    extract_variables)
 from .variables import ReplacementConstant
 
 import itertools
@@ -35,9 +35,8 @@ def interpolate_expression(x, expr, *, adj_x=None):
     else:
         check_space_type(x, "conjugate_dual")
         check_space_type(adj_x, "conjugate_dual")
-    for dep in extract_coefficients(expr):
-        if is_var(dep):
-            check_space_type(dep, "primal")
+    for dep in extract_variables(expr):
+        check_space_type(dep, "primal")
 
     expr = eliminate_zeros(expr)
 

--- a/tlm_adjoint/firedrake/interpolation.py
+++ b/tlm_adjoint/firedrake/interpolation.py
@@ -109,7 +109,6 @@ class ExprInterpolation(ExprEquation):
             dF = derivative(self._rhs, dep, argument=ufl.classes.IntValue(1))
         else:
             dF = derivative(self._rhs, dep)
-        dF = ufl.algorithms.expand_derivatives(dF)
         dF = eliminate_zeros(dF)
         dF = self._nonlinear_replace(dF, nl_deps)
 
@@ -131,7 +130,6 @@ class ExprInterpolation(ExprEquation):
                     tlm_rhs = (tlm_rhs
                                + derivative(self._rhs, dep, argument=tau_dep))
 
-        tlm_rhs = ufl.algorithms.expand_derivatives(tlm_rhs)
         if isinstance(tlm_rhs, ufl.classes.Zero):
             return ZeroAssignment(tlm_map[x])
         else:

--- a/tlm_adjoint/firedrake/solve.py
+++ b/tlm_adjoint/firedrake/solve.py
@@ -189,7 +189,6 @@ class EquationSolver(ExprEquation):
             F = lhs
             nl_solve_J = J
             J = derivative(F, x)
-            J = ufl.algorithms.expand_derivatives(J)
 
         for weight, _ in iter_expr(F):
             if len(tuple(c for c in extract_coefficients(weight)
@@ -203,7 +202,7 @@ class EquationSolver(ExprEquation):
             for dep in extract_coefficients(nl_solve_J):
                 if is_var(dep):
                     deps.setdefault(var_id(dep), dep)
-        deps = list(deps.values())
+        deps = sorted(deps.values(), key=var_id)
         if x in deps:
             deps.remove(x)
         deps.insert(0, x)
@@ -501,14 +500,12 @@ class EquationSolver(ExprEquation):
                 for weight, comp in iter_expr(self._F):
                     if isinstance(comp, ufl.classes.Form):
                         dF_term = derivative(weight * comp, dep)
-                        dF_term = ufl.algorithms.expand_derivatives(dF_term)
                         dF_term = eliminate_zeros(dF_term)
                         if not isinstance(dF_term, ufl.classes.ZeroBaseForm):
                             dF_forms = dF_forms + adjoint(dF_term)
                     elif isinstance(comp, ufl.classes.Cofunction):
                         # Note: Ignores weight dependencies
                         dF_term = ufl.conj(weight) * derivative(comp, dep)
-                        dF_term = ufl.algorithms.expand_derivatives(dF_term)
                         dF_term = eliminate_zeros(dF_term)
                         if not isinstance(dF_term, ufl.classes.ZeroBaseForm):
                             dF_cofunctions = dF_cofunctions + dF_term
@@ -601,7 +598,6 @@ class EquationSolver(ExprEquation):
                         # Note: Ignores weight dependencies
                         tlm_rhs = (tlm_rhs
                                    - weight * derivative(comp, dep, argument=tau_dep))  # noqa: E501
-        tlm_rhs = ufl.algorithms.expand_derivatives(tlm_rhs)
         return tlm_rhs
 
     def tangent_linear(self, tlm_map):

--- a/tlm_adjoint/firedrake/solve.py
+++ b/tlm_adjoint/firedrake/solve.py
@@ -15,8 +15,8 @@ from .caches import (
     assembly_cache, is_cached, linear_solver_cache, local_solver_cache,
     split_form)
 from .expr import (
-    ExprEquation, derivative, eliminate_zeros, expr_zero, extract_dependencies,
-    extract_variables, iter_expr)
+    ExprEquation, action, derivative, eliminate_zeros, expr_zero,
+    extract_dependencies, extract_variables, iter_expr)
 from .parameters import (
     form_compiler_quadrature_parameters, process_adjoint_solver_parameters,
     process_form_compiler_parameters, process_solver_parameters,
@@ -177,7 +177,7 @@ class EquationSolver(ExprEquation):
                     or x in extract_variables(rhs):
                 raise ValueError("Invalid dependency")
 
-            F = ufl.action(lhs, coefficient=x) - rhs
+            F = action(lhs, x) - rhs
             nl_solve_J = None
             J = lhs
         else:
@@ -209,7 +209,7 @@ class EquationSolver(ExprEquation):
         if all(isinstance(bc._function_arg, ufl.classes.Zero) for bc in bcs):
             rhs_bc = expr_zero(F)
         else:
-            rhs_bc = -ufl.action(J, coefficient=x)
+            rhs_bc = -action(J, x)
         deps, bc_nodes, bc_gs = unpack_bcs(bcs, deps=deps)
         hbcs = tuple(map(homogenized_bc, bcs))
 
@@ -520,7 +520,7 @@ class EquationSolver(ExprEquation):
                         eq_deps=eq_nl_deps, deps=nl_deps)
                     dep_B.sub(matrix_multiply(mat, adj_x_0))
                 else:
-                    dF_forms = ufl.action(dF_forms, coefficient=adj_x_0)
+                    dF_forms = action(dF_forms, adj_x_0)
                     dF_forms = self._assemble(dF_forms,
                                               eq_deps=eq_nl_deps, deps=nl_deps)
                     dep_B.sub(dF_forms)
@@ -540,8 +540,7 @@ class EquationSolver(ExprEquation):
                             eq_deps=eq_nl_deps, deps=nl_deps)
                         dF_bc = matrix_multiply(mat, adj_x_0)
                     else:
-                        dF_bc = ufl.action(adjoint(self._J),
-                                           coefficient=adj_x_0)
+                        dF_bc = action(adjoint(self._J), adj_x_0)
                         dF_bc = self._assemble(dF_bc,
                                                eq_deps=eq_nl_deps, deps=nl_deps)  # noqa: E501
 


### PR DESCRIPTION
The usage `ufl.derivative(form, u, argument=du)` with `u` and `du` `Function`s is technically inconsistent with the UFL documentation, but has always worked. However there are now cases with the Firedrake backend involving `Interpolate` where this doesn't seem to work.

This PR uses `action(ufl.derivative(...))` in some cases.

Other changes:

- FEniCS backend: `derivative` now applies `ufl.algorithms.expand_derivatives`.
- FEniCS/Firedrake backends: Remove unnecessary usage of `ufl.algorithms.expand_derivatives`.
- FEniCS/Firedrake backends: Replace most usage of `extract_coefficients` with (the new) `extract_variables`.
- Firedrake backend: Fix a bug in `extract_coefficients`, which missed `ReplacementConstant`s.
- Firedrake backend: Simplification to `Assembly.subtract_adjoint_derivative_actions`.