### PR TITLE
Remove some unused classes

### DIFF
--- a/tests/firedrake/test_base.py
+++ b/tests/firedrake/test_base.py
@@ -154,9 +154,7 @@ def test_leaks():
     manager._adj_cache.clear()
     for block in list(manager._blocks) + [manager._block]:
         for eq in block:
-            if isinstance(eq, PointInterpolation):
-                del eq._interp
-            elif isinstance(eq, AdjointActionMarker):
+            if isinstance(eq, AdjointActionMarker):
                 del eq._adj_X
 
     gc.collect()

--- a/tlm_adjoint/equations.py
+++ b/tlm_adjoint/equations.py
@@ -1,7 +1,7 @@
 from .interface import (
     check_space_types, check_space_types_conjugate_dual,
-    check_space_types_dual, packed, var_assign, var_axpy, var_axpy_conjugate,
-    var_dot, var_dtype, var_get_values, var_id, var_is_scalar, var_inner,
+    check_space_types_dual, var_assign, var_axpy, var_axpy_conjugate, var_dot,
+    var_dtype, var_get_values, var_id, var_is_scalar, var_inner,
     var_local_size, var_new_conjugate_dual, var_replacement, var_scalar_value,
     var_set_values, var_zero)
 

--- a/tlm_adjoint/equations.py
+++ b/tlm_adjoint/equations.py
@@ -1,5 +1,5 @@
 from .interface import (
-    Packed, check_space_types, check_space_types_conjugate_dual,
+    check_space_types, check_space_types_conjugate_dual,
     check_space_types_dual, packed, var_assign, var_axpy, var_axpy_conjugate,
     var_dot, var_dtype, var_get_values, var_id, var_is_scalar, var_inner,
     var_local_size, var_new_conjugate_dual, var_replacement, var_scalar_value,
@@ -22,8 +22,7 @@ __all__ = \
         "DotProductRHS",
         "DotProduct",
         "InnerProductRHS",
-        "InnerProduct",
-        "MatrixActionRHS"
+        "InnerProduct"
     ]
 
 
@@ -270,95 +269,6 @@ class InnerProduct(LinearEquation):
 
     def __init__(self, x, y, z, *, alpha=1.0, M=None):
         super().__init__(x, InnerProductRHS(y, z, alpha=alpha, M=M))
-
-
-class MatrixActionRHS(RHS):
-    """Represents a right-hand-side term
-
-    .. math::
-
-        A x.
-
-    :arg A: A :class:`tlm_adjoint.linear_equation.Matrix` defining :math:`A`.
-    :arg x: A variable or a :class:`Sequence` of variables defining :math:`x`.
-    """
-
-    def __init__(self, A, X):
-        X_packed = Packed(X)
-        X = tuple(X_packed)
-        if len(set(map(var_id, X))) != len(X):
-            raise ValueError("Invalid dependency")
-
-        A_nl_deps = A.nonlinear_dependencies()
-        if len(A_nl_deps) == 0:
-            x_indices = {i: i for i in range(len(X))}
-            super().__init__(X, nl_deps=[])
-        else:
-            nl_deps = list(A_nl_deps)
-            nl_dep_ids = {var_id(dep): i for i, dep in enumerate(nl_deps)}
-            x_indices = {}
-            for i, x in enumerate(X):
-                x_id = var_id(x)
-                if x_id not in nl_dep_ids:
-                    nl_deps.append(x)
-                    nl_dep_ids[x_id] = len(nl_deps) - 1
-                x_indices[nl_dep_ids[x_id]] = i
-            super().__init__(nl_deps, nl_deps=nl_deps)
-
-        self._packed = X_packed.mapped(lambda x: None)
-        self._A = A
-        self._x_indices = x_indices
-
-        self.add_referrer(A)
-
-    def drop_references(self):
-        super().drop_references()
-        self._A = self._A._weak_alias
-
-    def _unpack(self, obj):
-        return self._packed.unpack(obj)
-
-    def add_forward(self, B, deps):
-        B = packed(B)
-        X = tuple(deps[j] for j in self._x_indices)
-        self._A.forward_action(deps[:len(self._A.nonlinear_dependencies())],
-                               self._unpack(X),
-                               self._unpack(B),
-                               method="add")
-
-    def subtract_adjoint_derivative_action(self, nl_deps, dep_index, adj_X, b):
-        adj_X = packed(adj_X)
-        N_A_nl_deps = len(self._A.nonlinear_dependencies())
-        if dep_index < N_A_nl_deps:
-            X = tuple(nl_deps[j] for j in self._x_indices)
-            self._A.adjoint_derivative_action(
-                nl_deps[:N_A_nl_deps], dep_index,
-                self._unpack(X),
-                self._unpack(adj_X),
-                b, method="sub")
-
-        if dep_index in self._x_indices:
-            self._A.adjoint_action(nl_deps[:N_A_nl_deps],
-                                   self._unpack(adj_X),
-                                   b, b_index=self._x_indices[dep_index],
-                                   method="sub")
-
-    def tangent_linear_rhs(self, tlm_map):
-        deps = self.dependencies()
-        N_A_nl_deps = len(self._A.nonlinear_dependencies())
-
-        X = tuple(deps[j] for j in self._x_indices)
-        tlm_X = tuple(tlm_map[x] for x in X)
-        tlm_B = [MatrixActionRHS(self._A, self._unpack(tlm_X))]
-
-        if N_A_nl_deps > 0:
-            tlm_b = self._A.tangent_linear_rhs(tlm_map, X)
-            if tlm_b is None:
-                pass
-            else:
-                tlm_B.extend(packed(tlm_b))
-
-        return tlm_B
 
 
 class DotProductRHS(RHS):

--- a/tlm_adjoint/firedrake/interpolation.py
+++ b/tlm_adjoint/firedrake/interpolation.py
@@ -2,16 +2,13 @@
 """
 
 from .backend import (
-    FunctionSpace, Interpolator, TestFunction, VertexOnlyMesh,
-    backend_Cofunction, backend_Constant, backend_Function)
+    Interpolator, backend_Cofunction, backend_Constant, backend_Function)
 from ..interface import (
-    check_space_type, check_space_types, comm_dup_cached, packed, space_new,
-    var_assign, var_assign_conjugate, var_axpy, var_axpy_conjugate, var_comm,
-    var_copy_conjugate, var_id, var_inner, var_is_scalar, var_new,
-    var_new_conjugate, var_new_conjugate_dual, var_replacement,
-    var_scalar_value, var_zero)
+    check_space_types, var_assign, var_assign_conjugate, var_axpy,
+    var_axpy_conjugate, var_copy_conjugate, var_id, var_inner, var_new,
+    var_new_conjugate, var_new_conjugate_dual, var_replacement, var_zero)
 
-from ..equation import Equation, ZeroAssignment
+from ..equation import ZeroAssignment
 from ..manager import manager_disabled
 
 from .expr import (
@@ -19,14 +16,11 @@ from .expr import (
     iter_expr)
 from .variables import ReplacementConstant
 
-import itertools
-import numpy as np
 import ufl
 
 __all__ = \
     [
-        "ExprInterpolation",
-        "PointInterpolation"
+        "ExprInterpolation"
     ]
 
 
@@ -139,121 +133,3 @@ class ExprInterpolation(ExprEquation):
             return ZeroAssignment(tlm_map[x])
         else:
             return ExprInterpolation(tlm_map[x], tlm_rhs)
-
-
-def vmesh_coords_map(vmesh, X_coords):
-    comm = comm_dup_cached(vmesh.comm)
-    N, _ = X_coords.shape
-
-    vmesh_coords = vmesh.coordinates.dat.data_ro
-    Nm, _ = vmesh_coords.shape
-
-    vmesh_coords_indices = {tuple(vmesh_coords[i, :]): i for i in range(Nm)}
-    vmesh_coords_map = np.full(Nm, -1, dtype=np.int_)
-    for i in range(N):
-        key = tuple(X_coords[i, :])
-        if key in vmesh_coords_indices:
-            vmesh_coords_map[vmesh_coords_indices[key]] = i
-    if (vmesh_coords_map < 0).any():
-        raise RuntimeError("Failed to find vertex map")
-
-    vmesh_coords_map = comm.allgather(vmesh_coords_map)
-    if len(tuple(itertools.chain(*vmesh_coords_map))) != N:
-        raise RuntimeError("Failed to find vertex map")
-
-    return vmesh_coords_map
-
-
-class PointInterpolation(Equation):
-    r"""Represents interpolation of a scalar-valued function at given points.
-
-    The forward residual :math:`\mathcal{F}` is defined so that :math:`\partial
-    \mathcal{F} / \partial x` is the identity.
-
-    :arg X: A scalar variable, or a :class:`Sequence` of scalar variables,
-        defining the forward solution.
-    :arg y: A scalar-valued :class:`firedrake.function.Function` to
-        interpolate.
-    :arg X_coords: A :class:`numpy.ndarray` defining the coordinates at which
-        to interpolate `y`. Shape is `(n, d)` where `n` is the number of
-        interpolation points and `d` is the geometric dimension. Ignored if `P`
-        is supplied.
-    :arg tolerance: :class:`firedrake.mesh.VertexOnlyMesh` tolerance.
-    """
-
-    def __init__(self, X, y, X_coords=None, *, tolerance=None,
-                 _interp=None):
-        X = packed(X)
-        for x in X:
-            check_space_type(x, "primal")
-            if not var_is_scalar(x):
-                raise ValueError("Solution must be a scalar variable, or a "
-                                 "Sequence of scalar variables")
-        check_space_type(y, "primal")
-
-        if X_coords is None:
-            if _interp is None:
-                raise TypeError("X_coords required")
-        else:
-            if len(X) != X_coords.shape[0]:
-                raise ValueError("Invalid number of variables")
-        if not isinstance(y, backend_Function):
-            raise TypeError("y must be a Function")
-        if len(y.ufl_shape) > 0:
-            raise ValueError("y must be a scalar-valued Function")
-
-        interp = _interp
-        if interp is None:
-            y_space = y.function_space()
-            vmesh = VertexOnlyMesh(y_space.mesh(), X_coords,
-                                   tolerance=tolerance)
-            vspace = FunctionSpace(vmesh, "Discontinuous Lagrange", 0)
-            interp = Interpolator(TestFunction(y_space), vspace)
-            if not hasattr(interp, "_tlm_adjoint__vmesh_coords_map"):
-                interp._tlm_adjoint__vmesh_coords_map = vmesh_coords_map(vmesh, X_coords)  # noqa: E501
-
-        super().__init__(X, list(X) + [y], nl_deps=[], ic=False, adj_ic=False)
-        self._interp = interp
-
-    def forward_solve(self, X, deps=None):
-        y = (self.dependencies() if deps is None else deps)[-1]
-
-        Xm = space_new(self._interp.V)
-        self._interp._interpolate(y, output=Xm)
-
-        X_values = var_comm(Xm).allgather(Xm.dat.data_ro)
-        vmesh_coords_map = self._interp._tlm_adjoint__vmesh_coords_map
-        for x_val, index in zip(itertools.chain(*X_values),
-                                itertools.chain(*vmesh_coords_map)):
-            X[index].assign(x_val)
-
-    def adjoint_derivative_action(self, nl_deps, dep_index, adj_X):
-        if dep_index != len(self.X()):
-            raise ValueError("Unexpected dep_index")
-
-        adj_Xm = space_new(self._interp.V.dual())
-
-        vmesh_coords_map = self._interp._tlm_adjoint__vmesh_coords_map
-        rank = var_comm(adj_Xm).rank
-        # This line must be outside the loop to avoid deadlocks
-        adj_Xm_data = adj_Xm.dat.data
-        for i, j in enumerate(vmesh_coords_map[rank]):
-            adj_Xm_data[i] = var_scalar_value(adj_X[j])
-
-        F = var_new_conjugate_dual(self.dependencies()[-1])
-        self._interp._interpolate(adj_Xm, transpose=True, output=F)
-        return (-1.0, F)
-
-    def adjoint_jacobian_solve(self, adj_X, nl_deps, B):
-        return B
-
-    def tangent_linear(self, tlm_map):
-        X = self.X()
-        y = self.dependencies()[-1]
-
-        tlm_y = tlm_map[y]
-        if tlm_y is None:
-            return ZeroAssignment([tlm_map[x] for x in X])
-        else:
-            return PointInterpolation([tlm_map[x] for x in X], tlm_y,
-                                      _interp=self._interp)


### PR DESCRIPTION
Remove

- (Firedrake backend) `PointInterpolation`. Should be replaced with interpolation using a `VertexOnlyMesh`.
- `MatrixActionRHS`.

Closes #586.