### PR TITLE
Firedrake backend: Apply the Riesz map when drawing white noise samples

### DIFF
--- a/tlm_adjoint/firedrake/block_system.py
+++ b/tlm_adjoint/firedrake/block_system.py
@@ -389,7 +389,7 @@ class WhiteNoiseSampler:
 
         .. math::
 
-            X = \Xi^{-T} \sqrt{ \Xi^T M \Xi } Z,
+            X = \Xi^{-T} \sqrt{ \Xi^T M \Xi } Z.
 
         Returns
         -------
@@ -413,7 +413,7 @@ class WhiteNoiseSampler:
 
         .. math::
 
-            X = M^{-1} \Xi^{-T} \sqrt{ \Xi^T M \Xi } Z,
+            X = M^{-1} \Xi^{-T} \sqrt{ \Xi^T M \Xi } Z.
 
         Returns
         -------


### PR DESCRIPTION
Follow up to #575. We typically want primal space samples. The previous samples are retained via the `WhiteNoiseSampler.dual_sample` method (and this now returns a `Cofunction`).