### PR TITLE
Fix reason check in line_search

### DIFF
--- a/tlm_adjoint/optimization.py
+++ b/tlm_adjoint/optimization.py
@@ -535,7 +535,7 @@ def line_search(F, Fp, X, minus_P, *,
     s.scale(-1.0)
 
     phi, alpha, reason = taols.apply(x, g, s)
-    if reason <= 0:
+    if reason != PETSc.TAOLineSearch.Reason.SUCCESS:
         raise RuntimeError("Line search failure")
 
     new_Fp_val = vars_new_conjugate_dual(X)

--- a/tlm_adjoint/optimization.py
+++ b/tlm_adjoint/optimization.py
@@ -599,7 +599,7 @@ def l_bfgs(F, Fp, X0, *,
     gradient, gradient change, and step, and where :math:`M^{-1}` and
     :math:`H_0` are defined by `M_inv_action` and `H_0_action` respectively.
 
-    The line search is performed using :func:`line_search`.
+    The line search is performed using :func:`.line_search`.
 
     :arg F: A callable defining the functional. Accepts one or more variables
         as arguments, and returns the value of the functional.


### PR DESCRIPTION
Positive `reason` values do not necessarily indicate success with `TaoLineSearch`.