### PR TITLE
Remove extraneous lines when gathering non-linear dependencies

### DIFF
--- a/tlm_adjoint/fenics/expr.py
+++ b/tlm_adjoint/fenics/expr.py
@@ -87,7 +87,6 @@ def extract_dependencies(expr, *, space_type=None):
     nl_deps = {}
     for dep in deps.values():
         for nl_dep in extract_derivative_variables(expr, dep):
-            nl_deps.setdefault(var_id(dep), dep)
             nl_deps.setdefault(var_id(nl_dep), nl_dep)
     nl_deps = {nl_dep_id: nl_deps[nl_dep_id]
                for nl_dep_id in sorted(nl_deps.keys())}

--- a/tlm_adjoint/firedrake/expr.py
+++ b/tlm_adjoint/firedrake/expr.py
@@ -102,7 +102,6 @@ def extract_dependencies(expr, *, space_type=None):
     nl_deps = {}
     for dep in deps.values():
         for nl_dep in extract_derivative_variables(expr, dep):
-            nl_deps.setdefault(var_id(dep), dep)
             nl_deps.setdefault(var_id(nl_dep), nl_dep)
     nl_deps = {nl_dep_id: nl_deps[nl_dep_id]
                for nl_dep_id in sorted(nl_deps.keys())}

--- a/tlm_adjoint/overloaded_float.py
+++ b/tlm_adjoint/overloaded_float.py
@@ -856,7 +856,6 @@ class FloatEquation(Equation):
         for dep_index, dep in enumerate(deps):
             dF = dF_expr[dep_index] = F.diff(dep)
             for dep2 in expr_dependencies(dF):
-                nl_deps.setdefault(var_id(dep), dep)
                 nl_deps.setdefault(var_id(dep2), dep2)
         nl_deps = sorted(nl_deps.values(), key=var_id)
         dF = {dep_index: lambdify(dF, nl_deps)


### PR DESCRIPTION
Potentially erroneously adds extra non-linear dependencies in some corner cases, e.g. conditionals.