### PR TITLE
Firedrake backend: Remove tests for deprecated interfaces

### DIFF
--- a/tests/firedrake/test_base.py
+++ b/tests/firedrake/test_base.py
@@ -1,4 +1,5 @@
 from firedrake import *
+from firedrake.__future__ import Interpolator, interpolate
 from tlm_adjoint.firedrake import *
 from tlm_adjoint.firedrake import manager as _manager
 from tlm_adjoint.firedrake.backend import (
@@ -270,44 +271,35 @@ def solve_eq(request):
     return request.param["solve_eq"]
 
 
-def interpolate_interpolate(v, V):
-    return interpolate(v, V)
-
-
 def interpolate_Function_interpolate(v, V):
     return space_new(V).interpolate(v)
 
 
 def interpolate_Interpolator_Function(v, V):
     interp = Interpolator(v, V)
-    x = space_new(V)
-    interp.interpolate(output=x)
-    return x
+    return assemble(interp.interpolate())
 
 
 def interpolate_Interpolator_test(v, V):
     interp = Interpolator(TestFunction(v.function_space()), V)
+    return assemble(interp.interpolate(v))
+
+
+def interpolate_interpolate(v, V):
+    return assemble(interpolate(v, V))
+
+
+def interpolate_interpolate_tensor(v, V):
     x = space_new(V)
-    interp.interpolate(v, output=x)
+    assemble(interpolate(v, V), tensor=x)
     return x
 
 
-def interpolate_Interpolator_assemble(v, V):
-    return assemble(Interpolate(v, V))
-
-
-def interpolate_Interpolator_assemble_tensor(v, V):
-    x = space_new(V)
-    assemble(Interpolate(v, V), tensor=x)
-    return x
-
-
-@pytest.fixture(params=[{"interpolate_expr": interpolate_interpolate},
-                        {"interpolate_expr": interpolate_Function_interpolate},
+@pytest.fixture(params=[{"interpolate_expr": interpolate_Function_interpolate},
                         {"interpolate_expr": interpolate_Interpolator_Function},  # noqa: E501
                         {"interpolate_expr": interpolate_Interpolator_test},
-                        {"interpolate_expr": interpolate_Interpolator_assemble},  # noqa: E501
-                        {"interpolate_expr": interpolate_Interpolator_assemble_tensor}])  # noqa: E501
+                        {"interpolate_expr": interpolate_interpolate},
+                        {"interpolate_expr": interpolate_interpolate_tensor}])
 def interpolate_expr(request):
     return request.param["interpolate_expr"]
 

--- a/tests/firedrake/test_interface.py
+++ b/tests/firedrake/test_interface.py
@@ -11,7 +11,6 @@ pytestmark = pytest.mark.skipif(
 
 
 @pytest.fixture(params=[{"cls": lambda **kwargs: Constant(**kwargs)},
-                        {"cls": lambda **kwargs: Constant(domain=UnitIntervalMesh(20), **kwargs)},  # noqa: E501
                         {"cls": lambda **kwargs: Function(FunctionSpace(UnitIntervalMesh(20), "Lagrange", 1), **kwargs)},  # noqa: E501
                         {"cls": lambda **kwargs: Cofunction(FunctionSpace(UnitIntervalMesh(20), "Lagrange", 1).dual(), **kwargs)}])  # noqa: E501
 def var_cls(request):
@@ -185,14 +184,8 @@ def test_default_var_flags(setup_test, test_leaks):
     mesh = UnitIntervalMesh(20)
     space = FunctionSpace(mesh, "Lagrange", 1)
 
-    # Constant, without domain
+    # Constant
     c = Constant(0.0)
-    assert var_is_static(c) is not None and not var_is_static(c)
-    assert var_is_cached(c) is not None and not var_is_cached(c)
-    del c
-
-    # Constant, with domain
-    c = Constant(0.0, domain=mesh)
     assert var_is_static(c) is not None and not var_is_static(c)
     assert var_is_cached(c) is not None and not var_is_cached(c)
     del c

--- a/tlm_adjoint/equation.py
+++ b/tlm_adjoint/equation.py
@@ -216,7 +216,7 @@ class Equation(Referrer):
                                                       ("self", "nl_deps", "B")}:  # noqa: E501
             warnings.warn("Equation.adjoint_jacobian_solve(self, nl_deps, b/B) "  # noqa: E501
                           "method signature is deprecated",
-                          DeprecationWarning, stacklevel=2)
+                          FutureWarning, stacklevel=2)
 
             def adjoint_jacobian_solve(self, adj_X, nl_deps, B):
                 return adjoint_jacobian_solve_orig(self, nl_deps, B)
@@ -227,7 +227,7 @@ class Equation(Referrer):
         if tuple(tangent_linear_sig.parameters.keys()) == ("self", "M", "dM", "tlm_map"):  # noqa: E501
             warnings.warn("Equation.tangent_linear(self, M, dM, tlm_map) "
                           "method signature is deprecated",
-                          DeprecationWarning, stacklevel=2)
+                          FutureWarning, stacklevel=2)
 
             def tangent_linear(self, tlm_map):
                 return tangent_linear_orig(self, tlm_map.M, tlm_map.dM,
@@ -589,5 +589,5 @@ class NullSolver(ZeroAssignment):
     def __init__(self, X):
         warnings.warn("NullSolver is deprecated -- "
                       "use ZeroAssignment instead",
-                      DeprecationWarning, stacklevel=2)
+                      FutureWarning, stacklevel=2)
         super().__init__(X)

--- a/tlm_adjoint/firedrake/variables.py
+++ b/tlm_adjoint/firedrake/variables.py
@@ -22,6 +22,7 @@ import numpy as np
 import petsc4py.PETSc as PETSc
 import pyop2
 import ufl
+import warnings
 import weakref
 
 __all__ = \
@@ -323,6 +324,9 @@ class Constant(backend_Constant):
         if domain is None:
             return object().__new__(cls)
         else:
+            warnings.warn("domain argument is deprecated -- "
+                          "use a Real Function instead",
+                          FutureWarning, stacklevel=2)
             value = constant_value(value, shape)
             if space_type not in {"primal", "conjugate",
                                   "dual", "conjugate_dual"}:

--- a/tlm_adjoint/fixed_point.py
+++ b/tlm_adjoint/fixed_point.py
@@ -485,7 +485,7 @@ class FixedPointSolver(Equation, CustomNormSq):
             if tlm_eq is None:
                 warnings.warn("Equation.tangent_linear should return an "
                               "Equation",
-                              DeprecationWarning)
+                              FutureWarning)
                 tlm_eq = ZeroAssignment([tlm_map[x] for x in eq.X()])
             tlm_eqs.append(tlm_eq)
         return FixedPointSolver(

--- a/tlm_adjoint/functional.py
+++ b/tlm_adjoint/functional.py
@@ -23,7 +23,7 @@ class Functional(Float):
     def __init__(self, *args, space=None, **kwargs):
         if space is not None:
             warnings.warn("space argument is deprecated",
-                          DeprecationWarning, stacklevel=2)
+                          FutureWarning, stacklevel=2)
         super().__init__(*args, **kwargs)
 
     def assign(self, y):
@@ -67,6 +67,6 @@ class Functional(Float):
 
     def tlm(self, M, dM, *, max_depth=1):
         warnings.warn("Functional.tlm method is deprecated",
-                      DeprecationWarning, stacklevel=2)
+                      FutureWarning, stacklevel=2)
 
         return var_tlm(self, *((M, dM) for _ in range(max_depth)))

--- a/tlm_adjoint/hessian.py
+++ b/tlm_adjoint/hessian.py
@@ -66,7 +66,7 @@ class Hessian(ABC):
 
     def action_fn(self, m, m0=None):
         warnings.warn("Hessian.action_fn is deprecated",
-                      DeprecationWarning, stacklevel=2)
+                      FutureWarning, stacklevel=2)
 
         def action(dm):
             _, _, ddJ = self.action(m, dm, M0=m0)
@@ -252,7 +252,7 @@ class GaussNewton(ABC):
 
     def action_fn(self, m, m0=None):
         warnings.warn("GaussNewton.action_fn is deprecated",
-                      DeprecationWarning, stacklevel=2)
+                      FutureWarning, stacklevel=2)
 
         def action(dm):
             return var_copy_conjugate(self.action(m, dm, M0=m0))

--- a/tlm_adjoint/interface.py
+++ b/tlm_adjoint/interface.py
@@ -1809,7 +1809,7 @@ def is_function(x):
 
     warnings.warn("is_function is deprecated -- "
                   "use is_var instead",
-                  DeprecationWarning, stacklevel=2)
+                  FutureWarning, stacklevel=2)
     return is_var(x)
 
 
@@ -1819,7 +1819,7 @@ def _function_warning(fn):
 
         warnings.warn("function_ prefixed functions are deprecated -- "
                       "use var_ prefixed functions instead",
-                      DeprecationWarning, stacklevel=2)
+                      FutureWarning, stacklevel=2)
         return fn(*args, **kwargs)
 
     return wrapped_fn

--- a/tlm_adjoint/manager.py
+++ b/tlm_adjoint/manager.py
@@ -154,7 +154,7 @@ def configure_tlm(*args, annotate=None, tlm=True):
 def add_tlm(M, dM, max_depth=1):
     warnings.warn("add_tlm is deprecated -- "
                   "use configure_tlm instead",
-                  DeprecationWarning, stacklevel=2)
+                  FutureWarning, stacklevel=2)
     manager().add_tlm(M, dM, max_depth=max_depth, _warning=False)
 
 
@@ -177,7 +177,7 @@ def function_tlm(x, *args):
 
     warnings.warn("function_tlm is deprecated -- "
                   "use var_tlm instead",
-                  DeprecationWarning, stacklevel=2)
+                  FutureWarning, stacklevel=2)
     return manager().var_tlm(x, *args)
 
 

--- a/tlm_adjoint/tlm_adjoint.py
+++ b/tlm_adjoint/tlm_adjoint.py
@@ -479,7 +479,7 @@ class EquationManager:
         if _warning:
             warnings.warn("EquationManager.add_tlm method is deprecated -- "
                           "use EquationManager.configure_tlm instead",
-                          DeprecationWarning, stacklevel=2)
+                          FutureWarning, stacklevel=2)
 
         if self._tlm_state == TangentLinearState.FINAL:
             raise RuntimeError("Cannot configure tangent-linear after "
@@ -526,9 +526,9 @@ class EquationManager:
     def function_tlm(self, x, *args):
         """
         """
-        warnings.warn("function_tlm method is deprecated -- "
-                      "use var_tlm instead",
-                      DeprecationWarning, stacklevel=2)
+        warnings.warn("EquationManager.function_tlm method is deprecated -- "
+                      "use EquationManager.var_tlm instead",
+                      FutureWarning, stacklevel=2)
         return self.var_tlm(x, *args)
 
     def annotation_enabled(self):
@@ -691,7 +691,7 @@ class EquationManager:
                     if tlm_eq is None:
                         warnings.warn("Equation.tangent_linear should return "
                                       "an Equation",
-                                      DeprecationWarning)
+                                      FutureWarning)
                         tlm_eq = ZeroAssignment([tlm_map[x] for x in X])
                     tlm_eq._tlm_adjoint__tlm_root_id = getattr(
                         eq, "_tlm_adjoint__tlm_root_id", eq_id)


### PR DESCRIPTION
- Remove tests for old `interpolate` and `Interpolator.interpolate`.
- Remove tests for `Constant(..., domain=mesh)`. Code for this is retained, but with a `FutureWarning`, and is now untested.
- Convert all `DeprecationWarning`s to `FutureWarning`s.