### PR TITLE
Automatic flattening of `Mapping`s when setting PETSc options

### DIFF
--- a/tests/base/test_petsc.py
+++ b/tests/base/test_petsc.py
@@ -21,15 +21,15 @@ pytestmark = pytest.mark.skipif(
 _count = itertools.count()
 
 
+def flatten(options):
+    return dict(PETScOptions(
+        f"_tlm_adjoint__test_petsc_{next(_count):d}",
+        options))
+
+
 @pytest.mark.base
 @seed_test
 def test_flatten_petsc_options(setup_test):  # noqa: F811
-    def flatten(options):
-        petsc_options = PETScOptions(
-            f"_tlm_adjoint__test_flatten_petsc_options_{next(_count):d}")
-        petsc_options.update(options)
-        return dict(petsc_options)
-
     assert flatten({"zero": 0,
                     "one": 1}) == {"zero": "0",
                                    "one": "1"}
@@ -44,3 +44,12 @@ def test_flatten_petsc_options(setup_test):  # noqa: F811
                                              "one_two_three": "3",
                                              "one_two_four": "4",
                                              "one_five": "5"}
+
+
+@pytest.mark.base
+@seed_test
+def test_flatten_petsc_options_duplicate_key(setup_test):  # noqa: F811
+    with pytest.raises(ValueError):
+        flatten({"zero_one": 1, "zero": {"one": 1}})
+    with pytest.raises(ValueError):
+        flatten({"zero": {"one": 1}, "zero_one": 1})

--- a/tests/base/test_petsc.py
+++ b/tests/base/test_petsc.py
@@ -1,0 +1,46 @@
+from tlm_adjoint import DEFAULT_COMM
+from tlm_adjoint.petsc import PETScOptions
+
+import itertools
+try:
+    import petsc4py.PETSc as PETSc
+except ModuleNotFoundError:
+    PETSc = None
+import pytest
+
+from .test_base import seed_test, setup_test  # noqa: F401
+
+pytestmark = pytest.mark.skipif(
+    DEFAULT_COMM.size not in {1, 4},
+    reason="tests must be run in serial, or with 4 processes")
+pytestmark = pytest.mark.skipif(
+    PETSc is None,
+    reason="PETSc not available")
+
+
+_count = itertools.count()
+
+
+@pytest.mark.base
+@seed_test
+def test_flatten_petsc_options(setup_test):  # noqa: F811
+    def flatten(options):
+        petsc_options = PETScOptions(
+            f"_tlm_adjoint__test_flatten_petsc_options_{next(_count):d}")
+        petsc_options.update(options)
+        return dict(petsc_options)
+
+    assert flatten({"zero": 0,
+                    "one": 1}) == {"zero": "0",
+                                   "one": "1"}
+    assert flatten({"zero": 0,
+                    "one": {"two": 2,
+                            "three": 3}}) == {"zero": "0",
+                                              "one_two": "2",
+                                              "one_three": "3"}
+    assert flatten({"zero": 0,
+                    "one": {"two": {"three": 3, "four": 4},
+                            "five": 5}}) == {"zero": "0",
+                                             "one_two_three": "3",
+                                             "one_two_four": "4",
+                                             "one_five": "5"}

--- a/tlm_adjoint/block_system.py
+++ b/tlm_adjoint/block_system.py
@@ -825,8 +825,8 @@ def petsc_ksp(A, *, comm=None, solver_parameters=None, pc_fn=None):
         pc = None
 
     ksp = PETSc.KSP().create(comm=comm)
-    options = PETScOptions(f"_tlm_adjoint__{ksp.name:s}_")
-    options.update(solver_parameters)
+    options = PETScOptions(f"_tlm_adjoint__{ksp.name:s}_",
+                           solver_parameters)
     ksp.setOptionsPrefix(options.options_prefix)
     if pc is not None:
         ksp.setPC(pc)
@@ -992,8 +992,8 @@ def slepc_eps(A, B, *, B_inv=None, solver_parameters=None, comm=None):
         B_mat = None
 
     eps = SLEPc.EPS().create(comm=comm)
-    options = PETScOptions(f"_tlm_adjoint__{eps.name:s}_")
-    options.update(solver_parameters)
+    options = PETScOptions(f"_tlm_adjoint__{eps.name:s}_",
+                           solver_parameters)
     eps.setOptionsPrefix(options.options_prefix)
     if B is None:
         eps.setOperators(A_mat)
@@ -1233,8 +1233,8 @@ def slepc_mfn(A, *, solver_parameters=None, comm=None):
     A_mat.setUp()
 
     mfn = SLEPc.MFN().create(comm=comm)
-    options = PETScOptions(f"_tlm_adjoint__{mfn.name:s}_")
-    options.update(solver_parameters)
+    options = PETScOptions(f"_tlm_adjoint__{mfn.name:s}_",
+                           solver_parameters)
     mfn.setOptionsPrefix(options.options_prefix)
     mfn.setOperator(A_mat)
 

--- a/tlm_adjoint/optimization.py
+++ b/tlm_adjoint/optimization.py
@@ -371,8 +371,8 @@ class TAOSolver:
         new_vec = vec_interface.new_vec
 
         tao = PETSc.TAO().create(comm=comm)
-        options = PETScOptions(f"_tlm_adjoint__{tao.name:s}_")
-        options.update(solver_parameters)
+        options = PETScOptions(f"_tlm_adjoint__{tao.name:s}_",
+                               solver_parameters)
         tao.setOptionsPrefix(options.options_prefix)
 
         M = [None]

--- a/tlm_adjoint/petsc.py
+++ b/tlm_adjoint/petsc.py
@@ -21,32 +21,15 @@ __all__ = \
     ]
 
 
-def flattened_options(options):
-    options = deque(((), key, value) for key, value in options.items())
-    while len(options) > 0:
-        prefix, key, value = options.popleft()
-        if not isinstance(key, str):
-            raise TypeError("Unexpected key type")
-        if isinstance(value, Mapping):
-            sub_prefix = prefix + (key,)
-            options.extendleft(
-                (sub_prefix, sub_key, sub_value)
-                for sub_key, sub_value in reversed(value.items()))
-        else:
-            yield "_".join(prefix + (key,)), value
-
-
-# Do not inherit from Mapping or MutableMapping, as __setitem__ flattens the
-# value (and so can set multiple keys at once), and __len__ would be linear
-# time
+# Do not inherit from Mapping as __len__ would be linear time
 class PETScOptions:
-    def __init__(self, options_prefix):
+    def __init__(self, options_prefix, solver_parameters):
         if PETSc is None:
             raise RuntimeError("PETSc not available")
 
         self._options_prefix = options_prefix
         self._options = PETSc.Options()
-        self._keys = {}
+        self._keys = {}  # Use dict as an ordered set
 
         def finalize_callback(options_prefix, options, keys):
             for key in keys:
@@ -58,37 +41,56 @@ class PETScOptions:
             self, finalize_callback,
             self._options_prefix, self._options, self._keys)
 
+        self._update(solver_parameters)
+
+    @staticmethod
+    def _flattened_options(options):
+        options = deque(((), key, value) for key, value in options.items())
+        while len(options) > 0:
+            prefix, key, value = options.popleft()
+            if not isinstance(key, str):
+                raise TypeError("Unexpected key type")
+            if isinstance(value, Mapping):
+                sub_prefix = prefix + (key,)
+                options.extendleft(
+                    (sub_prefix, sub_key, sub_value)
+                    for sub_key, sub_value in reversed(value.items()))
+            else:
+                yield "_".join(prefix + (key,)), value
+
+    def _update(self, other):
+        keys = set()
+        for key, value in self._flattened_options(other):
+            if not isinstance(key, str):
+                raise TypeError("Unexpected key type")
+            if key in self or key in keys:
+                raise ValueError(f"Duplicate value for option key '{key:s}'")
+            keys.add(key)
+        del keys
+
+        for key, value in self._flattened_options(other):
+            self._keys[key] = None
+            self._options[f"{self.options_prefix:s}{key:s}"] = value
+
     @property
     def options_prefix(self):
         return self._options_prefix
 
+    def __contains__(self, key):
+        return (isinstance(key, str)
+                and key in self._keys
+                and f"{self.options_prefix:s}{key:s}" in self._options)
+
     def __getitem__(self, key):
+        if key not in self:
+            raise KeyError(f"Missing option key '{key}'")
         return self._options[f"{self.options_prefix:s}{key:s}"]
 
-    def __setitem__(self, key, value):
-        for key, value in flattened_options({key: value}):
-            self._keys[key] = None
-            self._options[f"{self.options_prefix:s}{key:s}"] = value
-
-    def __delitem__(self, key):
-        del self._keys[key]
-        del self._options[f"{self.options_prefix:s}{key:s}"]
-
     def __iter__(self):
-        for key in self._keys:
-            if f"{self.options_prefix:s}{key:s}" in self._options:
-                yield key
+        yield from self.keys()
 
     def keys(self):
-        return iter(self)
-
-    def update(self, other):
-        for key, value in other.items():
-            self[key] = value
-
-    def clear(self):
-        for key in self:
-            del self[key]
+        return (key for key in self._keys if key in self)
 
 
 @contextmanager


### PR DESCRIPTION
In the style of Firedrake's behaviour, options dictionaries are now flattened, so e.g.

```
options = {"ksp": {"atol", atol,
                   "rtol": rtol}}
```

is now automatically flattened in the options dictionary so that it is equivalent to

```
options = {"ksp_atol": atol,
           "ksp_rtol": rtol}
```

Applied recursively, with order preserved, and with duplicate keys detected.