### PR TITLE
Firedrake backend: Minor UFL API update

### DIFF
--- a/tlm_adjoint/fenics/caches.py
+++ b/tlm_adjoint/fenics/caches.py
@@ -108,16 +108,13 @@ def split_arity(form, x, argument):
         # Non-linear
         return ufl.classes.Form([]), form
 
-    try:
-        eq_form = ufl.replace(form, {x: argument})
-        eq_form = ufl.algorithms.expand_compounds(eq_form)
-        A = ufl.algorithms.formtransformations.compute_form_with_arity(
-            eq_form, arity + 1)
-        b = ufl.algorithms.formtransformations.compute_form_with_arity(
-            eq_form, arity)
-    except ufl.UFLException:
-        # UFL error encountered
-        return ufl.classes.Form([]), form
+    eq_form = ufl.algorithms.expand_derivatives(form)
+    eq_form = ufl.replace(eq_form, {x: argument})
+    eq_form = ufl.algorithms.expand_compounds(eq_form)
+    A = ufl.algorithms.formtransformations.compute_form_with_arity(
+        eq_form, arity + 1)
+    b = ufl.algorithms.formtransformations.compute_form_with_arity(
+        eq_form, arity)
 
     try:
         ufl.algorithms.check_arities.check_form_arity(

--- a/tlm_adjoint/fenics/caches.py
+++ b/tlm_adjoint/fenics/caches.py
@@ -110,6 +110,7 @@ def split_arity(form, x, argument):
 
     try:
         eq_form = ufl.replace(form, {x: argument})
+        eq_form = ufl.algorithms.expand_compounds(eq_form)
         A = ufl.algorithms.formtransformations.compute_form_with_arity(
             eq_form, arity + 1)
         b = ufl.algorithms.formtransformations.compute_form_with_arity(

--- a/tlm_adjoint/fenics/caches.py
+++ b/tlm_adjoint/fenics/caches.py
@@ -104,7 +104,7 @@ def split_arity(form, x, argument):
 
     form_derivative = derivative(form, x, argument=argument,
                                  enable_automatic_argument=False)
-    if x in extract_coefficients(form_derivative):
+    if form_derivative.empty() or x in extract_coefficients(form_derivative):
         # Non-linear
         return ufl.classes.Form([]), form
 

--- a/tlm_adjoint/firedrake/caches.py
+++ b/tlm_adjoint/firedrake/caches.py
@@ -142,6 +142,7 @@ def split_arity(form, x, argument):
 
     try:
         eq_form = ufl.replace(form, {x: argument})
+        eq_form = ufl.algorithms.apply_algebra_lowering.apply_algebra_lowering(eq_form)  # noqa: E501
         A = ufl.algorithms.formtransformations.compute_form_with_arity(
             eq_form, arity + 1)
         b = ufl.algorithms.formtransformations.compute_form_with_arity(

--- a/tlm_adjoint/firedrake/caches.py
+++ b/tlm_adjoint/firedrake/caches.py
@@ -136,7 +136,7 @@ def split_arity(form, x, argument):
 
     form_derivative = derivative(form, x, argument=argument,
                                  enable_automatic_argument=False)
-    if x in extract_coefficients(form_derivative):
+    if form_derivative.empty() or x in extract_coefficients(form_derivative):
         # Non-linear
         return ufl.classes.Form([]), form
 

--- a/tlm_adjoint/firedrake/caches.py
+++ b/tlm_adjoint/firedrake/caches.py
@@ -146,7 +146,7 @@ def split_arity(form, x, argument):
             eq_form, arity + 1)
         b = ufl.algorithms.formtransformations.compute_form_with_arity(
             eq_form, arity)
-    except ufl.UFLException:
+    except Exception:
         # UFL error encountered
         return ufl.classes.Form([]), form
 

--- a/tlm_adjoint/firedrake/caches.py
+++ b/tlm_adjoint/firedrake/caches.py
@@ -140,16 +140,14 @@ def split_arity(form, x, argument):
         # Non-linear
         return ufl.classes.Form([]), form
 
-    try:
-        eq_form = ufl.replace(form, {x: argument})
-        eq_form = ufl.algorithms.apply_algebra_lowering.apply_algebra_lowering(eq_form)  # noqa: E501
-        A = ufl.algorithms.formtransformations.compute_form_with_arity(
-            eq_form, arity + 1)
-        b = ufl.algorithms.formtransformations.compute_form_with_arity(
-            eq_form, arity)
-    except Exception:
-        # UFL error encountered
-        return ufl.classes.Form([]), form
+    eq_form = ufl.algorithms.expand_derivatives(form)
+    eq_form = ufl.replace(eq_form, {x: argument})
+    eq_form = ufl.algorithms.apply_algebra_lowering.apply_algebra_lowering(
+        eq_form)
+    A = ufl.algorithms.formtransformations.compute_form_with_arity(
+        eq_form, arity + 1)
+    b = ufl.algorithms.formtransformations.compute_form_with_arity(
+        eq_form, arity)
 
     try:
         ufl.algorithms.check_arities.check_form_arity(


### PR DESCRIPTION
With the Firedrake backend, and the latest UFL, `ufl.UFLException` is no longer defined. Remove the associated try/except when splitting by arity.

Also apply `expand_derivatives` before the `ufl.replace`, and apply `expand_compounds` / `apply_algebra_lowering` before splitting by arity.