### PR TITLE
Firedrake backend: Replace solver parameter copying with flattening

### DIFF
--- a/tlm_adjoint/firedrake/block_system.py
+++ b/tlm_adjoint/firedrake/block_system.py
@@ -12,9 +12,9 @@ from ..block_system import (
     BlockMatrix as _BlockMatrix, BlockNullspace, Eigensolver,
     LinearSolver as _LinearSolver, Matrix, MatrixFunctionSolver,
     MatrixFreeMatrix, MixedSpace, NoneNullspace, Nullspace, TypedSpace)
+from ..petsc import flattened_options
 
 from .backend_interface import assemble, matrix_multiply
-from .parameters import copy_parameters
 from .variables import Cofunction, Constant, Function
 
 from functools import cached_property
@@ -352,8 +352,8 @@ class WhiteNoiseSampler:
         self._M = M
         self._rng = rng
         self._pc = pc
-        self._mfn_solver_parameters = copy_parameters(mfn_solver_parameters)
-        self._ksp_solver_parameters = copy_parameters(ksp_solver_parameters)
+        self._mfn_solver_parameters = dict(flattened_options(mfn_solver_parameters))  # noqa: E501
+        self._ksp_solver_parameters = dict(flattened_options(ksp_solver_parameters))  # noqa: E501
 
     @cached_property
     def _mfn(self):

--- a/tlm_adjoint/firedrake/caches.py
+++ b/tlm_adjoint/firedrake/caches.py
@@ -14,6 +14,7 @@ from .backend_interface import (
 from .expr import (
     derivative, eliminate_zeros, expr_zero, extract_coefficients,
     extract_variables, form_cached, iter_expr, replaced_form)
+from .parameters import flattened_solver_parameters
 from .variables import ReplacementFunction
 
 from collections import defaultdict
@@ -479,7 +480,7 @@ class LinearSolverCache(Cache):
         key = (form_key(form, assemble_form),
                tuple(bcs),
                parameters_key(form_compiler_parameters),
-               parameters_key(linear_solver_parameters))
+               parameters_key(flattened_solver_parameters(linear_solver_parameters)))  # noqa: E501
 
         if assembly_cache is None:
             assembly_cache = globals()["assembly_cache"]()

--- a/tlm_adjoint/firedrake/parameters.py
+++ b/tlm_adjoint/firedrake/parameters.py
@@ -45,6 +45,8 @@ def flattened_solver_parameters(solver_parameters):
         tlm_adjoint_parameters = solver_parameters["tlm_adjoint"]
     solver_parameters = dict(flattened_options(solver_parameters))
     if have_tlm_adjoint_parameters:
+        if "tlm_adjoint" in solver_parameters:
+            raise ValueError("Duplicate key")
         solver_parameters["tlm_adjoint"] = tlm_adjoint_parameters
     return solver_parameters
 

--- a/tlm_adjoint/firedrake/parameters.py
+++ b/tlm_adjoint/firedrake/parameters.py
@@ -1,5 +1,7 @@
 from .backend import Parameters, parameters
 
+from ..petsc import flattened_options
+
 import ufl
 
 __all__ = []
@@ -36,6 +38,17 @@ def process_form_compiler_parameters(form_compiler_parameters):
     return params
 
 
+def flattened_solver_parameters(solver_parameters):
+    solver_parameters = copy_parameters(solver_parameters)
+    have_tlm_adjoint_parameters = "tlm_adjoint" in solver_parameters
+    if have_tlm_adjoint_parameters:
+        tlm_adjoint_parameters = solver_parameters["tlm_adjoint"]
+    solver_parameters = dict(flattened_options(solver_parameters))
+    if have_tlm_adjoint_parameters:
+        solver_parameters["tlm_adjoint"] = tlm_adjoint_parameters
+    return solver_parameters
+
+
 def form_compiler_quadrature_parameters(form, form_compiler_parameters):
     qd = form_compiler_parameters.get("quadrature_degree", "auto")
     if qd in {None, "auto", -1}:
@@ -44,7 +57,7 @@ def form_compiler_quadrature_parameters(form, form_compiler_parameters):
 
 
 def process_solver_parameters(solver_parameters, *, linear):
-    solver_parameters = copy_parameters(solver_parameters)
+    solver_parameters = flattened_solver_parameters(solver_parameters)
 
     tlm_adjoint_parameters = solver_parameters.setdefault("tlm_adjoint", {})
     tlm_adjoint_parameters.setdefault("options_prefix", None)
@@ -63,7 +76,7 @@ def process_adjoint_solver_parameters(linear_solver_parameters):
     nullspace = tlm_adjoint_parameters.get("nullspace", None)
     transpose_nullspace = tlm_adjoint_parameters.get("transpose_nullspace", None)  # noqa: E501
 
-    adjoint_solver_parameters = copy_parameters(linear_solver_parameters)
+    adjoint_solver_parameters = flattened_solver_parameters(linear_solver_parameters)  # noqa: E501
     adjoint_tlm_adjoint_parameters = adjoint_solver_parameters.setdefault("tlm_adjoint", {})  # noqa: E501
     adjoint_tlm_adjoint_parameters["nullspace"] = transpose_nullspace
     adjoint_tlm_adjoint_parameters["transpose_nullspace"] = nullspace

--- a/tlm_adjoint/petsc.py
+++ b/tlm_adjoint/petsc.py
@@ -64,7 +64,7 @@ class PETScOptions:
             if not isinstance(key, str):
                 raise TypeError("Unexpected key type")
             if key in self or key in keys:
-                raise ValueError(f"Duplicate value for option key '{key:s}'")
+                raise ValueError(f"Duplicate key '{key:s}'")
             keys.add(key)
         del keys
 


### PR DESCRIPTION
Avoids some cache misses, prevents `ksp_initial_guess_nonzero` being missed when detecting non-zero initial guesses.