### PR TITLE
Firedrake backend: Work around Firedrake issue #3933

### DIFF
--- a/tests/firedrake/test_interface.py
+++ b/tests/firedrake/test_interface.py
@@ -164,7 +164,7 @@ def test_var_alias(setup_test, test_leaks,
     for F_i in F.subfunctions:
         assert var_is_alias(F_i)
         test_state(F, F_i)
-    if dim > 1:
+    if len(F.function_space()) > 1:
         # dim == 1 skipped due to Firedrake issue #3933
         for i in range(dim):
             F_i = F.sub(i)
@@ -172,7 +172,7 @@ def test_var_alias(setup_test, test_leaks,
             test_state(F, F_i)
 
     F = cls(space, name="F")
-    if dim > 1:
+    if len(F.function_space()) > 1:
         # dim == 1 skipped due to Firedrake issue #3933
         for i in range(dim):
             F_i = F.sub(i)

--- a/tests/firedrake/test_interface.py
+++ b/tests/firedrake/test_interface.py
@@ -164,16 +164,20 @@ def test_var_alias(setup_test, test_leaks,
     for F_i in F.subfunctions:
         assert var_is_alias(F_i)
         test_state(F, F_i)
-    for i in range(dim):
-        F_i = F.sub(i)
-        assert dim == 1 or var_is_alias(F_i)
-        test_state(F, F_i)
+    if dim > 1:
+        # dim == 1 skipped due to Firedrake issue #3933
+        for i in range(dim):
+            F_i = F.sub(i)
+            assert var_is_alias(F_i)
+            test_state(F, F_i)
 
     F = cls(space, name="F")
-    for i in range(dim):
-        F_i = F.sub(i)
-        assert dim == 1 or var_is_alias(F_i)
-        test_state(F, F_i)
+    if dim > 1:
+        # dim == 1 skipped due to Firedrake issue #3933
+        for i in range(dim):
+            F_i = F.sub(i)
+            assert var_is_alias(F_i)
+            test_state(F, F_i)
     for F_i in F.subfunctions:
         assert var_is_alias(F_i)
         test_state(F, F_i)


### PR DESCRIPTION
Work around https://github.com/firedrakeproject/firedrake/issues/3933 by skipping the affected test.

No practical impact as tlm_adjoint only flags and checks for aliasing, but does not allow aliased variables in taped operations.